### PR TITLE
fix bug: error in getting all node gpu metrics

### DIFF
--- a/pkg/topnode/define.go
+++ b/pkg/topnode/define.go
@@ -297,7 +297,7 @@ func GetNodeGpuMetrics(client *kubernetes.Clientset) (map[string]types.NodeGpuMe
 	if server == nil {
 		return nodeGPUMetrics, nil
 	}
-	return prometheus.GetNodeGPUMetrics(client, server, []string{})
+	return prometheus.GetNodeGPUMetrics(client, server, []string{".*"})
 }
 
 func getGPUMetricsByNodeName(nodeName string, metrics map[string]types.NodeGpuMetric) types.NodeGpuMetric {

--- a/pkg/topnode/gpushare.go
+++ b/pkg/topnode/gpushare.go
@@ -160,6 +160,9 @@ func (g *gpushare) getUnhealthyGPUs() int {
 	if totalGPUs <= 0 {
 		return 0
 	}
+	if totalGPUMemory.Value() <= 0 {
+		return totalGPUs
+	}
 	unhealthyGPUMemory := totalGPUMemory.Value() - allocatableGPUMemory.Value()
 	return int(int64(totalGPUs) * unhealthyGPUMemory / totalGPUMemory.Value())
 }


### PR DESCRIPTION
fix bug: divide 0 in 'top node' when total gpu memory is 0