### PR TITLE
Check the tfjob status instead of get it

### DIFF
--- a/cmd/arena/commands/trainer_tensorflow.go
+++ b/cmd/arena/commands/trainer_tensorflow.go
@@ -17,6 +17,7 @@ package commands
 import (
 	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/kubeflow/arena/util"
 	"github.com/kubeflow/tf-operator/pkg/client/clientset/versioned"
@@ -82,16 +83,16 @@ func (tj *TensorFlowJob) AllPods() []v1.Pod {
 
 // Get the Status of the Job: RUNNING, PENDING, SUCCEEDED, FAILED
 func (tj *TensorFlowJob) GetStatus() (status string) {
-	status = "Unknown"
+	status = "UNKNOWN"
 	if tj.tfjob.Name == "" {
 		return status
 	}
 
 	t := checkStatus(tj.tfjob.Status)
 	if t == tfv1alpha2.TFJobCreated || t == tfv1alpha2.TFJobRestarting {
-		status = "Pending"
+		status = "PENDING"
 	} else {
-		status = string(t)
+		status = strings.ToUpper(string(t))
 	}
 
 	return status


### PR DESCRIPTION
This better to check the tfjob status instead of get it with
hasCondition. When get tfjobs form kube, sort the tfjobs status
conditions at first and put the newest condition at first. Then
check the status directly form sorted conditions.

Using hasCondition means if the tfjob has the condition at any time,
it alwayse will return True, but not the newest condition of 
the tfjob. So i think check tfjob status will be better and more accurate.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/arena/85)
<!-- Reviewable:end -->
