### PR TITLE
modify restful-serving to http-serving of serve deployment service port name

### DIFF
--- a/charts/custom-serving/Chart.yaml
+++ b/charts/custom-serving/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for custom-serving
 name: custom-serving
-version: 0.9.0
+version: 0.10.0

--- a/charts/custom-serving/templates/service.yaml
+++ b/charts/custom-serving/templates/service.yaml
@@ -28,7 +28,7 @@ spec:
       targetPort: {{ .Values.restApiPort }}
     {{- end }}
     {{- if ne (int .Values.metricsPort) 0 }}
-    - name: metrics
+    - name: http-metrics
       port: {{ .Values.metricsPort }}
       targetPort: {{ .Values.metricsPort }}
     {{- end }}

--- a/charts/custom-serving/templates/service.yaml
+++ b/charts/custom-serving/templates/service.yaml
@@ -13,7 +13,7 @@ metadata:
     servingType: "custom-serving"
   {{- range $key, $value := .Values.labels }}
     {{ $key }}: {{ $value | quote }}
-  {{- end }} 
+  {{- end }}
 spec:
   type: {{ .Values.serviceType }}
   ports:
@@ -23,7 +23,7 @@ spec:
       targetPort: {{ .Values.port }}
     {{- end }}
     {{- if ne (int .Values.restApiPort) 0 }}
-    - name: restful-serving
+    - name: http-serving
       port: {{ .Values.restApiPort }}
       targetPort: {{ .Values.restApiPort }}
     {{- end }}

--- a/charts/tfserving/Chart.yaml
+++ b/charts/tfserving/Chart.yaml
@@ -1,6 +1,6 @@
 name: tensorflow-serving
 home: https://github.com/kubernetes/charts
-version: 0.9.0
+version: 0.10.0
 appVersion: 1.8
 description: TensorFlow Serving is an open-source software library for serving machine learning models.
 sources:

--- a/charts/tfserving/templates/service.yaml
+++ b/charts/tfserving/templates/service.yaml
@@ -24,7 +24,7 @@ spec:
     - name: grpc-serving
       port: {{ .Values.port }}
       targetPort: {{ .Values.port }}
-    - name: restful-serving
+    - name: http-serving
       port: {{ .Values.restApiPort }}
       targetPort: {{ .Values.restApiPort }}
   selector:

--- a/charts/triton/Chart.yaml
+++ b/charts/triton/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: Triton Inference Server Helm Chart
 name: tritoninferenceserver
-version: 0.8.0
+version: 0.9.0

--- a/charts/triton/templates/service.yaml
+++ b/charts/triton/templates/service.yaml
@@ -16,14 +16,14 @@ metadata:
 spec:
   type: {{ .Values.serviceType }}
   ports:
-    - name: restful-serving
+    - name: http-serving
       port: {{ .Values.httpPort }}
       targetPort: {{ .Values.httpPort }}
     - name: grpc-serving
       port: {{ .Values.grpcPort }}
       targetPort: {{ .Values.grpcPort }}
     {{- if .Values.allowMetrics }}
-    - name: metrics
+    - name: http-metrics
       port: {{ .Values.metricsPort }}
       targetPort: {{ .Values.metricsPort }}
     {{- end }}

--- a/charts/trtserving/Chart.yaml
+++ b/charts/trtserving/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for NVIDIA TensorRT Inference Server
 name: tensorrt-serving
-version: 0.2.0
+version: 0.3.0

--- a/charts/trtserving/templates/service.yaml
+++ b/charts/trtserving/templates/service.yaml
@@ -13,7 +13,7 @@ metadata:
 spec:
   type: {{ .Values.serviceType }}
   ports:
-    - name: restful-serving
+    - name: http-serving
       port: {{ .Values.httpPort }}
       targetPort: {{ .Values.httpPort }}
     - name: grpc-serving

--- a/pkg/serving/serving.go
+++ b/pkg/serving/serving.go
@@ -30,7 +30,7 @@ const (
 	servingVersionLabelKey    = "servingVersion"
 	istioNamespace            = "istio-system"
 	grpcServingPortName       = "grpc-serving"
-	restfulServingPortName    = "restful-serving"
+	restfulServingPortName    = "http-serving"
 	istioGatewayHTTPPortName  = "http2"
 	istioGatewayHTTPsPortName = "https"
 )


### PR DESCRIPTION
Since Istio require the prefix of  service port name must be protocol, e.g. http-serving, we change arena serve deployment service port name to support this.