### PR TITLE
fix typo: apiversion v1 -> v1beta1

### DIFF
--- a/docs/userguide/13-preempted-mpijob.md
+++ b/docs/userguide/13-preempted-mpijob.md
@@ -8,7 +8,7 @@
 1.Create `PriorityClass` with the yaml below:
 
 ```yaml
-apiVersion: scheduling.k8s.io/v1
+apiVersion: scheduling.k8s.io/v1beta1
 description: Used for the critical app
 kind: PriorityClass
 metadata:
@@ -17,7 +17,7 @@ value: 1100000
 
 ---
 
-apiVersion: scheduling.k8s.io/v1
+apiVersion: scheduling.k8s.io/v1beta1
 description: Used for the medium app
 kind: PriorityClass
 metadata:

--- a/docs/userguide_cn/13-preempted-mpijob.md
+++ b/docs/userguide_cn/13-preempted-mpijob.md
@@ -8,7 +8,7 @@
 1.利用下列yaml创建`PriorityClass`对象，这里定义了两个优先级`critical`和`medium`:
 
 ```yaml
-apiVersion: scheduling.k8s.io/v1
+apiVersion: scheduling.k8s.io/v1beta1
 description: Used for the critical app
 kind: PriorityClass
 metadata:
@@ -17,7 +17,7 @@ value: 1100000
 
 ---
 
-apiVersion: scheduling.k8s.io/v1
+apiVersion: scheduling.k8s.io/v1beta1
 description: Used for the medium app
 kind: PriorityClass
 metadata:


### PR DESCRIPTION
```sh
$ kubectl create -f pc.yaml`
unable to recognize "pc.yaml": no matches for kind "PriorityClass" in version "scheduling.k8s.io/v1"
```

```sh
$ kubectl explain priorityclass --api-version scheduling.k8s.io/v1
error: Couldn't find resource for "scheduling.k8s.io/v1, Kind=PriorityClass"
```
the apiversion scheduling.k8s.io/v1 is not supported in current kubernetes, change it to scheduling.k8s.io/v1beta1.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/arena/251)
<!-- Reviewable:end -->
