### PR TITLE
remove initializers args in spark-operator.yaml 

### DIFF
--- a/kubernetes-artifacts/spark-operator/spark-operator.yaml
+++ b/kubernetes-artifacts/spark-operator/spark-operator.yaml
@@ -74,8 +74,6 @@ spec:
       labels:
         app.kubernetes.io/name: sparkoperator
         app.kubernetes.io/version: v2.4.0-v1beta1-0.8.1
-      initializers:
-        pending: []
     spec:
       serviceAccountName: sparkoperator
       containers:


### PR DESCRIPTION
remove initializers args in spark-operator.yaml for adapted to common k8s cluster