### PR TITLE
arena top job show wrong gpu request when enable chief or evaluator

### DIFF
--- a/pkg/argsbuilder/submit_tfjob.go
+++ b/pkg/argsbuilder/submit_tfjob.go
@@ -354,8 +354,8 @@ func (s *SubmitTFJobArgsBuilder) transformSelectorArrayToMap(selectorArray *[]st
 
 func (s *SubmitTFJobArgsBuilder) addRequestGPUsToAnnotation() error {
 	gpus := 0
-	gpus += s.args.ChiefCount
-	gpus += s.args.EvaluatorCount
+	gpus += s.args.ChiefCount * s.args.GPUCount
+	gpus += s.args.EvaluatorCount * s.args.GPUCount
 	gpus += s.args.WorkerCount * s.args.GPUCount
 	if s.args.Annotations == nil {
 		s.args.Annotations = map[string]string{}


### PR DESCRIPTION
REPRODUCE MEHOD:
1. submit a job with gpus=0
```
arena submit tf --loglevel=debug --name=tf-dist-gpu-count \
    --namespace=demo-ns \
    --working-dir=/root/ \
    --data fashion-demo-pvc:/data \
    --chief \
    --chief-cpu=1 \
    --chief-memory=16Gi \
    --evaluator \
    --evaluator-cpu=1 \
    --evaluator-memory=10Gi \
    --env=TEST_TMPDIR=/ \
    --env=GIT_SYNC_USERNAME=** \
    --env=GIT_SYNC_PASSWORD=** \
    --env=GIT_SYNC_BRANCH=master \
    --gpus=0 \
    --workers=1 \
    --worker-image=${TF_IMAGE} \
    --sync-mode=git \
    --sync-source=https://codeup.aliyun.com/60b4cf5c66bba1c04b442e49/tensorflow-fashion-mnist-sample.git \
    --ps=1 \
    --ps-image=${TF_IMAGE} \
    --tensorboard \
    "python code/tensorflow-fashion-mnist-sample/fashion_mnist_tf_estimator.py --output_dir=/root/fashion_dnn"
```
2. arena top job

```
arena top job -n demo-ns
NAME               STATUS  TRAINER  AGE  GPU(Requested)  GPU(Allocated)  NODE
tf-dist-gpu-count  FAILED  TFJOB    23s  2               0               N/A
```