### PR TITLE
Finish arena top node with GPUShare.

### DIFF
--- a/cmd/arena/commands/const.go
+++ b/cmd/arena/commands/const.go
@@ -19,6 +19,9 @@ const (
 	// GPUResourceName is the extended name of the GPU resource since v1.8
 	// this uses the device plugin mechanism
 	NVIDIAGPUResourceName = "nvidia.com/gpu"
+	resourceName          = "aliyun.com/gpu-mem"
+	resourceCount         = "aliyun.com/gpu-count"
+	envNVGPUID            = "ALIYUN_COM_GPU_MEM_IDX"
 
 	DeprecatedNVIDIAGPUResourceName = "alpha.kubernetes.io/nvidia-gpu"
 

--- a/cmd/arena/commands/nodeinfo_share.go
+++ b/cmd/arena/commands/nodeinfo_share.go
@@ -1,0 +1,262 @@
+package commands
+
+import (
+	"fmt"
+	"strconv"
+
+	log "github.com/golang/glog"
+	"k8s.io/api/core/v1"
+)
+
+type ShareNodeInfo struct {
+	pods           []v1.Pod
+	node           v1.Node
+	devs           map[int]*DeviceInfo
+	gpuCount       int
+	gpuTotalMemory int
+}
+
+type DeviceInfo struct {
+	idx         int
+	pods        []v1.Pod
+	usedGPUMem  int
+	totalGPUMem int
+	node        v1.Node
+}
+
+func (d *DeviceInfo) String() string {
+	if d.idx == -1 {
+		return fmt.Sprintf("%d", d.usedGPUMem)
+	}
+	return fmt.Sprintf("%d/%d", d.usedGPUMem, d.totalGPUMem)
+}
+
+//For all GPUShare nodes,decide whether the memory of GPU is measured by MiB or GiB
+func buildAllShareNodeInfos(allPods []v1.Pod, nodes []v1.Node) ([]*ShareNodeInfo, error) {
+	SharenodeInfos := buildShareNodeInfosWithPods(allPods, nodes)
+	for _, SharenodeInfo := range SharenodeInfos {
+		if SharenodeInfo.gpuTotalMemory > 0 {
+			setUnit(SharenodeInfo.gpuTotalMemory, SharenodeInfo.gpuCount)
+			err := SharenodeInfo.buildDeviceInfo()
+			if err != nil {
+				log.Warningf("Failed due to %v", err)
+				continue
+			}
+		}
+	}
+	return SharenodeInfos, nil
+}
+
+//For one GPUShare node,decide whether the memory of GPU is measured by MiB or GiB
+func buildShareNodeInfo(allPods []v1.Pod, node v1.Node) (*ShareNodeInfo, error) {
+	SharenodeInfo := buildShareNodeInfoWithPods(allPods, node)
+
+	if SharenodeInfo.gpuTotalMemory > 0 {
+		setUnit(SharenodeInfo.gpuTotalMemory, SharenodeInfo.gpuCount)
+		err := SharenodeInfo.buildDeviceInfo()
+		if err != nil {
+			log.Warningf("Failed due to %v", err)
+		}
+	}
+
+	return SharenodeInfo, nil
+}
+
+//Create  ShareNodeInfos for all gpushare nodes
+func buildShareNodeInfosWithPods(pods []v1.Pod, nodes []v1.Node) []*ShareNodeInfo {
+	nodeMap := map[string]*ShareNodeInfo{}
+	nodeList := []*ShareNodeInfo{}
+
+	for _, node := range nodes {
+		var info *ShareNodeInfo = &ShareNodeInfo{}
+		if value, ok := nodeMap[node.Name]; ok {
+			info = value
+		} else {
+			nodeMap[node.Name] = info
+			info.node = node
+			info.pods = []v1.Pod{}
+			info.gpuCount = getGPUCountInNode(node)
+			info.gpuTotalMemory = getTotalGPUMemory(node)
+			info.devs = map[int]*DeviceInfo{}
+
+			for i := 0; i < info.gpuCount; i++ {
+				dev := &DeviceInfo{
+					pods:        []v1.Pod{},
+					idx:         i,
+					totalGPUMem: info.gpuTotalMemory / info.gpuCount,
+					node:        info.node,
+				}
+				info.devs[i] = dev
+			}
+
+		}
+
+		for _, pod := range pods {
+			if pod.Spec.NodeName == node.Name {
+				info.pods = append(info.pods, pod)
+			}
+		}
+	}
+
+	for _, v := range nodeMap {
+		nodeList = append(nodeList, v)
+	}
+	return nodeList
+}
+
+//Create  ShareNodeInfo for one node
+func buildShareNodeInfoWithPods(pods []v1.Pod, node v1.Node) *ShareNodeInfo {
+
+	var info *ShareNodeInfo = &ShareNodeInfo{}
+	info.node = node
+	info.pods = []v1.Pod{}
+	info.gpuCount = getGPUCountInNode(node)
+	info.gpuTotalMemory = getTotalGPUMemory(node)
+	info.devs = map[int]*DeviceInfo{}
+
+	for i := 0; i < info.gpuCount; i++ {
+		dev := &DeviceInfo{
+			pods:        []v1.Pod{},
+			idx:         i,
+			totalGPUMem: info.gpuTotalMemory / info.gpuCount,
+			node:        info.node,
+		}
+		info.devs[i] = dev
+	}
+
+	for _, pod := range pods {
+		if pod.Spec.NodeName == node.Name {
+			info.pods = append(info.pods, pod)
+		}
+	}
+
+	return info
+}
+
+func getTotalGPUMemory(node v1.Node) int {
+	val, ok := node.Status.Allocatable[resourceName]
+
+	if !ok {
+		return 0
+	}
+
+	return int(val.Value())
+}
+
+func getGPUCountInNode(node v1.Node) int {
+	val, ok := node.Status.Allocatable[resourceCount]
+
+	if !ok {
+		return 0
+	}
+
+	return int(val.Value())
+}
+
+// Get Deviceinfo of ShareNodeinfo
+func (n *ShareNodeInfo) buildDeviceInfo() error {
+
+GPUSearchLoop:
+	for _, pod := range n.pods {
+		if gpuMemoryInPod(pod) <= 0 {
+			continue GPUSearchLoop
+		}
+
+		devID, usedGPUMem := n.getDeivceInfo(pod)
+
+		var dev *DeviceInfo
+		ok := false
+		if dev, ok = n.devs[devID]; !ok {
+			totalGPUMem := 0
+			if n.gpuCount > 0 {
+				totalGPUMem = n.gpuTotalMemory / n.gpuCount
+			}
+
+			dev = &DeviceInfo{
+				pods:        []v1.Pod{},
+				idx:         devID,
+				totalGPUMem: totalGPUMem,
+				node:        n.node,
+			}
+			n.devs[devID] = dev
+		}
+
+		dev.usedGPUMem = dev.usedGPUMem + usedGPUMem
+		dev.pods = append(dev.pods, pod)
+	}
+
+	return nil
+}
+
+func (n *ShareNodeInfo) getDeivceInfo(pod v1.Pod) (devIdx int, gpuMemory int) {
+	var err error
+	id := -1
+
+	if len(pod.ObjectMeta.Annotations) > 0 {
+		value, found := pod.ObjectMeta.Annotations[envNVGPUID]
+		if found {
+			id, err = strconv.Atoi(value)
+			if err != nil {
+				log.Warningf("Failed to parse dev id %s due to %v for pod %s in ns %s",
+					value,
+					err,
+					pod.Name,
+					pod.Namespace)
+				id = -1
+			}
+		} else {
+			log.Warningf("Failed to get dev id %s for pod %s in ns %s",
+				pod.Name,
+				pod.Namespace)
+		}
+	}
+
+	return id, gpuMemoryInPod(pod)
+}
+
+func hasPendingGPUMemory(nodeInfos []*ShareNodeInfo) (found bool) {
+	for _, info := range nodeInfos {
+		if info.hasPendingGPUMemory() {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (n *ShareNodeInfo) hasPendingGPUMemory() bool {
+	_, found := n.devs[-1]
+	return found
+}
+
+func isGPUSharingNode(node v1.Node) bool {
+	value, ok := node.Status.Allocatable[resourceName]
+
+	if ok {
+		ok = (int(value.Value()) > 0)
+	}
+
+	return ok
+}
+
+var (
+	memoryUnit = ""
+)
+
+func setUnit(gpuMemory, gpuCount int) {
+	if memoryUnit != "" {
+		return
+	}
+
+	if gpuCount == 0 {
+		return
+	}
+
+	gpuMemoryByDev := gpuMemory / gpuCount
+
+	if gpuMemoryByDev > 100 {
+		memoryUnit = "MiB"
+	} else {
+		memoryUnit = "GiB"
+	}
+}

--- a/cmd/arena/commands/podinfo_share.go
+++ b/cmd/arena/commands/podinfo_share.go
@@ -1,0 +1,76 @@
+package commands
+
+import (
+	"fmt"
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"time"
+)
+
+var (
+	retries = 5
+)
+
+type podInfo struct {
+	name      string
+	namespace string
+}
+
+func getActivePodsInAllNodes() ([]v1.Pod, error) {
+	pods, err := clientset.CoreV1().Pods(v1.NamespaceAll).List(metav1.ListOptions{
+		LabelSelector: labels.Everything().String(),
+	})
+
+	for i := 0; i < retries && err != nil; i++ {
+		pods, err = clientset.CoreV1().Pods(v1.NamespaceAll).List(metav1.ListOptions{
+			LabelSelector: labels.Everything().String(),
+		})
+		time.Sleep(100 * time.Millisecond)
+	}
+	if err != nil {
+		return []v1.Pod{}, fmt.Errorf("failed to get Pods")
+	}
+	return filterActivePods(pods.Items), nil
+}
+
+func filterActivePods(pods []v1.Pod) (activePods []v1.Pod) {
+	activePods = []v1.Pod{}
+	for _, pod := range pods {
+		if pod.Status.Phase == v1.PodSucceeded || pod.Status.Phase == v1.PodFailed {
+			continue
+		}
+
+		activePods = append(activePods, pod)
+	}
+
+	return activePods
+}
+
+func getAllSharedGPUNode() ([]v1.Node, error) {
+	nodes := []v1.Node{}
+	allNodes, err := clientset.CoreV1().Nodes().List(metav1.ListOptions{})
+	if err != nil {
+		return nodes, err
+	}
+
+	for _, item := range allNodes.Items {
+		if isGPUSharingNode(item) {
+			nodes = append(nodes, item)
+		}
+	}
+
+	return nodes, nil
+}
+
+func gpuMemoryInPod(pod v1.Pod) int {
+	var total int
+	containers := pod.Spec.Containers
+	for _, container := range containers {
+		if val, ok := container.Resources.Limits[resourceName]; ok {
+			total += int(val.Value())
+		}
+	}
+
+	return total
+}

--- a/cmd/arena/commands/top_node_gpushare.go
+++ b/cmd/arena/commands/top_node_gpushare.go
@@ -1,0 +1,243 @@
+package commands
+
+import (
+	"bytes"
+	"fmt"
+	log "github.com/golang/glog"
+	"k8s.io/api/core/v1"
+	"os"
+	"strconv"
+	"text/tabwriter"
+)
+
+func displayShareDetails(nodeInfos []*ShareNodeInfo) {
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	var (
+		totalGPUMemInCluster int64
+		usedGPUMemInCluster  int64
+		prtLineLen           int
+	)
+
+	for _, nodeInfo := range nodeInfos {
+		address := "unknown"
+		if len(nodeInfo.node.Status.Addresses) > 0 {
+			//address = nodeInfo.node.Status.Addresses[0].Address
+			for _, addr := range nodeInfo.node.Status.Addresses {
+				if addr.Type == v1.NodeInternalIP {
+					address = addr.Address
+					break
+				}
+			}
+		}
+
+		totalGPUMemInNode := nodeInfo.gpuTotalMemory
+		if totalGPUMemInNode <= 0 {
+			continue
+		}
+
+		fmt.Fprintf(w, "\n")
+		fmt.Fprintf(w, "NAME:\t%s\n", nodeInfo.node.Name)
+		fmt.Fprintf(w, "IPADDRESS:\t%s\n", address)
+		fmt.Fprintf(w, "\n")
+
+		usedGPUMemInNode := 0
+		var buf bytes.Buffer
+		buf.WriteString("NAME\tNAMESPACE\t")
+		for i := 0; i < nodeInfo.gpuCount; i++ {
+			buf.WriteString(fmt.Sprintf("GPU%d(Allocated)\t", i))
+		}
+
+		if nodeInfo.hasPendingGPUMemory() {
+			buf.WriteString("Pending(Allocated)\t")
+		}
+		buf.WriteString("\n")
+		fmt.Fprintf(w, buf.String())
+
+		var buffer bytes.Buffer
+		for i, dev := range nodeInfo.devs {
+			usedGPUMemInNode += dev.usedGPUMem
+			for _, pod := range dev.pods {
+
+				buffer.WriteString(fmt.Sprintf("%s\t%s\t", pod.Name, pod.Namespace))
+				count := nodeInfo.gpuCount
+				if nodeInfo.hasPendingGPUMemory() {
+					count += 1
+				}
+
+				for k := 0; k < count; k++ {
+					if k == i || (i == -1 && k == nodeInfo.gpuCount) {
+						buffer.WriteString(fmt.Sprintf("%d\t", getGPUMemoryInPod(pod)))
+					} else {
+						buffer.WriteString("0\t")
+					}
+				}
+				buffer.WriteString("\n")
+			}
+		}
+		if prtLineLen == 0 {
+			prtLineLen = buffer.Len() + 10
+		}
+		fmt.Fprintf(w, buffer.String())
+
+		var gpuUsageInNode float64 = 0
+		if totalGPUMemInNode > 0 {
+			gpuUsageInNode = float64(usedGPUMemInNode) / float64(totalGPUMemInNode) * 100
+		} else {
+			fmt.Fprintf(w, "\n")
+		}
+
+		fmt.Fprintf(w, "Allocated :\t%d (%d%%)\t\n", usedGPUMemInNode, int64(gpuUsageInNode))
+		fmt.Fprintf(w, "Total :\t%d \t\n", nodeInfo.gpuTotalMemory)
+		// fmt.Fprintf(w, "-----------------------------------------------------------------------------------------\n")
+		var prtLine bytes.Buffer
+		for i := 0; i < prtLineLen; i++ {
+			prtLine.WriteString("-")
+		}
+		prtLine.WriteString("\n")
+		fmt.Fprintf(w, prtLine.String())
+		totalGPUMemInCluster += int64(totalGPUMemInNode)
+		usedGPUMemInCluster += int64(usedGPUMemInNode)
+	}
+	fmt.Fprintf(w, "\n")
+	fmt.Fprintf(w, "\n")
+	fmt.Fprintf(w, "Allocated/Total GPU Memory In Cluster:\n")
+	log.V(2).Infof("gpu: %s, allocated GPU Memory %s", strconv.FormatInt(totalGPUMemInCluster, 10),
+		strconv.FormatInt(usedGPUMemInCluster, 10))
+
+	var gpuUsage float64 = 0
+	if totalGPUMemInCluster > 0 {
+		gpuUsage = float64(usedGPUMemInCluster) / float64(totalGPUMemInCluster) * 100
+	}
+	fmt.Fprintf(w, "%s/%s (%s) (%d%%)\t\n",
+		strconv.FormatInt(usedGPUMemInCluster, 10),
+		strconv.FormatInt(totalGPUMemInCluster, 10),
+		memoryUnit,
+		int64(gpuUsage))
+	// fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", ...)
+
+	_ = w.Flush()
+}
+
+func displayShareSummary(nodeInfos []*ShareNodeInfo) {
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	var (
+		maxGPUCount          int
+		totalGPUMemInCluster int64
+		usedGPUMemInCluster  int64
+		prtLineLen           int
+	)
+
+	hasPendingGPU := hasPendingGPUMemory(nodeInfos)
+
+	maxGPUCount = getMaxGPUCount(nodeInfos)
+
+	var buffer bytes.Buffer
+	buffer.WriteString("NAME\tIPADDRESS\t")
+	for i := 0; i < maxGPUCount; i++ {
+		buffer.WriteString(fmt.Sprintf("GPU%d(Allocated/Total)\t", i))
+	}
+
+	if hasPendingGPU {
+		buffer.WriteString("PENDING(Allocated)\t")
+	}
+	buffer.WriteString(fmt.Sprintf("\n"))
+
+	fmt.Fprintf(w, buffer.String())
+	for _, nodeInfo := range nodeInfos {
+		address := "unknown"
+		if len(nodeInfo.node.Status.Addresses) > 0 {
+			// address = nodeInfo.node.Status.Addresses[0].Address
+			for _, addr := range nodeInfo.node.Status.Addresses {
+				if addr.Type == v1.NodeInternalIP {
+					address = addr.Address
+					break
+				}
+			}
+		}
+
+		gpuMemInfos := []string{}
+		pendingGPUMemInfo := ""
+		usedGPUMemInNode := 0
+		totalGPUMemInNode := nodeInfo.gpuTotalMemory
+		if totalGPUMemInNode <= 0 {
+			continue
+		}
+
+		for i := 0; i < maxGPUCount; i++ {
+			gpuMemInfo := "0/0"
+			if dev, ok := nodeInfo.devs[i]; ok {
+				gpuMemInfo = dev.String()
+				usedGPUMemInNode += dev.usedGPUMem
+			}
+			gpuMemInfos = append(gpuMemInfos, gpuMemInfo)
+		}
+
+		// check if there is pending dev
+		if dev, ok := nodeInfo.devs[-1]; ok {
+			pendingGPUMemInfo = fmt.Sprintf("%d", dev.usedGPUMem)
+			usedGPUMemInNode += dev.usedGPUMem
+		}
+
+		var buf bytes.Buffer
+		buf.WriteString(fmt.Sprintf("%s\t%s\t", nodeInfo.node.Name, address))
+		for i := 0; i < maxGPUCount; i++ {
+			buf.WriteString(fmt.Sprintf("%s\t", gpuMemInfos[i]))
+		}
+		if hasPendingGPU {
+			buf.WriteString(fmt.Sprintf("%s\t", pendingGPUMemInfo))
+		}
+
+		buf.WriteString(fmt.Sprintf("\n"))
+		fmt.Fprintf(w, buf.String())
+
+		if prtLineLen == 0 {
+			prtLineLen = buf.Len() + 20
+		}
+
+		usedGPUMemInCluster += int64(usedGPUMemInNode)
+		totalGPUMemInCluster += int64(totalGPUMemInNode)
+	}
+	// fmt.Fprintf(w, "-----------------------------------------------------------------------------------------\n")
+	var prtLine bytes.Buffer
+	for i := 0; i < prtLineLen; i++ {
+		prtLine.WriteString("-")
+	}
+	prtLine.WriteString("\n")
+	fmt.Fprint(w, prtLine.String())
+
+	fmt.Fprintf(w, "Allocated/Total GPU Memory In Cluster:\n")
+	log.V(2).Infof("gpu: %s, allocated GPU Memory %s", strconv.FormatInt(totalGPUMemInCluster, 10),
+		strconv.FormatInt(usedGPUMemInCluster, 10))
+	var gpuUsage float64 = 0
+	if totalGPUMemInCluster > 0 {
+		gpuUsage = float64(usedGPUMemInCluster) / float64(totalGPUMemInCluster) * 100
+	}
+	fmt.Fprintf(w, "%s/%s (%s) (%d%%)\t\n",
+		strconv.FormatInt(usedGPUMemInCluster, 10),
+		strconv.FormatInt(totalGPUMemInCluster, 10),
+		memoryUnit,
+		int64(gpuUsage))
+	// fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", ...)
+
+	_ = w.Flush()
+}
+
+func getGPUMemoryInPod(pod v1.Pod) int {
+	gpuMem := 0
+	for _, container := range pod.Spec.Containers {
+		if val, ok := container.Resources.Limits[resourceName]; ok {
+			gpuMem += int(val.Value())
+		}
+	}
+	return gpuMem
+}
+
+func getMaxGPUCount(nodeInfos []*ShareNodeInfo) (max int) {
+	for _, node := range nodeInfos {
+		if node.gpuCount > max {
+			max = node.gpuCount
+		}
+	}
+
+	return max
+}


### PR DESCRIPTION
Premise: GPU resources on a node are either allocated by card or distributed by memory.

1. arena top node : Show the GPU resource usage of all nodes，If there is a GPUShare node in the entire cluster, the node is displayed as sharable.

2. arena top node -s : Show the GPUMemory resource usage of all GPUShare nodes.

3.arena top node -d: Show details of GPUCount task on a node. Including the name of the task, namespace, and  GPUCount used.

4.arena top node -s -d:Show details of GPUMemory task on a GPUShare node. Including the name of the task, namespace, and  GPUMemory used.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/arena/220)
<!-- Reviewable:end -->
