### PR TITLE
fix bug: set exit code as 2 when delete job failed

### DIFF
--- a/cmd/arena/commands/delete.go
+++ b/cmd/arena/commands/delete.go
@@ -54,13 +54,15 @@ func NewDeleteCommand() *cobra.Command {
 				fmt.Println(err)
 				os.Exit(1)
 			}
-
+			exitCode := 0
 			for _, jobName := range args {
 				err = deleteTrainingJob(jobName, trainingType)
 				if err != nil {
 					log.Errorf("Failed to delete %s, the reason is that %v\n", jobName, err)
+					exitCode = 2
 				}
 			}
+			os.Exit(exitCode)
 		},
 	}
 	command.Flags().StringVar(&trainingType, "type", "", "The training type to delete, the possible option is tfjob, mpijob, sparkjob,volcanojob,horovodjob or standalonejob. (optional)")

--- a/cmd/arena/commands/serve_delete.go
+++ b/cmd/arena/commands/serve_delete.go
@@ -56,15 +56,15 @@ func NewServingDeleteCommand() *cobra.Command {
 				fmt.Println(err)
 				os.Exit(1)
 			}
-
+			exitCode := 0
 			for _, jobName := range args {
 				err = deleteServingJob(client, jobName)
 				if err != nil {
 					log.Debugf("Failed due to %v", err)
-					fmt.Println(err)
-					os.Exit(1)
+					exitCode = 2
 				}
 			}
+			os.Exit(exitCode)
 		},
 	}
 	command.Flags().StringVar(&servingVersion, "version", "", "The serving version to delete.")


### PR DESCRIPTION
bug: exit code is 0 when deleting job failed,this is an error for arena-java-sdk

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/arena/295)
<!-- Reviewable:end -->
