### PR TITLE
add default value for protocol in trainingJob CR

### DIFF
--- a/kubernetes-artifacts/et-operator/et-operator.yaml
+++ b/kubernetes-artifacts/et-operator/et-operator.yaml
@@ -1824,6 +1824,7 @@ spec:
                                                 can be referred to by services.
                                               type: string
                                             protocol:
+                                              default: TCP
                                               description: Protocol for port. Must be
                                                 UDP, TCP, or SCTP. Defaults to "TCP".
                                               type: string
@@ -3127,6 +3128,7 @@ spec:
                                                 can be referred to by services.
                                               type: string
                                             protocol:
+                                              default: TCP
                                               description: Protocol for port. Must be
                                                 UDP, TCP, or SCTP. Defaults to "TCP".
                                               type: string
@@ -4438,6 +4440,7 @@ spec:
                                                 can be referred to by services.
                                               type: string
                                             protocol:
+                                              default: TCP
                                               description: Protocol for port. Must be
                                                 UDP, TCP, or SCTP. Defaults to "TCP".
                                               type: string
@@ -8365,6 +8368,7 @@ spec:
                                                 can be referred to by services.
                                               type: string
                                             protocol:
+                                              default: TCP
                                               description: Protocol for port. Must be
                                                 UDP, TCP, or SCTP. Defaults to "TCP".
                                               type: string
@@ -9668,6 +9672,7 @@ spec:
                                                 can be referred to by services.
                                               type: string
                                             protocol:
+                                              default: TCP
                                               description: Protocol for port. Must be
                                                 UDP, TCP, or SCTP. Defaults to "TCP".
                                               type: string
@@ -10979,6 +10984,7 @@ spec:
                                                 can be referred to by services.
                                               type: string
                                             protocol:
+                                              default: TCP
                                               description: Protocol for port. Must be
                                                 UDP, TCP, or SCTP. Defaults to "TCP".
                                               type: string


### PR DESCRIPTION
Fix et-operator install failed in 1.18 kubernetes cluster.
Compile et-operator crd with new version of kubebuilder.

Relation issues:
https://github.com/kubernetes-sigs/controller-tools/issues/444