### PR TITLE
horovod and standalone gets the only the jobs they created

### DIFF
--- a/cmd/arena/commands/trainer_horovod.go
+++ b/cmd/arena/commands/trainer_horovod.go
@@ -134,7 +134,7 @@ func (m *HorovodJobTrainer) IsSupported(name, ns string) bool {
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "ListOptions",
 				APIVersion: "v1",
-			}, LabelSelector: fmt.Sprintf("release=%s", name),
+			}, LabelSelector: fmt.Sprintf("release=%s,app=tf-horovod", name),
 		})
 		if err != nil {
 			log.Debugf("failed to search job %s in namespace %s due to %v", name, ns, err)

--- a/cmd/arena/commands/trainer_standalone.go
+++ b/cmd/arena/commands/trainer_standalone.go
@@ -113,7 +113,7 @@ func (s *StandaloneJobTrainer) IsSupported(name, ns string) bool {
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "ListOptions",
 				APIVersion: "v1",
-			}, LabelSelector: fmt.Sprintf("release=%s", name),
+			}, LabelSelector: fmt.Sprintf("release=%s,app=training", name),
 		})
 		if err != nil {
 			log.Debugf("failed to search job %s in namespace %s due to %v", name, ns, err)


### PR DESCRIPTION
horovod and standalone trainer should list only their own job resources.

We use our custom trainer that utilize the Job resource of kubernetes.
**What is happening**
1. Create a new job with our custom trainer
2. Get job using job name without specific `--type` flag
3. Gets an error "There are more than 1 training jobs with the same name ...", Altough only job job exists in the system
**What should happend**
1. Create a new job with our custom trainer.
2. Get job using job name without specific `--type` flag
3. Our job gets displayed

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/arena/281)
<!-- Reviewable:end -->
