### PR TITLE
Report unhealthy GPU info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ### Added
 
 - Add Priority class support for MPIJob and TFJob
+- Display Unhealthy GPU devices
+- Integrate GPUShare capablities
 
 
 ## [Release 0.2.0]

--- a/cmd/arena/commands/gpu.go
+++ b/cmd/arena/commands/gpu.go
@@ -28,8 +28,19 @@ func gpuPods(pods []v1.Pod) (podsWithGPU []v1.Pod) {
 	return podsWithGPU
 }
 
-// The way to get GPU Count of Node: nvidia.com/gpu
-func gpuInNode(node v1.Node) int64 {
+// The way to get total GPU Count of Node: nvidia.com/gpu
+func totalGpuInNode(node v1.Node) int64 {
+	val, ok := node.Status.Capacity[NVIDIAGPUResourceName]
+
+	if !ok {
+		return gpuInNodeDeprecated(node)
+	}
+
+	return val.Value()
+}
+
+// The way to get allocatble GPU Count of Node: nvidia.com/gpu
+func allocatableGpuInNode(node v1.Node) int64 {
 	val, ok := node.Status.Allocatable[NVIDIAGPUResourceName]
 
 	if !ok {

--- a/cmd/arena/commands/top_node.go
+++ b/cmd/arena/commands/top_node.go
@@ -168,7 +168,7 @@ func displayTopNodeSummary(nodeInfos []NodeInfo) {
 			totalGPUsOnReadyNodeInCluster += totalGPU
 		}
 		if hasUnhealthyGPUNode {
-			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n", nodeInfo.node.Name,
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n", nodeInfo.node.Name,
 				address,
 				role,
 				status,

--- a/cmd/arena/commands/top_node.go
+++ b/cmd/arena/commands/top_node.go
@@ -322,7 +322,7 @@ func displayTopNodeDetails(nodeInfos []NodeInfo) {
 		int64(gpuUsage))
 	// fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", ...)
 	if hasUnhealthyGPUNode {
-		fmt.Fprintf(w, "Unhealthy/Total GPUs In Cluster:")
+		fmt.Fprintf(w, "Unhealthy/Total GPUs In Cluster:\t")
 		var gpuUnhealthyPercentage float64 = 0
 		if totalGPUsInCluster > 0 {
 			gpuUnhealthyPercentage = float64(totalUnhealthyGPUsInCluster) / float64(totalGPUsInCluster) * 100

--- a/cmd/arena/commands/top_node.go
+++ b/cmd/arena/commands/top_node.go
@@ -184,7 +184,11 @@ func displayTopNodeSummary(nodeInfos []NodeInfo) {
 				strconv.FormatInt(allocatedGPU, 10))
 		}
 	}
-	fmt.Fprintf(w, "-----------------------------------------------------------------------------------------\n")
+	if hasUnhealthyGPUNode {
+		fmt.Fprintf(w, "---------------------------------------------------------------------------------------------------\n")
+	} else {
+		fmt.Fprintf(w, "-----------------------------------------------------------------------------------------\n")
+	}
 	fmt.Fprintf(w, "Allocated/Total GPUs In Cluster:\n")
 	log.Debugf("gpu: %s, allocated GPUs %s", strconv.FormatInt(totalGPUsInCluster, 10),
 		strconv.FormatInt(allocatedGPUsInCluster, 10))
@@ -318,7 +322,7 @@ func displayTopNodeDetails(nodeInfos []NodeInfo) {
 		int64(gpuUsage))
 	// fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", ...)
 	if hasUnhealthyGPUNode {
-		fmt.Fprintf(w, "Unhealthy/Total GPUs In Cluster:\n")
+		fmt.Fprintf(w, "Unhealthy/Total GPUs In Cluster:")
 		var gpuUnhealthyPercentage float64 = 0
 		if totalGPUsInCluster > 0 {
 			gpuUnhealthyPercentage = float64(totalUnhealthyGPUsInCluster) / float64(totalGPUsInCluster) * 100


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/arena/221)
<!-- Reviewable:end -->


### Case 1: the node is healthy

- no details
```
# arena top node
NAME                     IPADDRESS     ROLE    STATUS  GPU(Total)  GPU(Allocated)
cn-beijing.192.168.1.32  192.168.1.32  master  ready   0           0
cn-beijing.192.168.1.33  192.168.1.33  master  ready   0           0
cn-beijing.192.168.1.34  192.168.1.34  master  ready   0           0
cn-beijing.192.168.1.35  192.168.1.35  <none>  ready   1           0
-----------------------------------------------------------------------------------------
Allocated/Total GPUs In Cluster:
0/1 (0%)
```
- with details:

```
# arena top node
NAME                     IPADDRESS     ROLE    STATUS  GPU(Total)  GPU(Allocated)  GPU(Unhealthy)
cn-beijing.192.168.1.32  192.168.1.32  master  ready   0           0               0
cn-beijing.192.168.1.33  192.168.1.33  master  ready   0           0               0
cn-beijing.192.168.1.34  192.168.1.34  master  ready   0           0               0
cn-beijing.192.168.1.35  192.168.1.35  <none>  ready   1           0               1
---------------------------------------------------------------------------------------------------
Allocated/Total GPUs In Cluster:
0/1 (0%)
Unhealthy/Total GPUs In Cluster:
1/1 (100%)
```

### Case 2: the node is unhealthy

- Without details:

```
arena top node
NAME                     IPADDRESS     ROLE    STATUS  GPU(Total)  GPU(Allocated)  GPU(Unhealthy)
cn-beijing.192.168.1.32  192.168.1.32  master  ready   0           0               0
cn-beijing.192.168.1.33  192.168.1.33  master  ready   0           0               0
cn-beijing.192.168.1.34  192.168.1.34  master  ready   0           0               0
cn-beijing.192.168.1.35  192.168.1.35  <none>  ready   1           0               1
---------------------------------------------------------------------------------------------------
Allocated/Total GPUs In Cluster:
0/1 (0%)
Unhealthy/Total GPUs In Cluster:
1/1 (100%)
```

- with details：

```shell
NAME:       cn-beijing.192.168.1.32
IPADDRESS:  192.168.1.32
ROLE:       master

Total GPUs In Node cn-beijing.192.168.1.32:      0
Allocated GPUs In Node cn-beijing.192.168.1.32:  0 (0%)
Unhealthy GPUs In Node cn-beijing.192.168.1.32:  0 (0%)
-----------------------------------------------------------------------------------------

NAME:       cn-beijing.192.168.1.33
IPADDRESS:  192.168.1.33
ROLE:       master

Total GPUs In Node cn-beijing.192.168.1.33:      0
Allocated GPUs In Node cn-beijing.192.168.1.33:  0 (0%)
Unhealthy GPUs In Node cn-beijing.192.168.1.33:  0 (0%)
-----------------------------------------------------------------------------------------

NAME:       cn-beijing.192.168.1.34
IPADDRESS:  192.168.1.34
ROLE:       master

Total GPUs In Node cn-beijing.192.168.1.34:      0
Allocated GPUs In Node cn-beijing.192.168.1.34:  0 (0%)
Unhealthy GPUs In Node cn-beijing.192.168.1.34:  0 (0%)
-----------------------------------------------------------------------------------------

NAME:                                            cn-beijing.192.168.1.35
IPADDRESS:                                       192.168.1.35
ROLE:                                            <none>
Total GPUs In Node cn-beijing.192.168.1.35:      1
Allocated GPUs In Node cn-beijing.192.168.1.35:  0 (0%)
Unhealthy GPUs In Node cn-beijing.192.168.1.35:  1 (100%)
-----------------------------------------------------------------------------------------


Allocated/Total GPUs In Cluster:  0/1 (0%)
Unhealthy/Total GPUs In Cluster:  1/1 (100%)
```

