### PR TITLE
add PodSecurityContext for mpijob

### DIFF
--- a/charts/mpijob/CHANGELOG.md
+++ b/charts/mpijob/CHANGELOG.md
@@ -64,3 +64,7 @@
 ### 0.15.0
 
 * Add resource limits for mpi-launcher
+
+### 0.16.0
+
+* Add PodSecurityContext support for RunAsUser, RunAsGroup, RunAsNonRoot, SupplementalGroups

--- a/charts/mpijob/Chart.yaml
+++ b/charts/mpijob/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for MPIJob
 name: mpijob
-version: 0.15.0
+version: 0.16.0

--- a/charts/mpijob/templates/mpijob.yaml
+++ b/charts/mpijob/templates/mpijob.yaml
@@ -47,6 +47,18 @@ spec:
       {{- if .Values.useHostIPC }}
       hostIPC: {{ .Values.useHostIPC }}
       {{- end }}
+      {{- if .Values.enablePodSecurityContext }}
+      {{- if .Values.isNonRoot}}
+      securityContext:
+        runAsUser: {{ .Values.podSecurityContext.runAsUser }}
+        runAsGroup: {{ .Values.podSecurityContext.runAsGroup }}
+        runAsNonRoot: {{ .Values.podSecurityContext.runAsNonRoot }}
+        supplementalGroups:
+          {{- range $group := .Values.podSecurityContext.supplementalGroups }}
+          - {{ $group -}}
+          {{ end }}
+      {{- end }}
+      {{- end }}
       volumes:
       {{- if .Values.useTensorboard }}
       {{- if .Values.isLocalLogging }}

--- a/charts/mpijob/templates/tensorboard.yaml
+++ b/charts/mpijob/templates/tensorboard.yaml
@@ -39,6 +39,18 @@ spec:
                 values: 
                   - {{ .Release.Name }}-worker-0
             topologyKey: kubernetes.io/hostname
+      {{- if .Values.enablePodSecurityContext }}
+      {{- if .Values.isNonRoot}}
+      securityContext:
+        runAsUser: {{ .Values.podSecurityContext.runAsUser }}
+        runAsGroup: {{ .Values.podSecurityContext.runAsGroup }}
+        runAsNonRoot: {{ .Values.podSecurityContext.runAsNonRoot }}
+        supplementalGroups:
+          {{- range $group := .Values.podSecurityContext.supplementalGroups }}
+          - {{ $group -}}
+          {{ end }}
+      {{- end }}
+      {{- end }}
       volumes:
         {{- if .Values.isLocalLogging }}
         - hostPath:

--- a/charts/mpijob/values.yaml
+++ b/charts/mpijob/values.yaml
@@ -47,3 +47,7 @@ annotations: {}
 # annotations:
 
 ingress: false
+
+# enable PodSecurityContext
+# In the future, this flag should be protected separately, in case of arena admin and users are not the same people
+enablePodSecurityContext: false

--- a/charts/tfjob/templates/deployment.yaml
+++ b/charts/tfjob/templates/deployment.yaml
@@ -63,7 +63,6 @@ spec:
         runAsUser: {{ .Values.podSecurityContext.runAsUser }}
         runAsGroup: {{ .Values.podSecurityContext.runAsGroup }}
         runAsNonRoot: {{ .Values.podSecurityContext.runAsNonRoot }}
-        fsGroup: {{ .Values.podSecurityContext.fsGroup }}
         supplementalGroups:
           {{- range $group := .Values.podSecurityContext.supplementalGroups }}
           - {{ $group -}}

--- a/charts/tfjob/templates/tfjob.yaml
+++ b/charts/tfjob/templates/tfjob.yaml
@@ -100,7 +100,6 @@ spec:
             runAsUser: {{ .Values.podSecurityContext.runAsUser }}
             runAsGroup: {{ .Values.podSecurityContext.runAsGroup }}
             runAsNonRoot: {{ .Values.podSecurityContext.runAsNonRoot }}
-            fsGroup: {{ .Values.podSecurityContext.fsGroup }}
             supplementalGroups:
               {{- range $group := .Values.podSecurityContext.supplementalGroups }}
               - {{ $group -}}
@@ -342,7 +341,6 @@ spec:
             runAsUser: {{ .Values.podSecurityContext.runAsUser }}
             runAsGroup: {{ .Values.podSecurityContext.runAsGroup }}
             runAsNonRoot: {{ .Values.podSecurityContext.runAsNonRoot }}
-            fsGroup: {{ .Values.podSecurityContext.fsGroup }}
             supplementalGroups:
               {{- range $group := .Values.podSecurityContext.supplementalGroups }}
               - {{ $group -}}
@@ -617,7 +615,6 @@ spec:
             runAsUser: {{ .Values.podSecurityContext.runAsUser }}
             runAsGroup: {{ .Values.podSecurityContext.runAsGroup }}
             runAsNonRoot: {{ .Values.podSecurityContext.runAsNonRoot }}
-            fsGroup: {{ .Values.podSecurityContext.fsGroup }}
             supplementalGroups:
               {{- range $group := .Values.podSecurityContext.supplementalGroups }}
               - {{ $group -}}
@@ -851,7 +848,6 @@ spec:
             runAsUser: {{ .Values.podSecurityContext.runAsUser }}
             runAsGroup: {{ .Values.podSecurityContext.runAsGroup }}
             runAsNonRoot: {{ .Values.podSecurityContext.runAsNonRoot }}
-            fsGroup: {{ .Values.podSecurityContext.fsGroup }}
             supplementalGroups:
               {{- range $group := .Values.podSecurityContext.supplementalGroups }}
               - {{ $group -}}

--- a/cmd/arena/commands/submit.go
+++ b/cmd/arena/commands/submit.go
@@ -70,7 +70,6 @@ type limitedPodSecurityContext struct {
 	RunAsNonRoot       bool    `yaml:"runAsNonRoot"`
 	RunAsGroup         int64   `yaml:"runAsGroup"`
 	SupplementalGroups []int64 `yaml:"supplementalGroups"`
-	FSGroup            int64   `yaml:"fsGroup"`
 }
 
 func (s submitArgs) check() error {


### PR DESCRIPTION
add PodSecurityContext of RunAsUser, RunAsGroup, RunAsNonRoot, SupplementalGroups to mpijob

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/arena/179)
<!-- Reviewable:end -->
