### PR TITLE
fix the issue caused by api version upgrade

### DIFF
--- a/charts/mpijob/CHANGELOG.md
+++ b/charts/mpijob/CHANGELOG.md
@@ -72,6 +72,11 @@
 ### 0.17.0
 
 * Add Priority Class
+
 ### 0.18.0
 
 * Support node selector labels and tolerations
+
+### 0.19.0
+
+* Upgrade deployment to apps/v1

--- a/charts/mpijob/Chart.yaml
+++ b/charts/mpijob/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for MPIJob
 name: mpijob
-version: 0.18.0
+version: 0.19.0

--- a/charts/mpijob/templates/tensorboard.yaml
+++ b/charts/mpijob/templates/tensorboard.yaml
@@ -12,6 +12,12 @@ metadata:
     createdBy: "MPIJob"
     role: tensorboard
 spec:
+  selector:
+    matchLabels:
+      app: {{ template "mpijob.name" . }}
+      chart: {{ template "mpijob.chart" . }}
+      release: {{ .Release.Name }}
+      role: tensorboard
   template:
     metadata:
       labels:

--- a/charts/tfjob/CHANGELOG.md
+++ b/charts/tfjob/CHANGELOG.md
@@ -95,3 +95,7 @@
 ### 0.22.0
 
 * Support node selector labels and tolerations
+
+### 0.23.0
+
+* Upgrade deployment to apps/v1

--- a/charts/tfjob/Chart.yaml
+++ b/charts/tfjob/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for TFJob
 name: tfjob
-version: 0.22.0
+version: 0.23.0

--- a/charts/tfjob/templates/deployment.yaml
+++ b/charts/tfjob/templates/deployment.yaml
@@ -13,6 +13,12 @@ metadata:
     createdBy: "TFJob"
     role: tensorboard
 spec:
+  selector:
+    matchLabels:
+      app: {{ template "tfjob.name" . }}
+      chart: {{ template "tfjob.chart" . }}
+      release: {{ .Release.Name }}
+      role: tensorboard
   template:
     metadata:
       labels:


### PR DESCRIPTION

```
DEBU[0000] values: &{Cpu: Memory: submitArgs:{NodeSelectors:map[] Tolerations:[] Image:registry.cn-hangzhou.aliyuncs.com/tensorflow-samples/tf-mnist-standalone:gpu GPUCount:1 Envs:map[workers:1 gpus:1] WorkingDir:/root Command:python /app/main.py Mode:mpijob WorkerCount:1 Retry:0 DataSet:map[] DataDirs:[] EnableRDMA:false UseENI:false Annotations:map[] IsNonRoot:false PodSecurityContext:{RunAsUser:0 RunAsNonRoot:false RunAsGroup:0 SupplementalGroups:[]} PriorityClassName:} submitTensorboardArgs:{UseTensorboard:true TensorboardImage:registry.cn-zhangjiakou.aliyuncs.com/tensorflow-samples/tensorflow:1.12.0-devel TrainingLogdir:/training_logs HostLogPath:/arena_logs/training617706277 IsLocalLogging:true} submitSyncCodeArgs:{SyncMode: SyncSource: SyncImage: SyncGitProjectName:}}
DEBU[0000] Exec bash -c [/usr/local/bin/helm template -f /tmp/values128575825 --namespace default --name firstjob /charts/mpijob > /tmp/firstjob.yaml137653884]
DEBU[0000] Generating template  [/usr/local/bin/helm template -f /tmp/values128575825 --namespace default --name firstjob /charts/mpijob > /tmp/firstjob.yaml137653884]
DEBU[0000] Exec /usr/bin/kubectl, [create --dry-run --namespace default -f /tmp/firstjob.yaml137653884]
ERRO[0000] Failed to execute kubectl, [create --dry-run --namespace default -f /tmp/firstjob.yaml137653884] with exit status 1
ERRO[0000] The output is service/firstjob-tensorboard created (dry run)
error: error validating "/tmp/firstjob.yaml137653884": error validating data: ValidationError(Deployment.spec): missing required field "selector" in io.k8s.api.apps.v1.DeploymentSpec; if you choose to ignore these errors, turn validation off with --validate=false 
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/arena/284)
<!-- Reviewable:end -->
