### PR TITLE
Featues/support assigning configuration files when submitting jobs 

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,11 @@ Arena is a command-line interface to run and monitor the machine learning traini
 - [10. Run a distributed training job with RDMA](docs/userguide/10-rdma-integration.md)
 - [11. Run a distributed spark job](docs/userguide/11-sparkjob-distributed.md)
 - [12. Run a Volcano job](docs/userguide/12-volcanojob.md)
+- [13. Preempted mpi job](docs/userguide/13-preempted-mpijob.md)
+- [14. Submit jobs with node selectors](docs/userguide/14-submit-with-node-selector.md)
+- [15. Submit jobs with tolerating taints](docs/userguide/14-submit-with-node-toleration.md)
+- [16. Run a custom serving job](docs/userguide/15-custom-serving-sample.md)
+- [17. Assign configuration files when submitting jobs](docs/userguide/16-assign-config-file.md)
 
 ## Demo
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Arena is a command-line interface to run and monitor the machine learning traini
 - [14. Submit jobs with node selectors](docs/userguide/14-submit-with-node-selector.md)
 - [15. Submit jobs with tolerating taints](docs/userguide/14-submit-with-node-toleration.md)
 - [16. Run a custom serving job](docs/userguide/15-custom-serving-sample.md)
-- [17. Assign configuration files when submitting jobs](docs/userguide/16-assign-config-file.md)
+- [17. Run a training Job with configuration files](docs/userguide/16-assign-config-file.md)
 
 ## Demo
 

--- a/charts/mpijob/CHANGELOG.md
+++ b/charts/mpijob/CHANGELOG.md
@@ -80,3 +80,7 @@
 ### 0.19.0
 
 * Upgrade deployment to apps/v1
+
+### 0.19.1
+
+* Support assigning configuration files when submitting jobs

--- a/charts/mpijob/CHANGELOG.md
+++ b/charts/mpijob/CHANGELOG.md
@@ -81,6 +81,6 @@
 
 * Upgrade deployment to apps/v1
 
-### 0.19.1
+### 0.20.0
 
 * Support assigning configuration files when submitting jobs

--- a/charts/mpijob/Chart.yaml
+++ b/charts/mpijob/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for MPIJob
 name: mpijob
-version: 0.19.1
+version: 0.20.0

--- a/charts/mpijob/Chart.yaml
+++ b/charts/mpijob/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for MPIJob
 name: mpijob
-version: 0.19.0
+version: 0.19.1

