### PR TITLE
bugfix: fix submit spark job error.

### DIFF
--- a/cmd/arena/commands/submit_spark.go
+++ b/cmd/arena/commands/submit_spark.go
@@ -124,7 +124,7 @@ func submitSparkApplicationJob(args []string, submitArgs *submitSparkJobArgs) er
 
 	job, err := trainer.GetTrainingJob(name, namespace)
 	if err != nil {
-		return fmt.Errorf("failed to create sparkjob %s due to error %v", name, err)
+		log.Debugf("Check %s exist due to error %v", name, err)
 	}
 
 	if job != nil {


### PR DESCRIPTION
Arena can't submit spark job normally now. So like other training type job, when submitting spark job, arena should print the message rather than directly return.
The relevant PR: #185

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/arena/242)
<!-- Reviewable:end -->
