### PR TITLE
Fix Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,21 @@ endif
 
 # Build the project
 .PHONY: all
-all: cli-linux-amd64 
+all:
+ifeq ($(OS),Windows_NT)
+all: cli-windows
+else
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Linux)
+$(info "Building on Linux")
+all: cli-linux-amd64
+else ifeq ($(UNAME_S),Darwin)
+$(error "Building on Darwin")
+all: cli-darwin
+else
+$(info "The OS is not supported")
+endif
+endif
 
 .PHONY: cli-linux-amd64
 cli-linux-amd64:
@@ -67,12 +81,12 @@ cli-linux-amd64:
 .PHONY: cli-darwin
 cli-darwin:
 	mkdir -p bin
-	CGO_ENABLED=0 GOOS=darwin go build -tags 'netgo' -ldflags '${LDFLAGS}' -o ${DIST_DIR}/arena-darwin-amd64 ./cmd/arena/*.go
+	CGO_ENABLED=0 GOOS=darwin go build -tags 'netgo' -ldflags '${LDFLAGS}' -o ${DIST_DIR}/${ARENA_CLI_NAME} ./cmd/arena/*.go
 
 .PHONY: cli-windows
 cli-windows:
 	mkdir -p bin
-	CGO_ENABLED=0 GOARCH=amd64 GOOS=windows go build -tags 'netgo' -ldflags '${LDFLAGS}' -o ${DIST_DIR}/arena-windows-amd64 ./cmd/arena/*.go
+	CGO_ENABLED=0 GOARCH=amd64 GOOS=windows go build -tags 'netgo' -ldflags '${LDFLAGS}' -o ${DIST_DIR}/${ARENA_CLI_NAME} ./cmd/arena/*.go
 
 
 .PHONY: install-image

--- a/Makefile
+++ b/Makefile
@@ -55,20 +55,20 @@ IMAGE_PREFIX=${IMAGE_NAMESPACE}/
 endif
 
 # Build the project
-.PHONY: all
-all:
+.PHONY: default
+default:
 ifeq ($(OS),Windows_NT)
-all: cli-windows
+default: cli-windows
 else
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Linux)
 $(info "Building on Linux")
-all: cli-linux-amd64
+default: cli-linux-amd64
 else ifeq ($(UNAME_S),Darwin)
-$(error "Building on Darwin")
-all: cli-darwin
+$(info "Building on Darwin")
+default: cli-darwin
 else
-$(info "The OS is not supported")
+$(error "The OS is not supported")
 endif
 endif
 


### PR DESCRIPTION
Currently, the arena installation doesn't work per 8th step of the doc https://github.com/kubeflow/arena/blob/master/docs/installation/README.md because it ignores the OS dependency.  In order to fix the problem, this diff makes `make` run different targets depending on the OS, and also uniforms the output binary name to `arena` across different OSs.

Tested it on Darwin.

reference:
https://stackoverflow.com/a/12099167
https://stackoverflow.com/a/28720186

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/arena/153)
<!-- Reviewable:end -->