--- a/charts/mpijob/templates/configmap.yaml
+++ b/charts/mpijob/templates/configmap.yaml
@@ -1,0 +1,22 @@
+{{- if ne (len .Values.configFiles) 0 }}
+{{- $releaseName := .Release.Name }}
+{{- $releaseService := .Release.Service }}
+{{- range $containerPathKey,$configFileInfos := .Values.configFiles }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $releaseName }}-{{ $containerPathKey }}
+  labels:
+    app: {{ template "mpijob.name" $ }}
+    chart: {{ template "mpijob.chart" $ }}
+    release: {{ $releaseName }}
+    heritage: {{ $releaseService }}
+    createdBy: "MPIJob"
+data:
+{{- range $configFileKey,$configFileInfo := $configFileInfos }}
+  {{ $configFileInfo.containerFileName }}: |-
+{{ $configFileInfo.content | indent 4 }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/mpijob/templates/mpijob.yaml
+++ b/charts/mpijob/templates/mpijob.yaml
@@ -80,6 +80,14 @@ spec:
       {{- end }}
       {{- end }}
       volumes:
+      {{- if ne (len .Values.configFiles) 0 }}
+      {{- $releaseName := .Release.Name }}
+      {{- range $containerPathKey,$configFileInfos := .Values.configFiles }}
+      - name: {{ $containerPathKey }}
+        configMap:
+          name: {{ $releaseName }}-{{ $containerPathKey }}
+      {{- end }}
+      {{- end }}
       {{- if .Values.useTensorboard }}
       {{- if .Values.isLocalLogging }}
       - hostPath:
@@ -230,6 +238,19 @@ spec:
             - IPC_LOCK
         {{- end }}
         volumeMounts:
+        {{- if ne (len .Values.configFiles) 0 }}
+        {{- $releaseName := .Release.Name }}
+        {{- range $containerPathKey,$configFileInfos := .Values.configFiles }}
+        {{- $visit := "false" }}
+        {{- range $cofigFileKey,$configFileInfo := $configFileInfos }}
+        {{- if eq  "false" $visit }}
+        - mountPath: {{ $configFileInfo.containerFilePath }}
+          name: {{ $containerPathKey }}
+        {{- $visit = "true" }}  
+        {{- end }}
+        {{- end }}
+        {{- end }}
+        {{- end }}
         {{- if .Values.useTensorboard }}
         {{- if .Values.isLocalLogging }}
         - mountPath: {{ .Values.trainingLogdir }}

--- a/charts/tfjob/CHANGELOG.md
+++ b/charts/tfjob/CHANGELOG.md
@@ -100,6 +100,6 @@
 
 * Upgrade deployment to apps/v1
 
-### 0.23.1
+### 0.24.0
 
 * Support adding configuration files when submitting jobs

--- a/charts/tfjob/CHANGELOG.md
+++ b/charts/tfjob/CHANGELOG.md
@@ -99,3 +99,7 @@
 ### 0.23.0
 
 * Upgrade deployment to apps/v1
+
+### 0.23.1
+
+* Support adding configuration files when submitting jobs

--- a/charts/tfjob/Chart.yaml
+++ b/charts/tfjob/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for TFJob
 name: tfjob
-version: 0.23.1
+version: 0.24.0

--- a/charts/tfjob/Chart.yaml
+++ b/charts/tfjob/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for TFJob
 name: tfjob
-version: 0.23.0
+version: 0.23.1

--- a/charts/tfjob/templates/configmap.yaml
+++ b/charts/tfjob/templates/configmap.yaml
@@ -1,0 +1,22 @@
+{{- if ne (len .Values.configFiles) 0 }}
+{{- $releaseName := .Release.Name }}
+{{- $releaseService := .Release.Service }}
+{{- range $containerPathKey,$configFileInfos := .Values.configFiles }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $releaseName }}-{{ $containerPathKey }}
+  labels:
+    app: {{ template "tfjob.name" $ }}
+    chart: {{ template "tfjob.chart" $ }}
+    release: {{ $releaseName }}
+    heritage: {{ $releaseService }}
+    createdBy: "TFJob"
+data:
+{{- range $configFileKey,$configFileInfo := $configFileInfos }}
+  {{ $configFileInfo.containerFileName }}: |-
+{{ $configFileInfo.content | indent 4 }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/tfjob/templates/tfjob.yaml
+++ b/charts/tfjob/templates/tfjob.yaml
@@ -128,6 +128,14 @@ spec:
           {{- end }}
           {{- end }}
           volumes:
+            {{- if ne (len .Values.configFiles) 0 }}
+            {{- $releaseName := .Release.Name }}
+            {{- range $containerPathKey,$configFileInfos := .Values.configFiles }}
+            - name: {{ $containerPathKey }}
+              configMap:
+                name: {{ $releaseName }}-{{ $containerPathKey }}
+            {{- end }}
+            {{- end }}
             {{- if .Values.syncMode }}
             - name: code-sync
               emptyDir: {}
@@ -254,6 +262,19 @@ spec:
                   value: "{{ $value }}"
               {{- end }}
               volumeMounts:
+                {{- if ne (len .Values.configFiles) 0 }}
+                {{- $releaseName := .Release.Name }}
+                {{- range $containerPathKey,$configFileInfos := .Values.configFiles }}
+                {{- $visit := "false" }}
+                {{- range $cofigFileKey,$configFileInfo := $configFileInfos }}
+                {{- if eq  "false" $visit }}
+                - mountPath: {{ $configFileInfo.containerFilePath }}
+                  name: {{ $containerPathKey }}
+                {{- $visit = "true" }}  
+                {{- end }}
+                {{- end }}
+                {{- end }}
+                {{- end }}
                 {{- if .Values.syncMode }}
                 {{- if .Values.workingDir }}
                 - name: code-sync
@@ -389,6 +410,14 @@ spec:
           {{- end }}
           {{- end }}
           volumes:
+            {{- if ne (len .Values.configFiles) 0 }}
+            {{- $releaseName := .Release.Name }}
+            {{- range $containerPathKey,$configFileInfos := .Values.configFiles }}
+            - name: {{ $containerPathKey }}
+              configMap:
+                name: {{ $releaseName }}-{{ $containerPathKey }}
+            {{- end }}
+            {{- end }}
             {{- if .Values.useTensorboard }}
             {{- if .Values.isLocalLogging }}
             - hostPath:
@@ -538,6 +567,19 @@ spec:
                   value: "{{ $value }}"
               {{- end }}
               volumeMounts:
+                {{- if ne (len .Values.configFiles) 0 }}
+                {{- $releaseName := .Release.Name }}
+                {{- range $containerPathKey,$configFileInfos := .Values.configFiles }}
+                {{- $visit := "false" }}
+                {{- range $cofigFileKey,$configFileInfo := $configFileInfos }}
+                {{- if eq  "false" $visit }}
+                - mountPath: {{ $configFileInfo.containerFilePath }}
+                  name: {{ $containerPathKey }}
+                {{- $visit = "true" }}  
+                {{- end }}
+                {{- end }}
+                {{- end }}
+                {{- end }}
                 {{- if (not .Values.chief) }}
                 {{- if .Values.useTensorboard }}
                 {{- if .Values.isLocalLogging }}
@@ -683,6 +725,14 @@ spec:
           {{- end }}
           {{- end }}
           volumes:
+            {{- if ne (len .Values.configFiles) 0 }}
+            {{- $releaseName := .Release.Name }}
+            {{- range $containerPathKey,$configFileInfos := .Values.configFiles }}
+            - name: {{ $containerPathKey }}
+              configMap:
+                name: {{ $releaseName }}-{{ $containerPathKey }}
+            {{- end }}
+            {{- end }}
             {{- if .Values.useTensorboard }}
             {{- if .Values.isLocalLogging }}
             - hostPath:
@@ -832,6 +882,19 @@ spec:
                   value: "{{ $value }}"
               {{- end }}
               volumeMounts:
+                {{- if ne (len .Values.configFiles) 0 }}
+                {{- $releaseName := .Release.Name }}
+                {{- range $containerPathKey,$configFileInfos := .Values.configFiles }}
+                {{- $visit := "false" }}
+                {{- range $cofigFileKey,$configFileInfo := $configFileInfos }}
+                {{- if eq  "false" $visit }}
+                - mountPath: {{ $configFileInfo.containerFilePath }}
+                  name: {{ $containerPathKey }}
+                {{- $visit = "true" }}  
+                {{- end }}
+                {{- end }}
+                {{- end }}
+                {{- end }}
                 {{- if .Values.useTensorboard }}
                 {{- if .Values.isLocalLogging }}
                 - mountPath: {{ .Values.trainingLogdir }}
@@ -936,6 +999,14 @@ spec:
           {{- end }}
           {{- end }}
           volumes:
+            {{- if ne (len .Values.configFiles) 0 }}
+            {{- $releaseName := .Release.Name }}
+            {{- range $containerPathKey,$configFileInfos := .Values.configFiles }}
+            - name: {{ $containerPathKey }}
+              configMap:
+                name: {{ $releaseName }}-{{ $containerPathKey }}
+            {{- end }}
+            {{- end }}
             {{- if .Values.useTensorboard }}
             {{- if .Values.isLocalLogging }}
             - hostPath:
@@ -1069,6 +1140,19 @@ spec:
                   value: "{{ $value }}"
               {{- end }}
               volumeMounts:
+                {{- if ne (len .Values.configFiles) 0 }}
+                {{- $releaseName := .Release.Name }}
+                {{- range $containerPathKey,$configFileInfos := .Values.configFiles }}
+                {{- $visit := "false" }}
+                {{- range $cofigFileKey,$configFileInfo := $configFileInfos }}
+                {{- if eq  "false" $visit }}
+                - mountPath: {{ $configFileInfo.containerFilePath }}
+                  name: {{ $containerPathKey }}
+                {{- $visit = "true" }}  
+                {{- end }}
+                {{- end }}
+                {{- end }}
+                {{- end }}
                 {{- if .Values.syncMode }}
                 {{- if .Values.workingDir }}
                 - name: code-sync

--- a/cmd/arena/commands/submit.go
+++ b/cmd/arena/commands/submit.go
@@ -253,7 +253,7 @@ func (submitArgs *submitArgs) addJobConfigFiles() error {
 			HostFile:          hostFile,
 		}
 		// classify the files by container path
-		containerPathKey := util.GetMd5V2(path.Dir(containerFile))[0:15]
+		containerPathKey := util.Md5(path.Dir(containerFile))[0:15]
 		if _, ok := submitArgs.ConfigFiles[containerPathKey]; !ok {
 			submitArgs.ConfigFiles[containerPathKey] = map[string]configFileInfo{}
 		}

--- a/cmd/arena/commands/submit.go
+++ b/cmd/arena/commands/submit.go
@@ -261,7 +261,7 @@ func (submitArgs *submitArgs) addJobConfigFiles() error {
 	}
 	return nil
 }
