### PR TITLE
fix arena logs follow params

### DIFF
--- a/cmd/arena/commands/logs.go
+++ b/cmd/arena/commands/logs.go
@@ -15,7 +15,6 @@
 package commands
 
 import (
-	"bufio"
 	"fmt"
 	"io"
 	"os"
@@ -176,34 +175,11 @@ func (p *logPrinter) getPodLogs(displayName string, podName string, podNamespace
 		SinceTime:    sinceTime,
 		TailLines:    tail,
 	}).Stream()
-	// if err == nil {
-	// 	scanner := bufio.NewScanner(stream)
-	// 	for scanner.Scan() {
-	// 		line := scanner.Text()
-	// 		parts := strings.Split(line, " ")
-	// 		logTime, err := time.Parse(time.RFC3339, parts[0])
-	// 		if err == nil {
-	// 			lines := strings.Join(parts[1:], " ")
-	// 			for _, line := range strings.Split(lines, "\r") {
-	// 				if line != "" {
-	// 					callback(logEntry{
-	// 						pod:         podName,
-	// 						displayName: displayName,
-	// 						time:        logTime,
-	// 						line:        line,
-	// 					})
-	// 				}
-	// 			}
-	// 		}
-	// 	}
-	// }
 
 	if err != nil {
 		return err
 	}
-	writer := bufio.NewWriter(os.Stdout)
-	defer writer.Flush()
-	_, err = io.Copy(writer, readCloser)
+	_, err = io.Copy(os.Stdout, readCloser)
 
 	defer readCloser.Close()
 	return err


### PR DESCRIPTION
Fix arena logs -f command.
remove the buffer of os.stdout, so it can refresh logs as log stream update.
For issue [#70](https://github.com/kubeflow/arena/issues/70)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/arena/89)
<!-- Reviewable:end -->
