### PR TITLE
add replicas in chief & evaluator

### DIFF
--- a/charts/tfjob/templates/tfjob.yaml
+++ b/charts/tfjob/templates/tfjob.yaml
@@ -577,6 +577,7 @@ spec:
 {{- end }}
 {{- if .Values.chief }}
 {{ .Values.chiefName | indent  4}}:
+      replicas: 1
       restartPolicy: Never
       template:
         metadata:
@@ -868,6 +869,7 @@ spec:
 {{- end }}
 {{- if .Values.evaluator }}
     Evaluator:
+      replicas: 1
       restartPolicy: Never
       template:
         metadata:


### PR DESCRIPTION
add replicas in chief & evaluator

Fixes issue #158 

According to [multi_worker_util.py#L49-L60](https://github.com/tensorflow/tensorflow/blob/1916f19bd1a792d3ba5e9e0666fca5e6374cf298/tensorflow/python/distribute/multi_worker_util.py#L49-L60), I think tensorflow only support one chief/evaluator.

So I set 1 to both replicas.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/arena/257)
<!-- Reviewable:end -->
