### PR TITLE
Features/release v0.2.0/overall status

### DIFF
--- a/cmd/arena/commands/delete.go
+++ b/cmd/arena/commands/delete.go
@@ -73,6 +73,7 @@ func deleteTrainingJob(jobName, trainingType string) error {
 	// 1. Handle legacy training job
 	err := helm.DeleteRelease(jobName)
 	if err == nil {
+		log.Infof("Delete the job %s successfully.", jobName)
 		return nil
 	}
 

--- a/cmd/arena/commands/get.go
+++ b/cmd/arena/commands/get.go
@@ -249,7 +249,7 @@ func printSingleJobHelper(job TrainingJob, printArgs PrintArgs) {
 
 func printJobSummary(w io.Writer, job TrainingJob, namespace string) {
 	fmt.Fprintf(w, "STATUS: %s\n", GetJobRealStatus(job))
-	fmt.Fprintf(w, "\nNAMESPACE: %s\n", namespace)
+	fmt.Fprintf(w, "NAMESPACE: %s\n", namespace)
 }
 
 func printEvents(w io.Writer, namespace string, pods []v1.Pod) {

--- a/cmd/arena/commands/get.go
+++ b/cmd/arena/commands/get.go
@@ -250,6 +250,8 @@ func printSingleJobHelper(job TrainingJob, printArgs PrintArgs) {
 func printJobSummary(w io.Writer, job TrainingJob, namespace string) {
 	fmt.Fprintf(w, "STATUS: %s\n", GetJobRealStatus(job))
 	fmt.Fprintf(w, "NAMESPACE: %s\n", namespace)
+	fmt.Fprintln(w, "")
+
 }
 
 func printEvents(w io.Writer, namespace string, pods []v1.Pod) {

--- a/cmd/arena/commands/get.go
+++ b/cmd/arena/commands/get.go
@@ -247,7 +247,7 @@ func printSingleJobHelper(job TrainingJob, printArgs PrintArgs) {
 
 }
 
-func printJobSummary(w io.Writer, namespace string, job TrainingJob) {
+func printJobSummary(w io.Writer, job TrainingJob, namespace string) {
 	fmt.Fprintf(w, "STATUS: %s\n", GetJobRealStatus(job))
 	fmt.Fprintf(w, "\nNAMESPACE: %s\n", namespace)
 }

--- a/cmd/arena/commands/get.go
+++ b/cmd/arena/commands/get.go
@@ -250,6 +250,7 @@ func printSingleJobHelper(job TrainingJob, printArgs PrintArgs) {
 func printJobSummary(w io.Writer, job TrainingJob, namespace string) {
 	fmt.Fprintf(w, "STATUS: %s\n", GetJobRealStatus(job))
 	fmt.Fprintf(w, "NAMESPACE: %s\n", namespace)
+	fmt.Fprintf(w, "TRAINING DURATION: %s\n", job.Duration())
 	fmt.Fprintln(w, "")
 
 }

--- a/cmd/arena/commands/get.go
+++ b/cmd/arena/commands/get.go
@@ -208,7 +208,7 @@ func printTrainingJob(job TrainingJob, printArgs PrintArgs) {
 
 func printSingleJobHelper(job TrainingJob, printArgs PrintArgs) {
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	printJobSummary(w, job, job.ChiefPod().Namespace)
+	printJobSummary(w, job)
 
 	// apply a dummy FgDefault format to align tabwriter with the rest of the columns
 
@@ -247,9 +247,9 @@ func printSingleJobHelper(job TrainingJob, printArgs PrintArgs) {
 
 }
 
-func printJobSummary(w io.Writer, job TrainingJob, namespace string) {
+func printJobSummary(w io.Writer, job TrainingJob) {
 	fmt.Fprintf(w, "STATUS: %s\n", GetJobRealStatus(job))
-	fmt.Fprintf(w, "NAMESPACE: %s\n", namespace)
+	fmt.Fprintf(w, "NAMESPACE: %s\n", job.Namespace())
 	fmt.Fprintf(w, "TRAINING DURATION: %s\n", util.ShortHumanDuration(job.Duration()))
 	fmt.Fprintln(w, "")
 

--- a/cmd/arena/commands/get.go
+++ b/cmd/arena/commands/get.go
@@ -250,7 +250,7 @@ func printSingleJobHelper(job TrainingJob, printArgs PrintArgs) {
 func printJobSummary(w io.Writer, job TrainingJob, namespace string) {
 	fmt.Fprintf(w, "STATUS: %s\n", GetJobRealStatus(job))
 	fmt.Fprintf(w, "NAMESPACE: %s\n", namespace)
-	fmt.Fprintf(w, "TRAINING DURATION: %s\n", job.Duration())
+	fmt.Fprintf(w, "TRAINING DURATION: %s\n", util.ShortHumanDuration(job.Duration()))
 	fmt.Fprintln(w, "")
 
 }

--- a/cmd/arena/commands/get.go
+++ b/cmd/arena/commands/get.go
@@ -208,6 +208,7 @@ func printTrainingJob(job TrainingJob, printArgs PrintArgs) {
 
 func printSingleJobHelper(job TrainingJob, printArgs PrintArgs) {
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	printJobSummary(w, job, job.ChiefPod().Namespace)
 
 	// apply a dummy FgDefault format to align tabwriter with the rest of the columns
 
@@ -244,6 +245,11 @@ func printSingleJobHelper(job TrainingJob, printArgs PrintArgs) {
 
 	_ = w.Flush()
 
+}
+
+func printJobSummary(w io.Writer, namespace string, job TrainingJob) {
+	fmt.Fprintf(w, "STATUS: %s\n", GetJobRealStatus(job))
+	fmt.Fprintf(w, "\nNAMESPACE: %s\n", namespace)
 }
 
 func printEvents(w io.Writer, namespace string, pods []v1.Pod) {

--- a/cmd/arena/commands/job_info.go
+++ b/cmd/arena/commands/job_info.go
@@ -143,3 +143,7 @@ func (ji *JobInfo) GetStatus() (status string) {
 	}
 	return status
 }
+
+func (ji *JobInfo) Namespace() string {
+	return ji.job.Namespace
+}

--- a/cmd/arena/commands/job_info.go
+++ b/cmd/arena/commands/job_info.go
@@ -110,7 +110,7 @@ func (ji *JobInfo) Duration() time.Duration {
 		if !cond.LastTransitionTime.IsZero() {
 			return cond.LastTransitionTime.Time.Sub(job.Status.StartTime.Time)
 		} else {
-			log.Debugf("the latest condition's time is zero of pod %s", ji.chiefPod.Name)
+			log.Debugf("the latest condition's time is zero of pod %s", ji.ChiefPod().Name)
 		}
 	}
 

--- a/cmd/arena/commands/job_info.go
+++ b/cmd/arena/commands/job_info.go
@@ -101,10 +101,10 @@ func (ji *JobInfo) Duration() time.Duration {
 		return 0
 	}
 	if job.Status.CompletionTime != nil {
-		return mj.chiefjob.Status.CompletionTime.Time.Sub(mpijob.Status.StartTime.Time)
+		return job.Status.CompletionTime.Time.Sub(job.Status.StartTime.Time)
 	}
 
-	return metav1.Now().Sub(mpijob.Status.StartTime.Time)
+	return metav1.Now().Sub(job.Status.StartTime.Time)
 }
 
 func (ji *JobInfo) StartTime() *metav1.Time {

--- a/cmd/arena/commands/job_info.go
+++ b/cmd/arena/commands/job_info.go
@@ -92,6 +92,21 @@ func (ji *JobInfo) Age() time.Duration {
 	return metav1.Now().Sub(job.Status.StartTime.Time)
 }
 
+// Get the Job Training Duration
+func (ji *JobInfo) Duration() time.Duration {
+	job := ji.job
+
+	if job.Status.StartTime == nil ||
+		job.Status.StartTime.IsZero() {
+		return 0
+	}
+	if job.Status.CompletionTime != nil {
+		return mj.chiefjob.Status.CompletionTime.Time.Sub(mpijob.Status.StartTime.Time)
+	}
+
+	return metav1.Now().Sub(mpijob.Status.StartTime.Time)
+}
+
 func (ji *JobInfo) StartTime() *metav1.Time {
 	return ji.job.Status.StartTime
 }

--- a/cmd/arena/commands/job_info.go
+++ b/cmd/arena/commands/job_info.go
@@ -110,7 +110,7 @@ func (ji *JobInfo) Duration() time.Duration {
 		if !cond.LastTransitionTime.IsZero() {
 			return cond.LastTransitionTime.Time.Sub(job.Status.StartTime.Time)
 		} else {
-			log.Debugf("the latest condition's time is zero of pod %s", mj.chiefPod.Name)
+			log.Debugf("the latest condition's time is zero of pod %s", ji.chiefPod.Name)
 		}
 	}
 

--- a/cmd/arena/commands/job_info.go
+++ b/cmd/arena/commands/job_info.go
@@ -15,7 +15,7 @@
 package commands
 
 import (
-	"github.com/labstack/gommon/log"
+	log "github.com/sirupsen/logrus"
 	batchv1 "k8s.io/api/batch/v1"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/cmd/arena/commands/pod_helper.go
+++ b/cmd/arena/commands/pod_helper.go
@@ -232,7 +232,7 @@ func makePodConditionsSortedByTime(conditions []v1.PodCondition) []v1.PodConditi
 		newCondtions = append(newCondtions, c)
 	}
 	sort.Sort(newCondtions)
-	return []*v1.PodCondition(newCondtions)
+	return []v1.PodCondition(newCondtions)
 }
 
 func getPodLatestCondition(pod v1.Pod) (cond v1.PodCondition) {

--- a/cmd/arena/commands/pod_helper.go
+++ b/cmd/arena/commands/pod_helper.go
@@ -223,7 +223,7 @@ func (s SortPodConditionByLastTransitionTime) Len() int      { return len(s) }
 func (s SortPodConditionByLastTransitionTime) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
 func (s SortPodConditionByLastTransitionTime) Less(i, j int) bool {
 	// return s[i].CreatedAt.Before(s[j].CreatedAt)
-	return s[i].LastTransitionTime.After(s[j].LastTransitionTime)
+	return s[i].LastTransitionTime.Time.After(s[j].LastTransitionTime.Time)
 }
 
 func makePodConditionsSortedByTime(conditions []v1.PodCondition) []v1.PodCondition {

--- a/cmd/arena/commands/prune.go
+++ b/cmd/arena/commands/prune.go
@@ -85,7 +85,7 @@ func NewPruneCommand() *cobra.Command {
 				if GetJobRealStatus(job) != "RUNNING" {
 					if job.Age() > pruneArgs.since {
 						deleted = true
-						fmt.Printf("Delete %s %s", job.Trainer(), job.Name())
+						fmt.Printf("Delete %s %s with Age %s \n", job.Trainer(), job.Name(), util.ShortHumanDuration(job.Age()))
 						err = deleteTrainingJob(job.Name(), "")
 						if err != nil {
 							fmt.Printf("Failed to delete %s %s, err: %++v", job.Trainer(), job.Name(), err)

--- a/cmd/arena/commands/root.go
+++ b/cmd/arena/commands/root.go
@@ -85,7 +85,7 @@ func addKubectlFlagsToCmd(cmd *cobra.Command) {
 	overrides := clientcmd.ConfigOverrides{}
 	// kflags := clientcmd.RecommendedConfigOverrideFlags("")
 	cmd.PersistentFlags().StringVar(&loadingRules.ExplicitPath, "config", "", "Path to a kube config. Only required if out-of-cluster")
-	cmd.PersistentFlags().StringVar(&namespace, "namespace", "default", "the namespace of the job")
+	cmd.PersistentFlags().StringVarP(&namespace, "namespace", "n", "default", "the namespace of the job")
 	// clientcmd.BindOverrideFlags(&overrides, cmd.PersistentFlags(), kflags)
 	clientConfig = clientcmd.NewInteractiveDeferredLoadingClientConfig(loadingRules, &overrides, os.Stdin)
 }

--- a/cmd/arena/commands/trainer_horovod.go
+++ b/cmd/arena/commands/trainer_horovod.go
@@ -343,7 +343,7 @@ innerLoop:
 	log.Debugf("jobInfos %v", jobInfos)
 
 	for _, jobInfo := range jobInfos {
-		job, err := hj.getTrainingJob(jobInfo.Name, jobInfo.Namespace)
+		job, err := hj.getTrainingJobFromCache(jobInfo.Name, jobInfo.Namespace)
 		if err != nil {
 			return jobs, err
 		}

--- a/cmd/arena/commands/trainer_interface.go
+++ b/cmd/arena/commands/trainer_interface.go
@@ -30,6 +30,9 @@ type TrainingJob interface {
 	// Get the name of the Training Job
 	Name() string
 
+	// Get the namespace of the Training Job
+	Namespace() string
+
 	// Get all the pods of the Training Job
 	AllPods() []v1.Pod
 

--- a/cmd/arena/commands/trainer_interface.go
+++ b/cmd/arena/commands/trainer_interface.go
@@ -42,6 +42,9 @@ type TrainingJob interface {
 	// Get the Job Age
 	Age() time.Duration
 
+	// Get the Job Duration
+	Duration() time.Duration
+
 	// Get start time
 	StartTime() *metav1.Time
 

--- a/cmd/arena/commands/trainer_mpi.go
+++ b/cmd/arena/commands/trainer_mpi.go
@@ -131,6 +131,15 @@ func (mj *MPIJob) Duration() time.Duration {
 		return mj.chiefjob.Status.CompletionTime.Time.Sub(mpijob.CreationTimestamp.Time)
 	}
 
+	if mj.isFailed() {
+		cond := getPodLatestCondition(mj.chiefPod)
+		if !cond.LastTransitionTime.IsZero() {
+			return cond.LastTransitionTime.Time.Sub(mpijob.CreationTimestamp.Time)
+		} else {
+			log.Debugf("the latest condition's time is zero of pod %s", mj.chiefPod.Name)
+		}
+	}
+
 	return metav1.Now().Sub(mpijob.CreationTimestamp.Time)
 }
 

--- a/cmd/arena/commands/trainer_mpi.go
+++ b/cmd/arena/commands/trainer_mpi.go
@@ -20,6 +20,7 @@ import (
 	"github.com/kubeflow/arena/pkg/mpi-operator/client/clientset/versioned"
 	"github.com/kubeflow/arena/pkg/types"
 	log "github.com/sirupsen/logrus"
+	batchv1 "k8s.io/api/batch/v1"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -51,6 +52,7 @@ func initMPIJobClient() (mpijobClientset *versioned.Clientset, err error) {
 type MPIJob struct {
 	name         string
 	mpijob       v1alpha1.MPIJob
+	chiefjob     batchv1.Job
 	pods         []v1.Pod // all the pods including statefulset and job
 	chiefPod     v1.Pod   // the chief pod
 	requestedGPU int64
@@ -115,6 +117,22 @@ func (mj *MPIJob) Age() time.Duration {
 		return 0
 	}
 	return metav1.Now().Sub(job.CreationTimestamp.Time)
+}
+
+// Get the Job Training Duration
+func (mj *MPIJob) Duration() time.Duration {
+	mpijob := mj.mpijob
+
+	if mpijob.Status.StartTime == nil ||
+		mpijob.Status.StartTime.IsZero() {
+		return 0
+	}
+
+	if len(mj.chiefjob.Name) != 0 && mj.chiefjob.Status.CompletionTime != nil {
+		return mj.chiefjob.Status.CompletionTime.Time.Sub(mpijob.Status.StartTime.Time)
+	}
+
+	return metav1.Now().Sub(mpijob.Status.StartTime.Time)
 }
 
 // Get Dashboard url of the job
@@ -295,7 +313,11 @@ func (tt *MPIJobTrainer) GetTrainingJob(name, namespace string) (tj TrainingJob,
 func (tt *MPIJobTrainer) getTrainingJob(name, namespace string) (TrainingJob, error) {
 	var (
 		mpijob v1alpha1.MPIJob
+		job    batchv1.Job
 	)
+
+	// 0. get the batch job of the mpijob
+	job = tt.getChiefJob(name, namespace)
 
 	// 1. Get the batchJob of training Job
 	mpijobList, err := tt.mpijobClient.KubeflowV1alpha1().MPIJobs(namespace).List(metav1.ListOptions{
@@ -327,6 +349,7 @@ func (tt *MPIJobTrainer) getTrainingJob(name, namespace string) (TrainingJob, er
 	return &MPIJob{
 		mpijob:      mpijob,
 		chiefPod:    chiefPod,
+		chiefjob:    job,
 		pods:        pods,
 		name:        name,
 		trainerType: tt.Type(),
@@ -339,9 +362,19 @@ func (tt *MPIJobTrainer) getTrainingJobFromCache(name, ns string) (TrainingJob, 
 
 	var (
 		mpijob v1alpha1.MPIJob
+		job    batchv1.Job
 	)
 
-	// 1. Find the batch job
+	// 0. Find the batch job
+	//isChiefJob
+	for _, item := range allJobs {
+		if tt.isChiefJob(name, ns, item) {
+			job = item
+			break
+		}
+	}
+
+	// 1. Find the mpi job
 	for _, item := range allMPIjobs {
 		if tt.isMPIJob(name, ns, item) {
 			mpijob = item
@@ -357,8 +390,70 @@ func (tt *MPIJobTrainer) getTrainingJobFromCache(name, ns string) (TrainingJob, 
 		chiefPod:    chiefPod,
 		pods:        pods,
 		name:        name,
+		chiefjob:    job,
 		trainerType: tt.Type(),
 	}, nil
+}
+
+func (tt *MPIJobTrainer) getChiefJob(name string, namespace string) (job batchv1.Job) {
+	// try to search batch job of the mpijob, it may be name or name-mpijob
+	jobList, err := tt.client.BatchV1().Jobs(namespace).List(metav1.ListOptions{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ListOptions",
+			APIVersion: "v1",
+		}, LabelSelector: fmt.Sprintf("mpi_job_name=%s", name),
+	})
+
+	if len(jobList.Items) > 0 {
+		job = jobList.Items[0]
+		return job
+	}
+
+	if err != nil {
+		log.Debugf("mpijob list failed due to %v with mpi_job_name=%s", err, name)
+	}
+
+	jobList, err = tt.client.BatchV1().Jobs(namespace).List(metav1.ListOptions{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ListOptions",
+			APIVersion: "v1",
+		}, LabelSelector: fmt.Sprintf("mpi_job_name=%s-mpijob", name),
+	})
+
+	if len(jobList.Items) > 0 {
+		job = jobList.Items[0]
+		return job, nil
+	}
+
+	if err != nil {
+		log.Debugf("mpijob list failed due to %v with mpi_job_name=%s", err, name)
+	}
+
+	if len(jobList.Items) > 0 {
+		job = jobList.Items[0]
+	}
+
+	return job
+}
+
+func (tt *MPIJobTrainer) isChiefJob(job batchv1.Job, name string, namespace string) bool {
+	if job.Namespace != namespace {
+		log.Debugf("The job %s in namespace %s not the same namespace as the mpijob %s in the namespace %s",
+			job.Name,
+			job.Namespace,
+			name,
+			namespace)
+		return false
+	}
+
+	if job.Name == fmt.Sprintf("%s-launcher", name) || job.Name == fmt.Sprintf("%s-mpijob-launcher", name) {
+		log.Debugf("The job %s is the cheif job of %s", job.Name, name)
+		return true
+	} else {
+		log.Debugf("The job %s is not the cheif job of %s", job.Name, name)
+	}
+
+	return false
 }
 
 func (tt *MPIJobTrainer) isChiefPod(item v1.Pod) bool {

--- a/cmd/arena/commands/trainer_mpi.go
+++ b/cmd/arena/commands/trainer_mpi.go
@@ -534,7 +534,7 @@ func (tt *MPIJobTrainer) ListTrainingJobs() (jobs []TrainingJob, err error) {
 	log.Debugf("jobInfos %v", jobInfos)
 
 	for _, jobInfo := range jobInfos {
-		job, err := tt.getTrainingJob(jobInfo.Name, jobInfo.Namespace)
+		job, err := tt.getTrainingJobFromCache(jobInfo.Name, jobInfo.Namespace)
 		if err != nil {
 			return jobs, err
 		}

--- a/cmd/arena/commands/trainer_mpi.go
+++ b/cmd/arena/commands/trainer_mpi.go
@@ -219,6 +219,10 @@ func (mj *MPIJob) HostIPOfChief() (hostIP string) {
 	return hostIP
 }
 
+func (mj *MPIJob) Namespace() string {
+	return mj.mpijob.Namespace
+}
+
 // MPI Job trainer
 type MPIJobTrainer struct {
 	client       *kubernetes.Clientset

--- a/cmd/arena/commands/trainer_mpi.go
+++ b/cmd/arena/commands/trainer_mpi.go
@@ -123,16 +123,15 @@ func (mj *MPIJob) Age() time.Duration {
 func (mj *MPIJob) Duration() time.Duration {
 	mpijob := mj.mpijob
 
-	if mpijob.Status.StartTime == nil ||
-		mpijob.Status.StartTime.IsZero() {
+	if mpijob.CreationTimestamp.IsZero() {
 		return 0
 	}
 
 	if len(mj.chiefjob.Name) != 0 && mj.chiefjob.Status.CompletionTime != nil {
-		return mj.chiefjob.Status.CompletionTime.Time.Sub(mpijob.Status.StartTime.Time)
+		return mj.chiefjob.Status.CompletionTime.Time.Sub(mpijob.CreationTimestamp.Time)
 	}
 
-	return metav1.Now().Sub(mpijob.Status.StartTime.Time)
+	return metav1.Now().Sub(mpijob.CreationTimestamp.Time)
 }
 
 // Get Dashboard url of the job
@@ -368,7 +367,7 @@ func (tt *MPIJobTrainer) getTrainingJobFromCache(name, ns string) (TrainingJob, 
 	// 0. Find the batch job
 	//isChiefJob
 	for _, item := range allJobs {
-		if tt.isChiefJob(name, ns, item) {
+		if tt.isChiefJob(item, name, ns) {
 			job = item
 			break
 		}

--- a/cmd/arena/commands/trainer_mpi.go
+++ b/cmd/arena/commands/trainer_mpi.go
@@ -421,7 +421,7 @@ func (tt *MPIJobTrainer) getChiefJob(name string, namespace string) (job batchv1
 
 	if len(jobList.Items) > 0 {
 		job = jobList.Items[0]
-		return job, nil
+		return job
 	}
 
 	if err != nil {

--- a/cmd/arena/commands/trainer_standalone.go
+++ b/cmd/arena/commands/trainer_standalone.go
@@ -283,7 +283,7 @@ innerLoop:
 	log.Debugf("jobInfos %v", jobInfos)
 
 	for _, jobInfo := range jobInfos {
-		job, err := s.getTrainingJob(jobInfo.Name, jobInfo.Namespace)
+		job, err := s.getTrainingJobFromCache(jobInfo.Name, jobInfo.Namespace)
 		if err != nil {
 			return jobs, err
 		}

--- a/cmd/arena/commands/trainer_tensorflow.go
+++ b/cmd/arena/commands/trainer_tensorflow.go
@@ -115,6 +115,22 @@ func (tj *TensorFlowJob) Age() time.Duration {
 	return metav1.Now().Sub(job.Status.StartTime.Time)
 }
 
+// Get the Job Training Duration
+func (tj *TensorFlowJob) Duration() time.Duration {
+	job := tj.tfjob
+
+	if job.Status.StartTime == nil ||
+		job.Status.StartTime.IsZero() {
+		return 0
+	}
+
+	if !job.Status.CompletionTime.IsZero() {
+		return job.Status.CompletionTime.Sub(job.Status.StartTime)
+	}
+
+	return metav1.Now().Sub(job.Status.StartTime.Time)
+}
+
 // Get Dashboard url of the job
 func (tj *TensorFlowJob) GetJobDashboards(client *kubernetes.Clientset) ([]string, error) {
 	urls := []string{}

--- a/cmd/arena/commands/trainer_tensorflow.go
+++ b/cmd/arena/commands/trainer_tensorflow.go
@@ -467,7 +467,7 @@ func (tt *TensorFlowJobTrainer) ListTrainingJobs() (jobs []TrainingJob, err erro
 	log.Debugf("jobInfos %v", jobInfos)
 
 	for _, jobInfo := range jobInfos {
-		job, err := tt.getTrainingJob(jobInfo.Name, jobInfo.Namespace)
+		job, err := tt.getTrainingJobFromCache(jobInfo.Name, jobInfo.Namespace)
 		if err != nil {
 			return jobs, err
 		}

--- a/cmd/arena/commands/trainer_tensorflow.go
+++ b/cmd/arena/commands/trainer_tensorflow.go
@@ -104,6 +104,10 @@ func (tj *TensorFlowJob) StartTime() *metav1.Time {
 	return tj.tfjob.Status.StartTime
 }
 
+func (tj *TensorFlowJob) Namespace() string {
+	return tj.tfjob.Namespace
+}
+
 // Get the Job Age
 func (tj *TensorFlowJob) Age() time.Duration {
 	job := tj.tfjob

--- a/cmd/arena/commands/trainer_tensorflow.go
+++ b/cmd/arena/commands/trainer_tensorflow.go
@@ -133,7 +133,7 @@ func (tj *TensorFlowJob) Duration() time.Duration {
 		if !cond.LastTransitionTime.IsZero() {
 			return cond.LastTransitionTime.Time.Sub(job.Status.StartTime.Time)
 		} else {
-			log.Debugf("the latest condition's time is zero of pod %s", mj.chiefPod.Name)
+			log.Debugf("the latest condition's time is zero of pod %s", tj.chiefPod.Name)
 		}
 	}
 

--- a/cmd/arena/commands/trainer_tensorflow.go
+++ b/cmd/arena/commands/trainer_tensorflow.go
@@ -125,7 +125,7 @@ func (tj *TensorFlowJob) Duration() time.Duration {
 	}
 
 	if !job.Status.CompletionTime.IsZero() {
-		return job.Status.CompletionTime.Sub(job.Status.StartTime)
+		return job.Status.CompletionTime.Time.Sub(job.Status.StartTime.Time)
 	}
 
 	return metav1.Now().Sub(job.Status.StartTime.Time)

--- a/cmd/arena/commands/trainer_tensorflow.go
+++ b/cmd/arena/commands/trainer_tensorflow.go
@@ -128,6 +128,15 @@ func (tj *TensorFlowJob) Duration() time.Duration {
 		return job.Status.CompletionTime.Time.Sub(job.Status.StartTime.Time)
 	}
 
+	if tj.GetStatus() == "FAILED" {
+		cond := getPodLatestCondition(tj.chiefPod)
+		if !cond.LastTransitionTime.IsZero() {
+			return cond.LastTransitionTime.Time.Sub(job.Status.StartTime.Time)
+		} else {
+			log.Debugf("the latest condition's time is zero of pod %s", mj.chiefPod.Name)
+		}
+	}
+
 	return metav1.Now().Sub(job.Status.StartTime.Time)
 }
 


### PR DESCRIPTION

Show overall status and training duration of the job

```
# arena get --namespace kubeflow firstjob
STATUS: SUCCEEDED
NAMESPACE: kubeflow
TRAINING DURATION: 48s

NAME      STATUS     TRAINER  AGE  INSTANCE          NODE
firstjob  SUCCEEDED  TFJOB    5d   firstjob-chief-0  N/A

Your tensorboard will be available on:
192.168.0.199:31708
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/arena/120)
<!-- Reviewable:end -->
