### PR TITLE
update git-sync to version v3.1.1 to fix the git-sync issues-91

### DIFF
--- a/charts/tfjob/values.yaml
+++ b/charts/tfjob/values.yaml
@@ -35,7 +35,7 @@ evaluatorAnnotations: {}
 # rsync image
 rsyncImage: registry.cn-zhangjiakou.aliyuncs.com/tensorflow-samples/rsync
 # git sync image
-gitImage: registry.cn-zhangjiakou.aliyuncs.com/tensorflow-samples/git-sync:v2.0.6
+gitImage: registry.cn-zhangjiakou.aliyuncs.com/tensorflow-samples/git-sync:v3.1.1
 
 imagePullPolicy: Always
 


### PR DESCRIPTION
Fix ERROR: can't create .netrc file: error setting up git credentials exit status 255: error: could not lock config file //.gitconfig: Permission denied
Link issue: https://github.com/kubernetes/git-sync/issues/91
Link issue: https://github.com/kubeflow/arena/issues/134
please sync  aliyun  git-sync images   to lastest

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/arena/135)
<!-- Reviewable:end -->
