### PR TITLE
Easily address the GOAPTH in local for other README versions

### DIFF
--- a/README_cn.md
+++ b/README_cn.md
@@ -43,8 +43,8 @@ Arena 是一种命令行界面，支持轻而易举地运行和监控机器学�
 - Go >= 1.8
 
 ```
-mkdir -p $GOPATH/src/github.com/kubeflow
-cd $GOPATH/src/github.com/kubeflow
+mkdir -p $(go env GOPATH)/src/github.com/kubeflow
+cd $(go env GOPATH)/src/github.com/kubeflow
 git clone https://github.com/kubeflow/arena.git
 cd arena
 make

--- a/docs/installation/README.md
+++ b/docs/installation/README.md
@@ -70,8 +70,8 @@ Prerequisites:
 - Go >= 1.8
 
 ```
-mkdir -p $GOPATH/src/github.com/kubeflow
-cd $GOPATH/src/github.com/kubeflow
+mkdir -p $(go env GOPATH)/src/github.com/kubeflow
+cd $(go env GOPATH)/src/github.com/kubeflow
 git clone https://github.com/kubeflow/arena.git
 cd arena
 make

--- a/docs/installation_cn/README.md
+++ b/docs/installation_cn/README.md
@@ -70,8 +70,8 @@ kubectl create -f arena/kubernetes-artifacts/mpi-operator/mpi-operator.yaml
 - Go >= 1.8
 
 ```
-mkdir -p $GOPATH/src/github.com/kubeflow
-cd $GOPATH/src/github.com/kubeflow
+mkdir -p $(go env GOPATH)/src/github.com/kubeflow
+cd $(go env GOPATH)/src/github.com/kubeflow
 git clone https://github.com/kubeflow/arena.git
 cd arena
 make

--- a/jupyter/README.md
+++ b/jupyter/README.md
@@ -3,8 +3,8 @@
 1. Build jupyter notebook with `arena` by yourself
 
 ```
-mkdir -p $GOPATH/src/github.com/kubeflow
-cd $GOPATH/src/github.com/kubeflow
+mkdir -p $(go env GOPATH)/src/github.com/kubeflow
+cd $(go env GOPATH)/src/github.com/kubeflow
 git clone https://github.com/kubeflow/arena.git
 cd arena
 make notebook-image-cpu


### PR DESCRIPTION
To address the review comment in PR #194  and keep same in other README versions when referenced  the `GOAPTH`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/arena/195)
<!-- Reviewable:end -->
