### PR TITLE
volcano trainer isSupported for the specific job

### DIFF
--- a/cmd/arena/commands/trainer_volcano.go
+++ b/cmd/arena/commands/trainer_volcano.go
@@ -357,7 +357,9 @@ func (st *VolcanoJobTrainer) IsSupported(name, ns string) bool {
 			}
 		}
 	} else {
-		volcanoJobList, err := st.volcanoJobClient.BatchV1alpha1().Jobs(ns).List(metav1.ListOptions{})
+		volcanoJobList, err := st.volcanoJobClient.BatchV1alpha1().Jobs(ns).List(metav1.ListOptions{
+			LabelSelector: fmt.Sprintf("release=%s", name),
+		})
 
 		if err != nil {
 			log.Debugf("failed to search job %s in namespace %s due to %v", name, ns, err)


### PR DESCRIPTION
Currently Volcano is supported function return true if any volcano jobs exists in the system.
This created problem with list commands.

It should return true for the specific job name.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/arena/277)
<!-- Reviewable:end -->
