### PR TITLE
support $HOME/charts as the helm charts path

### DIFF
--- a/cmd/arena/commands/serve_tensorflow.go
+++ b/cmd/arena/commands/serve_tensorflow.go
@@ -30,7 +30,7 @@ import (
 )
 
 var (
-	tfservingChart        = "/charts/tfserving"
+	tfservingChart        = util.GetChartsFolder() + "/tfserving"
 	defaultTfServingImage = "tensorflow/serving:latest"
 )
 

--- a/cmd/arena/commands/submit.go
+++ b/cmd/arena/commands/submit.go
@@ -22,14 +22,13 @@ import (
 	"strings"
 
 	"github.com/kubeflow/arena/util"
-	validate "github.com/kubeflow/arena/util"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
 var (
-	standalone_training_chart = "/charts/training"
-	horovod_training_chart    = "/charts/tf-horovod"
+	standalone_training_chart = util.GetChartsFolder() + "/training"
+	horovod_training_chart    = util.GetChartsFolder() + "/tf-horovod"
 	envs                      []string
 	dataset                   []string
 	dataDirs                  []string
@@ -71,7 +70,7 @@ func (s submitArgs) check() error {
 	}
 
 	// return fmt.Errorf("must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character.")
-	err := validate.ValidateJobName(name)
+	err := util.ValidateJobName(name)
 	if err != nil {
 		return err
 	}

--- a/cmd/arena/commands/submit_mpi.go
+++ b/cmd/arena/commands/submit_mpi.go
@@ -25,7 +25,7 @@ import (
 )
 
 var (
-	mpijob_chart = "/charts/mpijob"
+	mpijob_chart = util.GetChartsFolder() + "/mpijob"
 )
 
 func NewSubmitMPIJobCommand() *cobra.Command {

--- a/cmd/arena/commands/submit_tfjob.go
+++ b/cmd/arena/commands/submit_tfjob.go
@@ -27,7 +27,7 @@ import (
 )
 
 var (
-	tfjob_chart = "/charts/tfjob"
+	tfjob_chart = util.GetChartsFolder() + "/tfjob"
 )
 
 func NewSubmitTFJobCommand() *cobra.Command {

--- a/util/charts.go
+++ b/util/charts.go
@@ -1,0 +1,30 @@
+package util
+
+import (
+	"os"
+)
+
+func pathExists(path string) bool {
+	_, err := os.Stat(path)
+	if err != nil {
+		if os.IsExist(err) {
+			return true
+		}
+		return false
+	}
+	return true
+}
+var chartFolder=""
+
+func GetChartsFolder() string  {
+	if chartFolder != "" {
+		return chartFolder
+	}
+	homeChartsFolder := os.Getenv("HOME") + "/charts"
+	if !pathExists(homeChartsFolder) {
+		chartFolder = "/charts"
+	}else {
+		chartFolder = homeChartsFolder
+	}
+	return chartFolder
+}


### PR DESCRIPTION
Support use $HOME/charts as the charts path, for issue #97

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/arena/99)
<!-- Reviewable:end -->
