### PR TITLE
fix: change debugf to errorf when print error message

### DIFF
--- a/cmd/arena/commands/serve_delete.go
+++ b/cmd/arena/commands/serve_delete.go
@@ -60,7 +60,7 @@ func NewServingDeleteCommand() *cobra.Command {
 			for _, jobName := range args {
 				err = deleteServingJob(client, jobName)
 				if err != nil {
-					log.Debugf("Failed due to %v", err)
+					log.Errorf("Failed due to %v", err)
 					exitCode = 2
 				}
 			}


### PR DESCRIPTION
bug: exit code is 0 when deleting job failed,this is an error for arena-java-sdk

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/arena/296)
<!-- Reviewable:end -->