-
+// add --set-file flag to 'helm template' 
 func (submitArgs *submitArgs) addHelmOptions() []string {
 	options := []string{}
 	for containerPathkey, val := range submitArgs.ConfigFiles {

--- a/cmd/arena/commands/submit_mpi.go
+++ b/cmd/arena/commands/submit_mpi.go
@@ -119,7 +119,9 @@ func (submitArgs *submitMPIJobArgs) prepare(args []string) (err error) {
 	if err != nil {
 		return err
 	}
-
+	if err := submitArgs.addConfigFiles(); err != nil {
+		return err
+	}
 	// process tensorboard
 	submitArgs.processTensorboard(submitArgs.DataSet)
 
@@ -128,7 +130,7 @@ func (submitArgs *submitMPIJobArgs) prepare(args []string) (err error) {
 	}
 	// add node labels,if given
 	submitArgs.addMPINodeSelectors()
-	// add tolerations, if given 
+	// add tolerations, if given
 	submitArgs.addMPITolerations()
 	submitArgs.addMPIInfoToEnv()
 
@@ -147,16 +149,25 @@ func (submitArgs submitMPIJobArgs) check() error {
 
 	return nil
 }
+
 // add k8s nodes labels
 func (submitArgs *submitMPIJobArgs) addMPINodeSelectors() {
 	submitArgs.addNodeSelectors()
 }
+
 // add k8s tolerations for taints
 func (submitArgs *submitMPIJobArgs) addMPITolerations() {
 	submitArgs.addTolerations()
 }
 func (submitArgs *submitMPIJobArgs) addMPIInfoToEnv() {
 	submitArgs.addJobInfoToEnv()
+}
+
+func (submitArgs *submitMPIJobArgs) addConfigFiles() error {
+	return submitArgs.addJobConfigFiles()
+}
+func (submitArgs *submitMPIJobArgs) addHelmTemplateOptions() []string {
+	return submitArgs.addHelmOptions()
 }
 
 // Submit MPIJob
@@ -179,7 +190,7 @@ func submitMPIJob(args []string, submitArgs *submitMPIJobArgs) (err error) {
 	// the master is also considered as a worker
 	// submitArgs.WorkerCount = submitArgs.WorkerCount - 1
 
-	err = workflow.SubmitJob(name, submitArgs.Mode, namespace, submitArgs, mpijob_chart)
+	err = workflow.SubmitJob(name, submitArgs.Mode, namespace, submitArgs, mpijob_chart, submitArgs.addHelmTemplateOptions()...)
 	if err != nil {
 		return err
 	}

--- a/cmd/arena/commands/submit_mpi.go
+++ b/cmd/arena/commands/submit_mpi.go
@@ -166,9 +166,6 @@ func (submitArgs *submitMPIJobArgs) addMPIInfoToEnv() {
 func (submitArgs *submitMPIJobArgs) addConfigFiles() error {
 	return submitArgs.addJobConfigFiles()
 }
-func (submitArgs *submitMPIJobArgs) addHelmTemplateOptions() []string {
-	return submitArgs.addHelmOptions()
-}
 
 // Submit MPIJob
 func submitMPIJob(args []string, submitArgs *submitMPIJobArgs) (err error) {
@@ -190,7 +187,7 @@ func submitMPIJob(args []string, submitArgs *submitMPIJobArgs) (err error) {
 	// the master is also considered as a worker
 	// submitArgs.WorkerCount = submitArgs.WorkerCount - 1
 
-	err = workflow.SubmitJob(name, submitArgs.Mode, namespace, submitArgs, mpijob_chart, submitArgs.addHelmTemplateOptions()...)
+	err = workflow.SubmitJob(name, submitArgs.Mode, namespace, submitArgs, mpijob_chart, submitArgs.addHelmOptions()...)
 	if err != nil {
 		return err
 	}

--- a/cmd/arena/commands/submit_tfjob.go
+++ b/cmd/arena/commands/submit_tfjob.go
@@ -380,10 +380,6 @@ func (submitArgs *submitTFJobArgs) addConfigFiles() error {
 	return submitArgs.addJobConfigFiles()
 }
 
-func (submitArgs *submitTFJobArgs) addHelmTemplateOptions() []string {
-	return submitArgs.addHelmOptions()
-}
-
 func (submitArgs *submitTFJobArgs) checkGangCapablitiesInCluster() {
 	gangCapablity := false
 	if clientset != nil {
@@ -418,7 +414,7 @@ func submitTFJob(args []string, submitArgs *submitTFJobArgs) (err error) {
 	// the master is also considered as a worker
 	// submitArgs.WorkerCount = submitArgs.WorkerCount - 1
 
-	err = workflow.SubmitJob(name, submitArgs.Mode, namespace, submitArgs, tfjob_chart, submitArgs.addHelmTemplateOptions()...)
+	err = workflow.SubmitJob(name, submitArgs.Mode, namespace, submitArgs, tfjob_chart, submitArgs.addHelmOptions()...)
 	if err != nil {
 		return err
 	}

--- a/cmd/arena/commands/submit_tfjob.go
+++ b/cmd/arena/commands/submit_tfjob.go
@@ -35,8 +35,8 @@ var (
 	// to receive values from command operation --ps-selector
 	psSelectors []string
 	// to receive values from command operation --chief-selector
-	chiefSelectors []string 
-	tfjob_chart = util.GetChartsFolder() + "/tfjob"
+	chiefSelectors []string
+	tfjob_chart    = util.GetChartsFolder() + "/tfjob"
 )
 
 func NewSubmitTFJobCommand() *cobra.Command {
@@ -118,7 +118,7 @@ func NewSubmitTFJobCommand() *cobra.Command {
 	command.Flags().StringVar(&submitArgs.PSMemory, "psMemory", "", "the memory resource to use for the parameter servers, like 1Gi.")
 	command.Flags().MarkDeprecated("psMemory", "please use --ps-memory instead")
 	command.Flags().StringVar(&submitArgs.PSMemory, "ps-memory", "", "the memory resource to use for the parameter servers, like 1Gi.")
-	command.Flags().StringArrayVarP(&psSelectors,"ps-selector","",[]string{},`assigning jobs with "PS" role to some k8s particular nodes(this option would cover --selector), usage: "--ps-selector=key=value"`)
+	command.Flags().StringArrayVarP(&psSelectors, "ps-selector", "", []string{}, `assigning jobs with "PS" role to some k8s particular nodes(this option would cover --selector), usage: "--ps-selector=key=value"`)
 	// How to clean up Task
 	command.Flags().StringVar(&submitArgs.CleanPodPolicy, "cleanTaskPolicy", "Running", "How to clean tasks after Training is done, only support Running, None.")
 	command.Flags().MarkDeprecated("cleanTaskPolicy", "please use --clean-task-policy instead")
@@ -154,38 +154,38 @@ func NewSubmitTFJobCommand() *cobra.Command {
 	command.Flags().IntVar(&submitArgs.ChiefPort, "chiefPort", 0, "the port of the chief.")
 	command.Flags().MarkDeprecated("chiefPort", "please use --chief-port instead")
 	command.Flags().IntVar(&submitArgs.ChiefPort, "chief-port", 0, "the port of the chief.")
-	command.Flags().StringArrayVarP(&workerSelectors,"worker-selector","",[]string{},`assigning jobs with "Worker" role to some k8s particular nodes(this option would cover --selector), usage: "--worker-selector=key=value"`)
-	command.Flags().StringArrayVarP(&chiefSelectors,"chief-selector","",[]string{},`assigning jobs with "Chief" role to some k8s particular nodes(this option would cover --selector), usage: "--chief-selector=key=value"`)
-	command.Flags().StringArrayVarP(&evaluatorSelectors,"evaluator-selector","",[]string{},`assigning jobs with "Evaluator" role to some k8s particular nodes(this option would cover --selector), usage: "--evaluator-selector=key=value"`)
+	command.Flags().StringArrayVarP(&workerSelectors, "worker-selector", "", []string{}, `assigning jobs with "Worker" role to some k8s particular nodes(this option would cover --selector), usage: "--worker-selector=key=value"`)
+	command.Flags().StringArrayVarP(&chiefSelectors, "chief-selector", "", []string{}, `assigning jobs with "Chief" role to some k8s particular nodes(this option would cover --selector), usage: "--chief-selector=key=value"`)
+	command.Flags().StringArrayVarP(&evaluatorSelectors, "evaluator-selector", "", []string{}, `assigning jobs with "Evaluator" role to some k8s particular nodes(this option would cover --selector), usage: "--evaluator-selector=key=value"`)
 
 	// command.Flags().BoolVarP(&showDetails, "details", "d", false, "Display details")
 	return command
 }
 
 type submitTFJobArgs struct {
-	TFNodeSelectors  map[string]map[string]string `yaml:"tfNodeSelectors"`
-	Port           int    // --port, it's used set workerPort and PSPort if they are not set
-	WorkerImage    string `yaml:"workerImage"`    // --workerImage
-	WorkerPort     int    `yaml:"workerPort"`     // --workerPort
-	PSPort         int    `yaml:"psPort"`         // --psPort
-	//PSNodeSelectors map[string]string `yaml:"psNodeSelectors"` // --ps-selector 
-	PSCount        int    `yaml:"ps"`             // --ps
-	PSImage        string `yaml:"psImage"`        // --psImage
-	WorkerCpu      string `yaml:"workerCPU"`      // --workerCpu
+	TFNodeSelectors map[string]map[string]string `yaml:"tfNodeSelectors"`
+	Port            int                          // --port, it's used set workerPort and PSPort if they are not set
+	WorkerImage     string                       `yaml:"workerImage"` // --workerImage
+	WorkerPort      int                          `yaml:"workerPort"`  // --workerPort
+	PSPort          int                          `yaml:"psPort"`      // --psPort
+	//PSNodeSelectors map[string]string `yaml:"psNodeSelectors"` // --ps-selector
+	PSCount   int    `yaml:"ps"`        // --ps
+	PSImage   string `yaml:"psImage"`   // --psImage
+	WorkerCpu string `yaml:"workerCPU"` // --workerCpu
 	//WorkerNodeSelectors map[string]string `yaml:"workerNodeSelectors"` // --worker-selector
 	WorkerMemory   string `yaml:"workerMemory"`   // --workerMemory
 	PSCpu          string `yaml:"psCPU"`          // --psCpu
 	PSMemory       string `yaml:"psMemory"`       // --psMemory
 	CleanPodPolicy string `yaml:"cleanPodPolicy"` // --cleanTaskPolicy
 	// For esitmator, it reuses workerImage
-	UseChief        bool   `yaml:",omitempty"` // --chief
-	ChiefCount      int    `yaml:"chief"`
-	UseEvaluator    bool   `yaml:",omitempty"`      // --evaluator
-	ChiefPort       int    `yaml:"chiefPort"`       // --chiefPort
+	UseChief     bool `yaml:",omitempty"` // --chief
+	ChiefCount   int  `yaml:"chief"`
+	UseEvaluator bool `yaml:",omitempty"` // --evaluator
+	ChiefPort    int  `yaml:"chiefPort"`  // --chiefPort
 	//ChiefNodeSelectors map[string]string `yaml:"chiefNodeSelectors"` // --chief-selector
-	ChiefCpu        string `yaml:"chiefCPU"`        // --chiefCpu
-	ChiefMemory     string `yaml:"chiefMemory"`     // --chiefMemory
-	EvaluatorCpu    string `yaml:"evaluatorCPU"`    // --evaluatorCpu
+	ChiefCpu     string `yaml:"chiefCPU"`     // --chiefCpu
+	ChiefMemory  string `yaml:"chiefMemory"`  // --chiefMemory
+	EvaluatorCpu string `yaml:"evaluatorCPU"` // --evaluatorCpu
 	//EvaluatorNodeSelectors map[string]string `yaml:"evaluatorNodeSelectors"` // --evaluator-selector
 	EvaluatorMemory string `yaml:"evaluatorMemory"` // --evaluatorMemory
 	EvaluatorCount  int    `yaml:"evaluator"`
@@ -226,7 +226,9 @@ func (submitArgs *submitTFJobArgs) prepare(args []string) (err error) {
 	if err != nil {
 		return nil
 	}
-
+	if err := submitArgs.addConfigFiles(); err != nil {
+		return err
+	}
 	// process tensorboard
 	submitArgs.processTensorboard(submitArgs.DataSet)
 
@@ -327,44 +329,43 @@ func (submitArgs *submitTFJobArgs) transform() error {
 	return nil
 }
 
-// add node selectors 
+// add node selectors
 func (submitArgs *submitTFJobArgs) addTFNodeSelectors() {
 	submitArgs.addNodeSelectors()
 	submitArgs.TFNodeSelectors = make(map[string]map[string]string)
-	for _,role := range []string{"PS","Worker","Evaluator","Chief"} {
+	for _, role := range []string{"PS", "Worker", "Evaluator", "Chief"} {
 		switch role {
 		case "PS":
-			log.Debugf("psSelectors: %v",psSelectors)
-			submitArgs.transformSelectorArrayToMap(psSelectors,"PS")
+			log.Debugf("psSelectors: %v", psSelectors)
+			submitArgs.transformSelectorArrayToMap(psSelectors, "PS")
 			break
 		case "Worker":
-			log.Debugf("workerSelectors: %v",workerSelectors)
-			submitArgs.transformSelectorArrayToMap(workerSelectors,"Worker")
+			log.Debugf("workerSelectors: %v", workerSelectors)
+			submitArgs.transformSelectorArrayToMap(workerSelectors, "Worker")
 			break
 		case "Chief":
-			log.Debugf("chiefSelectors: %v",chiefSelectors)
-			submitArgs.transformSelectorArrayToMap(chiefSelectors,"Chief")
+			log.Debugf("chiefSelectors: %v", chiefSelectors)
+			submitArgs.transformSelectorArrayToMap(chiefSelectors, "Chief")
 			break
 		case "Evaluator":
-			log.Debugf("evaluatorSelectors: %v",evaluatorSelectors)
-			submitArgs.transformSelectorArrayToMap(evaluatorSelectors,"Evaluator")
+			log.Debugf("evaluatorSelectors: %v", evaluatorSelectors)
+			submitArgs.transformSelectorArrayToMap(evaluatorSelectors, "Evaluator")
 			break
 		}
 
 	}
 }
 
-func(submitArgs *submitTFJobArgs) transformSelectorArrayToMap(selectorArray []string,role string) {
+func (submitArgs *submitTFJobArgs) transformSelectorArrayToMap(selectorArray []string, role string) {
 	if len(selectorArray) != 0 {
-		submitArgs.TFNodeSelectors[role] =transformSliceToMap(selectorArray,"=") 
-		return 
+		submitArgs.TFNodeSelectors[role] = transformSliceToMap(selectorArray, "=")
+		return
 	}
 	if len(submitArgs.NodeSelectors) == 0 {
 		submitArgs.TFNodeSelectors[role] = map[string]string{}
-		return 
+		return
 	}
 	submitArgs.TFNodeSelectors[role] = submitArgs.NodeSelectors
-
 
 }
 
@@ -374,6 +375,13 @@ func (submitArgs *submitTFJobArgs) addTFTolerations() {
 }
 func (submitArgs *submitTFJobArgs) addTFJobInfoToEnv() {
 	submitArgs.addJobInfoToEnv()
+}
+func (submitArgs *submitTFJobArgs) addConfigFiles() error {
+	return submitArgs.addJobConfigFiles()
+}
+
+func (submitArgs *submitTFJobArgs) addHelmTemplateOptions() []string {
+	return submitArgs.addHelmOptions()
 }
 
 func (submitArgs *submitTFJobArgs) checkGangCapablitiesInCluster() {
@@ -410,7 +418,7 @@ func submitTFJob(args []string, submitArgs *submitTFJobArgs) (err error) {
 	// the master is also considered as a worker
 	// submitArgs.WorkerCount = submitArgs.WorkerCount - 1
 
-	err = workflow.SubmitJob(name, submitArgs.Mode, namespace, submitArgs, tfjob_chart)
+	err = workflow.SubmitJob(name, submitArgs.Mode, namespace, submitArgs, tfjob_chart, submitArgs.addHelmTemplateOptions()...)
 	if err != nil {
 		return err
 	}

--- a/docs/userguide/16-assign-config-file.md
+++ b/docs/userguide/16-assign-config-file.md
@@ -1,0 +1,77 @@
+# Assign configuration files for jobs
+
+you can pass the configuration files to containers when submiting jobs.
+
+this feature only support follow jobs:
+
+* tfjob
+* mpijob
+
+and requirements are:
+
+* helm version >= 2.14.1 and not support helm v3
+  
+## 1.usage
+
+you can use `--config-file <host_path_file>:<container_path_file>` to assign a configuration file to container.and there is some rules:
+
+* if assignd <host_path_file> and not assign <container_path_file>,we see <container_path_file> is the same as <host_path_file>
+* <container_path_file> must be a file with absolute path
+*  you can use `--config-file` more than one in a command,eg: "--config-file /tmp/test1.conf:/etc/config/test1.conf --config-file /tmp/test2.conf:/etc/config/test2.conf"
+
+
+## 2.sample
+
+
+firstly,we create a test file which name is "test-config.json",its' path is "/tmp/test-config.json". we want push this file to containers of a tfjob (or mpijob) and the path in container is "/etc/config/config.json". 
+```
+# cat /tmp/test-config.json
+{
+    "key": "job-config"
+
+}
+```
+secondly,use follow command to create tfjob:
+```
+# arena submit tfjob \
+    --name=tf \
+    --gpus=1              \
+    --workers=1              \
+    --workerImage=cheyang/tf-mnist-distributed:gpu \
+    --psImage=cheyang/tf-mnist-distributed:cpu \
+    --ps=1              \
+    --tensorboard \
+    --config-file /tmp/test-config.json:/etc/config/config.json \
+      "python /app/main.py"
+```
+wait a minute,get the job status:
+```
+# arena get tf
+STATUS: RUNNING
+NAMESPACE: default
+PRIORITY: N/A
+TRAINING DURATION: 16s
+
+NAME  STATUS   TRAINER  AGE  INSTANCE     NODE
+tf    RUNNING  TFJOB    16s  tf-ps-0      192.168.7.18
+tf    RUNNING  TFJOB    16s  tf-worker-0  192.168.7.16
+
+Your tensorboard will be available on:
+http://192.168.7.10:31825
+```
+use kubectl to check file is in container or not:
+```
+# kubectl exec -ti tf-ps-0 -- cat /etc/config/config.json
+{
+    "key": "job-config"
+
+}
+# kubectl exec -ti tf-worker-0 -- cat /etc/config/config.json
+{
+    "key": "job-config"
+
+}
+
+```
+
+as you see,the file is in the containers.

--- a/docs/userguide/16-assign-config-file.md
+++ b/docs/userguide/16-assign-config-file.md
@@ -7,10 +7,6 @@ this feature only support follow jobs:
 * tfjob
 * mpijob
 
-and requirements are:
-
-* helm version >= 2.14.1 and not support helm v3
-  
 ## 1.usage
 
 you can use `--config-file <host_path_file>:<container_path_file>` to assign a configuration file to container.and there is some rules:

--- a/docs/userguide_cn/16-assign-config-file.md
+++ b/docs/userguide_cn/16-assign-config-file.md
@@ -1,0 +1,78 @@
+#  为训练任务提供配置文件
+
+在提交训练任务时，我们可以指定该训练任务所需的配置文件。
+
+目前，该功能只支持如下两种任务:
+
+* tfjob
+* mpijob
+
+需要满足如下条件:
+
+* helm version >= 2.14.1
+* 不支持helm v3
+  
+## 1.用法
+
+当提交训练任务时，通过 `--config-file <host_path_file>:<container_path_file>` 为训练任务指定配置文件，该选项有一些规则：
+
+* 如果指定了 <host_path_file> 并且没有指定 <container_path_file>，我们认为 <container_path_file> 的值与 <host_path_file>相同
+* <container_path_file> 必须是一个文件，并且是绝对路径
+*  在一个提交命令中，可以多次指定 `--config-file` ，例如: "--config-file /tmp/test1.conf:/etc/config/test1.conf --config-file /tmp/test2.conf:/etc/config/test2.conf"
+
+
+## 2.例子
+
+
+首先，我们创建一个名为"test-config.json"的文件,它的路径为"/tmp/test-config.json"。我们希望把这个文件放到训练任务的实例中，并存放路径为"/etc/config/config.json"。这个文件内容如下：
+```
+# cat /tmp/test-config.json
+{
+    "key": "job-config"
+
+}
+```
+接着，使用如下命令提交一个tfjob:
+```
+# arena submit tfjob \
+    --name=tf \
+    --gpus=1              \
+    --workers=1              \
+    --workerImage=cheyang/tf-mnist-distributed:gpu \
+    --psImage=cheyang/tf-mnist-distributed:cpu \
+    --ps=1              \
+    --tensorboard \
+    --config-file /tmp/test-config.json:/etc/config/config.json \
+      "python /app/main.py"
+```
+等一段时间,查看任务状态:
+```
+# arena get tf
+STATUS: RUNNING
+NAMESPACE: default
+PRIORITY: N/A
+TRAINING DURATION: 16s
+
+NAME  STATUS   TRAINER  AGE  INSTANCE     NODE
+tf    RUNNING  TFJOB    16s  tf-ps-0      192.168.7.18
+tf    RUNNING  TFJOB    16s  tf-worker-0  192.168.7.16
+
+Your tensorboard will be available on:
+http://192.168.7.10:31825
+```
+使用kubectl检测文件是否已经存放在了任务的实例中:
+```
+# kubectl exec -ti tf-ps-0 -- cat /etc/config/config.json
+{
+    "key": "job-config"
+
+}
+# kubectl exec -ti tf-worker-0 -- cat /etc/config/config.json
+{
+    "key": "job-config"
+
+}
+
+```
+
+可以看到，文件已经在实例中存在了。

--- a/docs/userguide_cn/16-assign-config-file.md
+++ b/docs/userguide_cn/16-assign-config-file.md
@@ -7,11 +7,6 @@
 * tfjob
 * mpijob
 
-需要满足如下条件:
-
-* helm version >= 2.14.1
-* 不支持helm v3
-  
 ## 1.用法
 
 当提交训练任务时，通过 `--config-file <host_path_file>:<container_path_file>` 为训练任务指定配置文件，该选项有一些规则：

--- a/install.sh
+++ b/install.sh
@@ -95,9 +95,9 @@ if [ -f "/usr/local/bin/arena" ]; then
 fi
 cp $SCRIPT_DIR/bin/arena /usr/local/bin/arena
 
-if ! which helm; then
-	cp $SCRIPT_DIR/bin/helm /usr/local/bin/helm
-fi
+rm -rf /usr/local/bin/arena-helm
+
+cp $SCRIPT_DIR/bin/helm /usr/local/bin/arena-helm
 
 if [ -d "/charts" ]; then
     mv /charts /charts-$now

--- a/pkg/util/base.go
+++ b/pkg/util/base.go
@@ -1,6 +1,8 @@
 package util
 
 import (
+	"fmt"
+	"crypto/md5"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 	"os"
@@ -27,4 +29,11 @@ func GetClientSetForTest(t *testing.T) *kubernetes.Clientset {
 		t.Errorf("failed to NewForConfig, %++v", err)
 	}
 	return clientset
+}
+
+func GetMd5V2(str string) string {
+    data := []byte(str)
+    has := md5.Sum(data)
+    md5str := fmt.Sprintf("%x", has)
+    return md5str
 }

--- a/pkg/util/base.go
+++ b/pkg/util/base.go
@@ -1,12 +1,13 @@
 package util
 
 import (
-	"fmt"
 	"crypto/md5"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/clientcmd"
+	"fmt"
 	"os"
 	"testing"
+
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 func GetClientSetForTest(t *testing.T) *kubernetes.Clientset {
@@ -31,9 +32,9 @@ func GetClientSetForTest(t *testing.T) *kubernetes.Clientset {
 	return clientset
 }
 
-func GetMd5V2(str string) string {
-    data := []byte(str)
-    has := md5.Sum(data)
-    md5str := fmt.Sprintf("%x", has)
-    return md5str
+func Md5(str string) string {
+	data := []byte(str)
+	has := md5.Sum(data)
+	md5str := fmt.Sprintf("%x", has)
+	return md5str
 }

--- a/pkg/util/helm/helm.go
+++ b/pkg/util/helm/helm.go
@@ -27,7 +27,7 @@ import (
 	yaml "gopkg.in/yaml.v2"
 )
 
-var helmCmd = []string{"helm"}
+var helmCmd = []string{"arena-helm"}
 
 /**
 * install the release with cmd: helm install -f values.yaml chart_name

--- a/pkg/util/helm/helm_advanced.go
+++ b/pkg/util/helm/helm_advanced.go
@@ -49,7 +49,7 @@ func GenerateValueFile(values interface{}) (valueFileName string, err error) {
 * Exec /usr/local/bin/helm, [template -f /tmp/values313606961 --namespace default --name hj /charts/tf-horovod]
 * returns generated template file: templateFileName
  */
-func GenerateHelmTemplate(name string, namespace string, valueFileName string, chartName string) (templateFileName string, err error) {
+func GenerateHelmTemplate(name string, namespace string, valueFileName string, chartName string, options ...string) (templateFileName string, err error) {
 	tempName := fmt.Sprintf("%s.yaml", name)
 	templateFile, err := ioutil.TempFile("", tempName)
 	if err != nil {
@@ -72,7 +72,13 @@ func GenerateHelmTemplate(name string, namespace string, valueFileName string, c
 	// 4. prepare the arguments
 	args := []string{binary, "template", "-f", valueFileName,
 		"--namespace", namespace,
-		"--name", name, chartName, ">", templateFileName}
+		"--name", name,
+	}
+	if len(options) != 0 {
+		args = append(args, options...)
+	}
+
+	args = append(args, []string{chartName, ">", templateFileName}...)
 
 	log.Debugf("Exec bash -c %v", args)
 

--- a/pkg/util/kubectl/kubectl.go
+++ b/pkg/util/kubectl/kubectl.go
@@ -27,6 +27,19 @@ import (
 
 var kubectlCmd = []string{"kubectl"}
 
+func CreateNamespace(namespace string) ([]byte, error) {
+	args := []string{"get", "ns", namespace}
+	out, err := kubectl(args)
+	if err == nil {
+		return []byte(""), nil
+	}
+	if strings.Contains(string(out), "(NotFound)") {
+		args = []string{"create", "ns", namespace}
+		return kubectl(args)
+	}
+	return out, err
+}
+
 /**
 * dry-run creating kubernetes App Info for delete in future
 * Exec /usr/local/bin/kubectl, [create --dry-run -f /tmp/values313606961 --namespace default]

--- a/pkg/util/kubectl/kubectl.go
+++ b/pkg/util/kubectl/kubectl.go
@@ -27,19 +27,6 @@ import (
 
 var kubectlCmd = []string{"kubectl"}
 
-func CreateNamespace(namespace string) ([]byte, error) {
-	args := []string{"get", "ns", namespace}
-	out, err := kubectl(args)
-	if err == nil {
-		return []byte(""), nil
-	}
-	if strings.Contains(string(out), "(NotFound)") {
-		args = []string{"create", "ns", namespace}
-		return kubectl(args)
-	}
-	return out, err
-}
-
 /**
 * dry-run creating kubernetes App Info for delete in future
 * Exec /usr/local/bin/kubectl, [create --dry-run -f /tmp/values313606961 --namespace default]

--- a/pkg/workflow/workflow.go
+++ b/pkg/workflow/workflow.go
@@ -42,7 +42,7 @@ func DeleteJob(name, namespace, trainingType string) error {
 *	Submit training job
 **/
 
-func SubmitJob(name string, trainingType string, namespace string, values interface{}, chart string) error {
+func SubmitJob(name string, trainingType string, namespace string, values interface{}, chart string, options ...string) error {
 	found := kubectl.CheckAppConfigMap(fmt.Sprintf("%s-%s", name, trainingType), namespace)
 	if found {
 		return fmt.Errorf("the job %s is already exist, please delete it first. use 'arena delete %s'", name, name)
@@ -55,7 +55,7 @@ func SubmitJob(name string, trainingType string, namespace string, values interf
 	}
 
 	// 2. Generate Template file
-	template, err := helm.GenerateHelmTemplate(name, namespace, valueFileName, chart)
+	template, err := helm.GenerateHelmTemplate(name, namespace, valueFileName, chart, options...)
 	if err != nil {
 		return err
 	}
@@ -72,7 +72,10 @@ func SubmitJob(name string, trainingType string, namespace string, values interf
 	if err != nil {
 		return err
 	}
-
+	// if namespace is not exist,so we should create it
+	if _, err := kubectl.CreateNamespace(namespace); err != nil {
+		return err
+	}
 	err = kubectl.CreateAppConfigmap(name,
 		trainingType,
 		namespace,

--- a/pkg/workflow/workflow.go
+++ b/pkg/workflow/workflow.go
@@ -72,10 +72,6 @@ func SubmitJob(name string, trainingType string, namespace string, values interf
 	if err != nil {
 		return err
 	}
-	// if namespace is not exist,so we should create it
-	if _, err := kubectl.CreateNamespace(namespace); err != nil {
-		return err
-	}
 	err = kubectl.CreateAppConfigmap(name,
 		trainingType,
 		namespace,


### PR DESCRIPTION
1.support assigning configuration files when submitting jobs
2.current, only support tfjob and mpijob
3.sample
command:
```
#!/bin/bash
arena submit tfjob \
      --name=tf \
      --gpus=1              \
      --workers=1              \
      --workerImage=cheyang/tf-mnist-distributed:gpu \
      --psImage=cheyang/tf-mnist-distributed:cpu \
      --ps=1              \
      --tensorboard \
      --config-file /tmp/test.json:/etc/config/config.json \
      "sleep 5000"
```
then get configmap:
```
# kubectl get configmap
NAME                 DATA   AGE
tf-a9cbad1b8719778   1      6m8s
tf-tfjob             3      6m9s
```
get the configmap information:
```
# kubectl get configmap tf-a9cbad1b8719778 -o yaml
apiVersion: v1
data:
  config.json: "{\n\t\"key\": \"key1\",\n\t\"value\": \"value1\"\n}"
kind: ConfigMap
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"v1","data":{"config.json":"{\n\t\"key\": \"key1\",\n\t\"value\": \"value1\"\n}"},"kind":"ConfigMap","metadata":{"annotations":{},"labels":{"app":"tfjob","chart":"tfjob-0.24.0","createdBy":"TFJob","heritage":"Tiller","release":"tf"},"name":"tf-a9cbad1b8719778","namespace":"default"}}
  creationTimestamp: "2019-12-27T14:15:04Z"
  labels:
    app: tfjob
    chart: tfjob-0.24.0
    createdBy: TFJob
    heritage: Tiller
    release: tf
  name: tf-a9cbad1b8719778
  namespace: default
  resourceVersion: "1013491"
  selfLink: /api/v1/namespaces/default/configmaps/tf-a9cbad1b8719778
  uid: 46fb91ba-28b3-11ea-aeef-00163e035331
```
display in pod spec:
```
......
  volumes:
  - configMap:
      defaultMode: 420
      name: tf-a9cbad1b8719778
    name: a9cbad1b8719778
......
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/arena/285)
<!-- Reviewable:end -->
