### PR TITLE
add empty-dir and empty-dir-subpath-expr arg 

### DIFF
--- a/charts/custom-serving/Chart.yaml
+++ b/charts/custom-serving/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for custom-serving
 name: custom-serving
-version: 0.10.0
+version: 0.11.0

--- a/charts/custom-serving/templates/deployment.yaml
+++ b/charts/custom-serving/templates/deployment.yaml
@@ -151,6 +151,15 @@ spec:
               {{- end }}
             {{- end }}
             {{- end }}
+            {{- if .Values.emptyDirs }}
+            {{- range $name, $destPath := .Values.emptyDirs}}
+            - name: "{{ $name }}"
+              mountPath: "{{ $destPath }}"
+              {{- if hasKey $.Values.emptyDirSubPathExprs $name }}
+              subPathExpr: {{ get $.Values.emptyDirSubPathExprs $name }}
+              {{- end }}
+            {{- end }}
+            {{- end }}
             {{- if ne (len .Values.configFiles) 0 }}
             {{- $releaseName := .Release.Name }}
             {{- range $containerPathKey,$configFileInfos := .Values.configFiles }}
@@ -170,6 +179,12 @@ spec:
         - name: "{{ $pvcName }}"
           persistentVolumeClaim:
             claimName: "{{ $pvcName }}"
+        {{- end }}
+        {{- end }}
+        {{- if .Values.emptyDirs }}
+        {{- range $name, $destPath := .Values.emptyDirs}}
+        - name: "{{ $name }}"
+          emptyDir: {}
         {{- end }}
         {{- end }}
         {{- if ne (len .Values.configFiles) 0 }}

--- a/charts/custom-serving/templates/deployment.yaml
+++ b/charts/custom-serving/templates/deployment.yaml
@@ -151,12 +151,12 @@ spec:
               {{- end }}
             {{- end }}
             {{- end }}
-            {{- if .Values.emptyDirs }}
-            {{- range $name, $destPath := .Values.emptyDirs}}
+            {{- if .Values.tempDirs }}
+            {{- range $name, $destPath := .Values.tempDirs}}
             - name: "{{ $name }}"
               mountPath: "{{ $destPath }}"
-              {{- if hasKey $.Values.emptyDirSubPathExprs $name }}
-              subPathExpr: {{ get $.Values.emptyDirSubPathExprs $name }}
+              {{- if hasKey $.Values.tempDirSubPathExprs $name }}
+              subPathExpr: {{ get $.Values.tempDirSubPathExprs $name }}
               {{- end }}
             {{- end }}
             {{- end }}
@@ -181,8 +181,8 @@ spec:
             claimName: "{{ $pvcName }}"
         {{- end }}
         {{- end }}
-        {{- if .Values.emptyDirs }}
-        {{- range $name, $destPath := .Values.emptyDirs}}
+        {{- if .Values.tempDirs }}
+        {{- range $name, $destPath := .Values.tempDirs}}
         - name: "{{ $name }}"
           emptyDir: {}
         {{- end }}

--- a/charts/tfserving/Chart.yaml
+++ b/charts/tfserving/Chart.yaml
@@ -1,6 +1,6 @@
 name: tensorflow-serving
 home: https://github.com/kubernetes/charts
-version: 0.10.0
+version: 0.11.0
 appVersion: 1.8
 description: TensorFlow Serving is an open-source software library for serving machine learning models.
 sources:

--- a/charts/tfserving/templates/deployment.yaml
+++ b/charts/tfserving/templates/deployment.yaml
@@ -160,12 +160,12 @@ spec:
               {{- end }}
             {{- end }}
             {{- end }}
-            {{- if .Values.emptyDirs }}
-            {{- range $name, $destPath := .Values.emptyDirs}}
+            {{- if .Values.tempDirs }}
+            {{- range $name, $destPath := .Values.tempDirs }}
             - name: "{{ $name }}"
               mountPath: "{{ $destPath }}"
-              {{- if hasKey $.Values.emptyDirSubPathExprs $name }}
-              subPathExpr: {{ get $.Values.emptyDirSubPathExprs $name }}
+              {{- if hasKey $.Values.tempDirSubPathExprs $name }}
+              subPathExpr: {{ get $.Values.tempDirSubPathExprs $name }}
               {{- end }}
             {{- end }}
             {{- end }}
@@ -190,8 +190,8 @@ spec:
             claimName: "{{ $pvcName }}"
         {{- end }}
         {{- end }}
-        {{- if .Values.emptyDirs }}
-        {{- range $name, $destPath := .Values.emptyDirs}}
+        {{- if .Values.tempDirs }}
+        {{- range $name, $destPath := .Values.tempDirs}}
         - name: "{{ $name }}"
           emptyDir: {}
         {{- end }}

--- a/charts/tfserving/templates/deployment.yaml
+++ b/charts/tfserving/templates/deployment.yaml
@@ -160,6 +160,15 @@ spec:
               {{- end }}
             {{- end }}
             {{- end }}
+            {{- if .Values.emptyDirs }}
+            {{- range $name, $destPath := .Values.emptyDirs}}
+            - name: "{{ $name }}"
+              mountPath: "{{ $destPath }}"
+              {{- if hasKey $.Values.emptyDirSubPathExprs $name }}
+              subPathExpr: {{ get $.Values.emptyDirSubPathExprs $name }}
+              {{- end }}
+            {{- end }}
+            {{- end }}
             {{- if ne (len .Values.configFiles) 0 }}
             {{- $releaseName := .Release.Name }}
             {{- range $containerPathKey,$configFileInfos := .Values.configFiles }}
@@ -179,6 +188,12 @@ spec:
         - name: "{{ $pvcName }}"
           persistentVolumeClaim:
             claimName: "{{ $pvcName }}"
+        {{- end }}
+        {{- end }}
+        {{- if .Values.emptyDirs }}
+        {{- range $name, $destPath := .Values.emptyDirs}}
+        - name: "{{ $name }}"
+          emptyDir: {}
         {{- end }}
         {{- end }}
         {{- if ne (len .Values.configFiles) 0 }}

--- a/charts/triton/Chart.yaml
+++ b/charts/triton/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: Triton Inference Server Helm Chart
 name: tritoninferenceserver
-version: 0.9.0
+version: 0.10.0

--- a/charts/triton/templates/deployment.yaml
+++ b/charts/triton/templates/deployment.yaml
@@ -165,12 +165,12 @@ spec:
               {{- end }}
             {{- end }}
             {{- end }}
-            {{- if .Values.emptyDirs }}
-            {{- range $name, $destPath := .Values.emptyDirs}}
+            {{- if .Values.tempDirs }}
+            {{- range $name, $destPath := .Values.tempDirs }}
             - name: "{{ $name }}"
               mountPath: "{{ $destPath }}"
-              {{- if hasKey $.Values.emptyDirSubPathExprs $name }}
-              subPathExpr: {{ get $.Values.emptyDirSubPathExprs $name }}
+              {{- if hasKey $.Values.tempDirSubPathExprs $name }}
+              subPathExpr: {{ get $.Values.tempDirSubPathExprs $name }}
               {{- end }}
             {{- end }}
             {{- end }}
@@ -195,8 +195,8 @@ spec:
             claimName: "{{ $pvcName }}"
         {{- end }}
         {{- end }}
-        {{- if .Values.emptyDirs }}
-        {{- range $name, $destPath := .Values.emptyDirs}}
+        {{- if .Values.tempDirs }}
+        {{- range $name, $destPath := .Values.tempDirs }}
         - name: "{{ $name }}"
           emptyDir: {}
         {{- end }}

--- a/charts/triton/templates/deployment.yaml
+++ b/charts/triton/templates/deployment.yaml
@@ -165,6 +165,15 @@ spec:
               {{- end }}
             {{- end }}
             {{- end }}
+            {{- if .Values.emptyDirs }}
+            {{- range $name, $destPath := .Values.emptyDirs}}
+            - name: "{{ $name }}"
+              mountPath: "{{ $destPath }}"
+              {{- if hasKey $.Values.emptyDirSubPathExprs $name }}
+              subPathExpr: {{ get $.Values.emptyDirSubPathExprs $name }}
+              {{- end }}
+            {{- end }}
+            {{- end }}
             {{- if ne (len .Values.configFiles) 0 }}
             {{- $releaseName := .Release.Name }}
             {{- range $containerPathKey,$configFileInfos := .Values.configFiles }}
@@ -184,6 +193,12 @@ spec:
         - name: "{{ $pvcName }}"
           persistentVolumeClaim:
             claimName: "{{ $pvcName }}"
+        {{- end }}
+        {{- end }}
+        {{- if .Values.emptyDirs }}
+        {{- range $name, $destPath := .Values.emptyDirs}}
+        - name: "{{ $name }}"
+          emptyDir: {}
         {{- end }}
         {{- end }}
         {{- if ne (len .Values.configFiles) 0 }}

--- a/pkg/apis/serving/custom_builder.go
+++ b/pkg/apis/serving/custom_builder.go
@@ -221,6 +221,28 @@ func (b *CustomServingJobBuilder) DataSubPathExprs(exprs map[string]string) *Cus
 	return b
 }
 
+func (b *CustomServingJobBuilder) EmptyDirs(volumes map[string]string) *CustomServingJobBuilder {
+	if volumes != nil && len(volumes) != 0 {
+		s := []string{}
+		for key, value := range volumes {
+			s = append(s, fmt.Sprintf("%v:%v", key, value))
+		}
+		b.argValues["empty-dir"] = &s
+	}
+	return b
+}
+
+func (b *CustomServingJobBuilder) EmptyDirSubPathExprs(exprs map[string]string) *CustomServingJobBuilder {
+	if exprs != nil && len(exprs) != 0 {
+		s := []string{}
+		for key, value := range exprs {
+			s = append(s, fmt.Sprintf("%v:%v", key, value))
+		}
+		b.argValues["empty-dir-subpath-expr"] = &s
+	}
+	return b
+}
+
 // DataDirs is used to mount host files to job containers,match option --data-dir
 func (b *CustomServingJobBuilder) DataDirs(volumes map[string]string) *CustomServingJobBuilder {
 	if volumes != nil && len(volumes) != 0 {

--- a/pkg/apis/serving/custom_builder.go
+++ b/pkg/apis/serving/custom_builder.go
@@ -221,13 +221,13 @@ func (b *CustomServingJobBuilder) DataSubPathExprs(exprs map[string]string) *Cus
 	return b
 }
 
-func (b *CustomServingJobBuilder) EmptyDirs(volumes map[string]string) *CustomServingJobBuilder {
+func (b *CustomServingJobBuilder) TempDirs(volumes map[string]string) *CustomServingJobBuilder {
 	if volumes != nil && len(volumes) != 0 {
 		s := []string{}
 		for key, value := range volumes {
 			s = append(s, fmt.Sprintf("%v:%v", key, value))
 		}
-		b.argValues["empty-dir"] = &s
+		b.argValues["temp-dir"] = &s
 	}
 	return b
 }
@@ -238,7 +238,7 @@ func (b *CustomServingJobBuilder) EmptyDirSubPathExprs(exprs map[string]string) 
 		for key, value := range exprs {
 			s = append(s, fmt.Sprintf("%v:%v", key, value))
 		}
-		b.argValues["empty-dir-subpath-expr"] = &s
+		b.argValues["temp-dir-subpath-expr"] = &s
 	}
 	return b
 }

--- a/pkg/apis/serving/tensorflow_builder.go
+++ b/pkg/apis/serving/tensorflow_builder.go
@@ -241,6 +241,30 @@ func (b *TFServingJobBuilder) DataSubPathExprs(exprs map[string]string) *TFServi
 	return b
 }
 
+// EmptyDirs specify the deployment empty dir
+func (b *TFServingJobBuilder) EmptyDirs(volumes map[string]string) *TFServingJobBuilder {
+	if volumes != nil && len(volumes) != 0 {
+		s := []string{}
+		for key, value := range volumes {
+			s = append(s, fmt.Sprintf("%v:%v", key, value))
+		}
+		b.argValues["empty-dir"] = &s
+	}
+	return b
+}
+
+// EmptyDirSubPathExprs specify the datasource subpath to mount to the pod by expression
+func (b *TFServingJobBuilder) EmptyDirSubPathExprs(exprs map[string]string) *TFServingJobBuilder {
+	if exprs != nil && len(exprs) != 0 {
+		s := []string{}
+		for key, value := range exprs {
+			s = append(s, fmt.Sprintf("%v:%v", key, value))
+		}
+		b.argValues["empty-dir-subpath-expr"] = &s
+	}
+	return b
+}
+
 // DataDirs is used to mount host files to job containers,match option --data-dir
 func (b *TFServingJobBuilder) DataDirs(volumes map[string]string) *TFServingJobBuilder {
 	if volumes != nil && len(volumes) != 0 {

--- a/pkg/apis/serving/tensorflow_builder.go
+++ b/pkg/apis/serving/tensorflow_builder.go
@@ -241,14 +241,14 @@ func (b *TFServingJobBuilder) DataSubPathExprs(exprs map[string]string) *TFServi
 	return b
 }
 
-// EmptyDirs specify the deployment empty dir
-func (b *TFServingJobBuilder) EmptyDirs(volumes map[string]string) *TFServingJobBuilder {
+// TempDirs specify the deployment empty dir
+func (b *TFServingJobBuilder) TempDirs(volumes map[string]string) *TFServingJobBuilder {
 	if volumes != nil && len(volumes) != 0 {
 		s := []string{}
 		for key, value := range volumes {
 			s = append(s, fmt.Sprintf("%v:%v", key, value))
 		}
-		b.argValues["empty-dir"] = &s
+		b.argValues["temp-dir"] = &s
 	}
 	return b
 }
@@ -260,7 +260,7 @@ func (b *TFServingJobBuilder) EmptyDirSubPathExprs(exprs map[string]string) *TFS
 		for key, value := range exprs {
 			s = append(s, fmt.Sprintf("%v:%v", key, value))
 		}
-		b.argValues["empty-dir-subpath-expr"] = &s
+		b.argValues["temp-dir-subpath-expr"] = &s
 	}
 	return b
 }

--- a/pkg/apis/serving/triton_builder.go
+++ b/pkg/apis/serving/triton_builder.go
@@ -226,14 +226,14 @@ func (b *TritonServingJobBuilder) DataSubPathExprs(exprs map[string]string) *Tri
 	return b
 }
 
-// EmptyDirs specify the deployment empty dir
-func (b *TritonServingJobBuilder) EmptyDirs(volumes map[string]string) *TritonServingJobBuilder {
+// TempDirs specify the deployment empty dir
+func (b *TritonServingJobBuilder) TempDirs(volumes map[string]string) *TritonServingJobBuilder {
 	if volumes != nil && len(volumes) != 0 {
 		s := []string{}
 		for key, value := range volumes {
 			s = append(s, fmt.Sprintf("%v:%v", key, value))
 		}
-		b.argValues["empty-dir"] = &s
+		b.argValues["temp-dir"] = &s
 	}
 	return b
 }
@@ -245,7 +245,7 @@ func (b *TritonServingJobBuilder) EmptyDirSubPathExprs(exprs map[string]string) 
 		for key, value := range exprs {
 			s = append(s, fmt.Sprintf("%v:%v", key, value))
 		}
-		b.argValues["empty-dir-subpath-expr"] = &s
+		b.argValues["temp-dir-subpath-expr"] = &s
 	}
 	return b
 }

--- a/pkg/apis/serving/triton_builder.go
+++ b/pkg/apis/serving/triton_builder.go
@@ -226,6 +226,30 @@ func (b *TritonServingJobBuilder) DataSubPathExprs(exprs map[string]string) *Tri
 	return b
 }
 
+// EmptyDirs specify the deployment empty dir
+func (b *TritonServingJobBuilder) EmptyDirs(volumes map[string]string) *TritonServingJobBuilder {
+	if volumes != nil && len(volumes) != 0 {
+		s := []string{}
+		for key, value := range volumes {
+			s = append(s, fmt.Sprintf("%v:%v", key, value))
+		}
+		b.argValues["empty-dir"] = &s
+	}
+	return b
+}
+
+// EmptyDirSubPathExprs specify the datasource subpath to mount to the pod by expression
+func (b *TritonServingJobBuilder) EmptyDirSubPathExprs(exprs map[string]string) *TritonServingJobBuilder {
+	if exprs != nil && len(exprs) != 0 {
+		s := []string{}
+		for key, value := range exprs {
+			s = append(s, fmt.Sprintf("%v:%v", key, value))
+		}
+		b.argValues["empty-dir-subpath-expr"] = &s
+	}
+	return b
+}
+
 // DataDirs is used to mount host files to job containers,match option --data-dir
 func (b *TritonServingJobBuilder) DataDirs(volumes map[string]string) *TritonServingJobBuilder {
 	if volumes != nil && len(volumes) != 0 {

--- a/pkg/apis/types/serving.go
+++ b/pkg/apis/types/serving.go
@@ -138,27 +138,27 @@ type ServingInstance struct {
 }
 
 type CommonServingArgs struct {
-	Name                 string            `yaml:"servingName"`
-	Version              string            `yaml:"servingVersion"`
-	Namespace            string            `yaml:"-"`
-	Type                 ServingJobType    `yaml:"-"`
-	Image                string            `yaml:"image"`
-	ImagePullPolicy      string            `yaml:"imagePullPolicy"`      // --imagePullPolicy
-	GPUCount             int               `yaml:"gpuCount"`             // --gpus
-	GPUMemory            int               `yaml:"gpuMemory"`            // --gpumemory
-	GPUCore              int               `yaml:"gpuCore"`              // --gpucore
-	Cpu                  string            `yaml:"cpu"`                  // --cpu
-	Memory               string            `yaml:"memory"`               // --memory
-	Envs                 map[string]string `yaml:"envs"`                 // --envs
-	Shell                string            `yaml:"shell"`                // --shell
-	Command              string            `yaml:"command"`              // --command
-	Replicas             int               `yaml:"replicas"`             // --replicas
-	EnableIstio          bool              `yaml:"enableIstio"`          // --enableIstio
-	ExposeService        bool              `yaml:"exposeService"`        // --exposeService
-	ModelDirs            map[string]string `yaml:"modelDirs"`            // --data
-	DataSubpathExprs     map[string]string `yaml:"dataSubPathExprs"`     // --data-subpath-expr
-	EmptyDirSubpathExprs map[string]string `yaml:"emptyDirSubPathExprs"` // --empty-dir-subpath-expr
-	EmptyDirs            map[string]string `yaml:"emptyDirs"`            // --empty-dir
+	Name               string            `yaml:"servingName"`
+	Version            string            `yaml:"servingVersion"`
+	Namespace          string            `yaml:"-"`
+	Type               ServingJobType    `yaml:"-"`
+	Image              string            `yaml:"image"`
+	ImagePullPolicy    string            `yaml:"imagePullPolicy"`     // --imagePullPolicy
+	GPUCount           int               `yaml:"gpuCount"`            // --gpus
+	GPUMemory          int               `yaml:"gpuMemory"`           // --gpumemory
+	GPUCore            int               `yaml:"gpuCore"`             // --gpucore
+	Cpu                string            `yaml:"cpu"`                 // --cpu
+	Memory             string            `yaml:"memory"`              // --memory
+	Envs               map[string]string `yaml:"envs"`                // --envs
+	Shell              string            `yaml:"shell"`               // --shell
+	Command            string            `yaml:"command"`             // --command
+	Replicas           int               `yaml:"replicas"`            // --replicas
+	EnableIstio        bool              `yaml:"enableIstio"`         // --enableIstio
+	ExposeService      bool              `yaml:"exposeService"`       // --exposeService
+	ModelDirs          map[string]string `yaml:"modelDirs"`           // --data
+	DataSubpathExprs   map[string]string `yaml:"dataSubPathExprs"`    // --data-subpath-expr
+	TempDirSubpathExpr map[string]string `yaml:"tempDirSubPathExprs"` // --temp-dir-subpath-expr
+	TempDirs           map[string]string `yaml:"tempDirs"`            // --temp-dir
 
 	HostVolumes   []DataDirVolume   `yaml:"hostVolumes"`   // --data-dir
 	NodeSelectors map[string]string `yaml:"nodeSelectors"` // --selector

--- a/pkg/apis/types/serving.go
+++ b/pkg/apis/types/serving.go
@@ -138,25 +138,27 @@ type ServingInstance struct {
 }
 
 type CommonServingArgs struct {
-	Name             string            `yaml:"servingName"`
-	Version          string            `yaml:"servingVersion"`
-	Namespace        string            `yaml:"-"`
-	Type             ServingJobType    `yaml:"-"`
-	Image            string            `yaml:"image"`
-	ImagePullPolicy  string            `yaml:"imagePullPolicy"`  // --imagePullPolicy
-	GPUCount         int               `yaml:"gpuCount"`         // --gpus
-	GPUMemory        int               `yaml:"gpuMemory"`        // --gpumemory
-	GPUCore          int               `yaml:"gpuCore"`          // --gpucore
-	Cpu              string            `yaml:"cpu"`              // --cpu
-	Memory           string            `yaml:"memory"`           // --memory
-	Envs             map[string]string `yaml:"envs"`             // --envs
-	Shell            string            `yaml:"shell"`            // --shell
-	Command          string            `yaml:"command"`          // --command
-	Replicas         int               `yaml:"replicas"`         // --replicas
-	EnableIstio      bool              `yaml:"enableIstio"`      // --enableIstio
-	ExposeService    bool              `yaml:"exposeService"`    // --exposeService
-	ModelDirs        map[string]string `yaml:"modelDirs"`        // --data
-	DataSubpathExprs map[string]string `yaml:"dataSubPathExprs"` // --data-subpath-expr
+	Name                 string            `yaml:"servingName"`
+	Version              string            `yaml:"servingVersion"`
+	Namespace            string            `yaml:"-"`
+	Type                 ServingJobType    `yaml:"-"`
+	Image                string            `yaml:"image"`
+	ImagePullPolicy      string            `yaml:"imagePullPolicy"`      // --imagePullPolicy
+	GPUCount             int               `yaml:"gpuCount"`             // --gpus
+	GPUMemory            int               `yaml:"gpuMemory"`            // --gpumemory
+	GPUCore              int               `yaml:"gpuCore"`              // --gpucore
+	Cpu                  string            `yaml:"cpu"`                  // --cpu
+	Memory               string            `yaml:"memory"`               // --memory
+	Envs                 map[string]string `yaml:"envs"`                 // --envs
+	Shell                string            `yaml:"shell"`                // --shell
+	Command              string            `yaml:"command"`              // --command
+	Replicas             int               `yaml:"replicas"`             // --replicas
+	EnableIstio          bool              `yaml:"enableIstio"`          // --enableIstio
+	ExposeService        bool              `yaml:"exposeService"`        // --exposeService
+	ModelDirs            map[string]string `yaml:"modelDirs"`            // --data
+	DataSubpathExprs     map[string]string `yaml:"dataSubPathExprs"`     // --data-subpath-expr
+	EmptyDirSubpathExprs map[string]string `yaml:"emptyDirSubPathExprs"` // --empty-dir-subpath-expr
+	EmptyDirs            map[string]string `yaml:"emptyDirs"`            // --empty-dir
 
 	HostVolumes   []DataDirVolume   `yaml:"hostVolumes"`   // --data-dir
 	NodeSelectors map[string]string `yaml:"nodeSelectors"` // --selector

--- a/sdk/arena-java-sdk/src/main/java/com/github/kubeflow/arena/model/serving/CustomServingJobBuilder.java
+++ b/sdk/arena-java-sdk/src/main/java/com/github/kubeflow/arena/model/serving/CustomServingJobBuilder.java
@@ -102,7 +102,15 @@ public class CustomServingJobBuilder extends JobBuilder {
         super.dataSubpathExprs(exprs);
         return this;
     }
+    public CustomServingJobBuilder emptyDirs(Map<String, String> emptyDirs) {
+        super.emptyDirs(emptyDirs);
+        return this;
+    }
 
+    public CustomServingJobBuilder emptyDirSubpathExprs(Map<String, String> exprs) {
+        super.emptyDirSubpathExprs(exprs);
+        return this;
+    }
     public CustomServingJobBuilder dataDirs(Map<String, String> dataDirs) {
         super.dataDirs(dataDirs);
         return  this;

--- a/sdk/arena-java-sdk/src/main/java/com/github/kubeflow/arena/model/serving/CustomServingJobBuilder.java
+++ b/sdk/arena-java-sdk/src/main/java/com/github/kubeflow/arena/model/serving/CustomServingJobBuilder.java
@@ -102,13 +102,13 @@ public class CustomServingJobBuilder extends JobBuilder {
         super.dataSubpathExprs(exprs);
         return this;
     }
-    public CustomServingJobBuilder emptyDirs(Map<String, String> emptyDirs) {
-        super.emptyDirs(emptyDirs);
+    public CustomServingJobBuilder tempDirs(Map<String, String> tempDirs) {
+        super.tempDirs(tempDirs);
         return this;
     }
 
-    public CustomServingJobBuilder emptyDirSubpathExprs(Map<String, String> exprs) {
-        super.emptyDirSubpathExprs(exprs);
+    public CustomServingJobBuilder tempDirSubpathExprs(Map<String, String> exprs) {
+        super.tempDirSubpathExprs(exprs);
         return this;
     }
     public CustomServingJobBuilder dataDirs(Map<String, String> dataDirs) {

--- a/sdk/arena-java-sdk/src/main/java/com/github/kubeflow/arena/model/serving/JobBuilder.java
+++ b/sdk/arena-java-sdk/src/main/java/com/github/kubeflow/arena/model/serving/JobBuilder.java
@@ -112,13 +112,13 @@ public abstract class JobBuilder {
         return this;
     }
 
-    public JobBuilder emptyDirs(Map<String, String> emptyDirs) {
-        this.options.add(new StringMapField("--empty-dir", emptyDirs, ":"));
+    public JobBuilder tempDirs(Map<String, String> tempDirs) {
+        this.options.add(new StringMapField("--temp-dir", tempDirs, ":"));
         return this;
     }
 
-    public JobBuilder emptyDirSubpathExprs(Map<String, String> exprs) {
-        this.options.add(new StringMapField("--empty-dir-subpath-expr", exprs, ":"));
+    public JobBuilder tempDirSubpathExprs(Map<String, String> exprs) {
+        this.options.add(new StringMapField("--temp-dir-subpath-expr", exprs, ":"));
         return this;
     }
 

--- a/sdk/arena-java-sdk/src/main/java/com/github/kubeflow/arena/model/serving/JobBuilder.java
+++ b/sdk/arena-java-sdk/src/main/java/com/github/kubeflow/arena/model/serving/JobBuilder.java
@@ -112,6 +112,16 @@ public abstract class JobBuilder {
         return this;
     }
 
+    public JobBuilder emptyDirs(Map<String, String> emptyDirs) {
+        this.options.add(new StringMapField("--empty-dir", emptyDirs, ":"));
+        return this;
+    }
+
+    public JobBuilder emptyDirSubpathExprs(Map<String, String> exprs) {
+        this.options.add(new StringMapField("--empty-dir-subpath-expr", exprs, ":"));
+        return this;
+    }
+
     public JobBuilder dataDirs(Map<String, String> dataDirs) {
         this.options.add(new StringMapField("--data-dir", dataDirs, ":"));
         return this;

--- a/sdk/arena-java-sdk/src/main/java/com/github/kubeflow/arena/model/serving/TensorflowServingJobBuilder.java
+++ b/sdk/arena-java-sdk/src/main/java/com/github/kubeflow/arena/model/serving/TensorflowServingJobBuilder.java
@@ -122,13 +122,13 @@ public class TensorflowServingJobBuilder extends JobBuilder {
         super.dataSubpathExprs(exprs);
         return this;
     }
-    public TensorflowServingJobBuilder emptyDirs(Map<String, String> emptyDirs) {
-        super.emptyDirs(emptyDirs);
+    public TensorflowServingJobBuilder tempDirs(Map<String, String> tempDirs) {
+        super.tempDirs(tempDirs);
         return this;
     }
 
-    public TensorflowServingJobBuilder emptyDirSubpathExprs(Map<String, String> exprs) {
-        super.emptyDirSubpathExprs(exprs);
+    public TensorflowServingJobBuilder tempDirSubpathExprs(Map<String, String> exprs) {
+        super.tempDirSubpathExprs(exprs);
         return this;
     }
 

--- a/sdk/arena-java-sdk/src/main/java/com/github/kubeflow/arena/model/serving/TensorflowServingJobBuilder.java
+++ b/sdk/arena-java-sdk/src/main/java/com/github/kubeflow/arena/model/serving/TensorflowServingJobBuilder.java
@@ -122,6 +122,15 @@ public class TensorflowServingJobBuilder extends JobBuilder {
         super.dataSubpathExprs(exprs);
         return this;
     }
+    public TensorflowServingJobBuilder emptyDirs(Map<String, String> emptyDirs) {
+        super.emptyDirs(emptyDirs);
+        return this;
+    }
+
+    public TensorflowServingJobBuilder emptyDirSubpathExprs(Map<String, String> exprs) {
+        super.emptyDirSubpathExprs(exprs);
+        return this;
+    }
 
     public TensorflowServingJobBuilder dataDirs(Map<String, String> dataDirs) {
         super.dataDirs(dataDirs);

--- a/sdk/arena-java-sdk/src/main/java/com/github/kubeflow/arena/model/serving/TritonServingJobBuilder.java
+++ b/sdk/arena-java-sdk/src/main/java/com/github/kubeflow/arena/model/serving/TritonServingJobBuilder.java
@@ -112,7 +112,15 @@ public class TritonServingJobBuilder extends JobBuilder {
         super.dataSubpathExprs(exprs);
         return this;
     }
+    public TritonServingJobBuilder emptyDirs(Map<String, String> emptyDirs) {
+        super.emptyDirs(emptyDirs);
+        return this;
+    }
 
+    public TritonServingJobBuilder emptyDirSubpathExprs(Map<String, String> exprs) {
+        super.emptyDirSubpathExprs(exprs);
+        return this;
+    }
     public TritonServingJobBuilder dataDirs(Map<String, String> dataDirs) {
         super.dataDirs(dataDirs);
         return  this;

--- a/sdk/arena-java-sdk/src/main/java/com/github/kubeflow/arena/model/serving/TritonServingJobBuilder.java
+++ b/sdk/arena-java-sdk/src/main/java/com/github/kubeflow/arena/model/serving/TritonServingJobBuilder.java
@@ -112,13 +112,13 @@ public class TritonServingJobBuilder extends JobBuilder {
         super.dataSubpathExprs(exprs);
         return this;
     }
-    public TritonServingJobBuilder emptyDirs(Map<String, String> emptyDirs) {
-        super.emptyDirs(emptyDirs);
+    public TritonServingJobBuilder tempDirs(Map<String, String> tempDirs) {
+        super.tempDirs(tempDirs);
         return this;
     }
 
-    public TritonServingJobBuilder emptyDirSubpathExprs(Map<String, String> exprs) {
-        super.emptyDirSubpathExprs(exprs);
+    public TritonServingJobBuilder tempDirSubpathExprs(Map<String, String> exprs) {
+        super.tempDirSubpathExprs(exprs);
         return this;
     }
     public TritonServingJobBuilder dataDirs(Map<String, String> dataDirs) {

--- a/sdk/arena-java-sdk/src/test/java/com/github/kubeflow/arena/CustomServingJobTest.java
+++ b/sdk/arena-java-sdk/src/test/java/com/github/kubeflow/arena/CustomServingJobTest.java
@@ -36,8 +36,8 @@ public class CustomServingJobTest {
         String jobVersion = "alpha";
         ServingJobType jobType = ServingJobType.CustomServingJob;
         // 2.create mpi job
-        Map<String, String> emptyDirs = new HashMap<>();
-        emptyDirs.put("empty-0", "/opt/logs");
+        Map<String, String> tempDirs = new HashMap<>();
+        tempDirs.put("empty-0", "/opt/logs");
         Map<String, String> exprs = new HashMap<>();
         exprs.put("empty-0", "$(ARENA_POD_NAMESPACE)/$(ARENA_POD_NAME)");
         ServingJob job = new CustomServingJobBuilder()
@@ -45,8 +45,8 @@ public class CustomServingJobTest {
                 .version(jobVersion)
                 .gpus(1)
                 .replicas(1)
-                .emptyDirs(emptyDirs)
-                .emptyDirSubpathExprs(exprs)
+                .tempDirs(tempDirs)
+                .tempDirSubpathExprs(exprs)
                 .restfulPort(5000)
                 .image("happy365/fast-style-transfer:latest")
                 .command("python app.py")

--- a/sdk/arena-java-sdk/src/test/java/com/github/kubeflow/arena/CustomServingJobTest.java
+++ b/sdk/arena-java-sdk/src/test/java/com/github/kubeflow/arena/CustomServingJobTest.java
@@ -16,7 +16,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.Charset;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 public class CustomServingJobTest {
@@ -34,11 +36,17 @@ public class CustomServingJobTest {
         String jobVersion = "alpha";
         ServingJobType jobType = ServingJobType.CustomServingJob;
         // 2.create mpi job
+        Map<String, String> emptyDirs = new HashMap<>();
+        emptyDirs.put("empty-0", "/opt/logs");
+        Map<String, String> exprs = new HashMap<>();
+        exprs.put("empty-0", "$(ARENA_POD_NAMESPACE)/$(ARENA_POD_NAME)");
         ServingJob job = new CustomServingJobBuilder()
                 .name(jobName)
                 .version(jobVersion)
                 .gpus(1)
                 .replicas(1)
+                .emptyDirs(emptyDirs)
+                .emptyDirSubpathExprs(exprs)
                 .restfulPort(5000)
                 .image("happy365/fast-style-transfer:latest")
                 .command("python app.py")

--- a/sdk/arena-java-sdk/src/test/java/com/github/kubeflow/arena/TensorflowServingJobTest.java
+++ b/sdk/arena-java-sdk/src/test/java/com/github/kubeflow/arena/TensorflowServingJobTest.java
@@ -20,8 +20,8 @@ public class TensorflowServingJobTest {
         Map<String, String> datas = new HashMap<>();
         datas.put("model-pvc", "/data");
 
-        Map<String, String> emptyDirs = new HashMap<>();
-        emptyDirs.put("empty-0", "/opt/logs");
+        Map<String, String> tempDirs = new HashMap<>();
+        tempDirs.put("empty-0", "/opt/logs");
         Map<String, String> exprs = new HashMap<>();
         exprs.put("empty-0", "$(ARENA_POD_NAMESPACE)/$(ARENA_POD_NAME)");
         ServingJob job = new TensorflowServingJobBuilder()
@@ -33,8 +33,8 @@ public class TensorflowServingJobTest {
                 .labels(labels)
                 .image("tensorflow/serving:1.15.0-gpu")
                 .datas(datas)
-                .emptyDirs(emptyDirs)
-                .emptyDirSubpathExprs(exprs)
+                .tempDirs(tempDirs)
+                .tempDirSubpathExprs(exprs)
                 .shell("bash")
                 .modelPath("/data/models/soul/saved_model/transformer")
                 .build();

--- a/sdk/arena-java-sdk/src/test/java/com/github/kubeflow/arena/TritonServingJobTest.java
+++ b/sdk/arena-java-sdk/src/test/java/com/github/kubeflow/arena/TritonServingJobTest.java
@@ -1,26 +1,16 @@
 package com.github.kubeflow.arena;
 import com.github.kubeflow.arena.client.ArenaClient;
-import com.github.kubeflow.arena.enums.ArenaErrorEnum;
-import com.github.kubeflow.arena.enums.ServingJobType;
 import com.github.kubeflow.arena.exceptions.ArenaException;
-import com.github.kubeflow.arena.model.common.Logger;
-import com.github.kubeflow.arena.model.serving.CustomServingJobBuilder;
-import com.github.kubeflow.arena.model.serving.Instance;
 import com.github.kubeflow.arena.model.serving.ServingJob;
-import com.github.kubeflow.arena.model.serving.ServingJobInfo;
 import com.github.kubeflow.arena.model.serving.TritonServingJobBuilder;
 
 import org.junit.Test;
 
-import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.nio.charset.Charset;
+
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
+
 public class TritonServingJobTest {
     @Test
     public void testTensorflowServing() throws ArenaException, IOException {
@@ -28,8 +18,8 @@ public class TritonServingJobTest {
         labels.put("key1", "value1");
         Map<String, String> datas = new HashMap<>();
         datas.put("model-pvc", "/data");
-        Map<String, String> emptyDirs = new HashMap<>();
-        emptyDirs.put("empty-0", "/opt/logs");
+        Map<String, String> tempDirs = new HashMap<>();
+        tempDirs.put("empty-0", "/opt/logs");
         Map<String, String> exprs = new HashMap<>();
         exprs.put("empty-0", "$(ARENA_POD_NAMESPACE)/$(ARENA_POD_NAME)");
         ServingJob job = new TritonServingJobBuilder()
@@ -40,8 +30,8 @@ public class TritonServingJobTest {
                 .labels(labels)
                 .image("tensorflow/serving:1.15.0-gpu")
                 .datas(datas)
-                .emptyDirs(emptyDirs)
-                .emptyDirSubpathExprs(exprs)
+                .tempDirs(tempDirs)
+                .tempDirSubpathExprs(exprs)
                 .shell("bash")
                 .build();
 

--- a/sdk/arena-java-sdk/src/test/java/com/github/kubeflow/arena/TritonServingJobTest.java
+++ b/sdk/arena-java-sdk/src/test/java/com/github/kubeflow/arena/TritonServingJobTest.java
@@ -1,59 +1,51 @@
 package com.github.kubeflow.arena;
-
 import com.github.kubeflow.arena.client.ArenaClient;
+import com.github.kubeflow.arena.enums.ArenaErrorEnum;
+import com.github.kubeflow.arena.enums.ServingJobType;
 import com.github.kubeflow.arena.exceptions.ArenaException;
+import com.github.kubeflow.arena.model.common.Logger;
+import com.github.kubeflow.arena.model.serving.CustomServingJobBuilder;
+import com.github.kubeflow.arena.model.serving.Instance;
 import com.github.kubeflow.arena.model.serving.ServingJob;
-import com.github.kubeflow.arena.model.serving.TensorflowServingJobBuilder;
+import com.github.kubeflow.arena.model.serving.ServingJobInfo;
+import com.github.kubeflow.arena.model.serving.TritonServingJobBuilder;
+
 import org.junit.Test;
 
+import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.Charset;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
-
-public class TensorflowServingJobTest {
-
+import java.util.concurrent.TimeUnit;
+public class TritonServingJobTest {
     @Test
     public void testTensorflowServing() throws ArenaException, IOException {
         Map<String, String> labels = new HashMap<>();
         labels.put("key1", "value1");
-
         Map<String, String> datas = new HashMap<>();
         datas.put("model-pvc", "/data");
-
         Map<String, String> emptyDirs = new HashMap<>();
         emptyDirs.put("empty-0", "/opt/logs");
         Map<String, String> exprs = new HashMap<>();
         exprs.put("empty-0", "$(ARENA_POD_NAMESPACE)/$(ARENA_POD_NAME)");
-        ServingJob job = new TensorflowServingJobBuilder()
-                .name("bert3")
+        ServingJob job = new TritonServingJobBuilder()
+                .name("triton-serv")
                 .namespace("default-group")
                 .gpus(1)
                 .replicas(1)
-                .modelName("transformer")
                 .labels(labels)
                 .image("tensorflow/serving:1.15.0-gpu")
                 .datas(datas)
                 .emptyDirs(emptyDirs)
                 .emptyDirSubpathExprs(exprs)
                 .shell("bash")
-                .modelPath("/data/models/soul/saved_model/transformer")
                 .build();
 
         ArenaClient client = new ArenaClient();
         client.serving().submit(job);
     }
-
-    @Test
-    public void testUpdate() throws ArenaException, IOException {
-        ServingJob job = new TensorflowServingJobBuilder()
-                .name("cartoongan")
-                .namespace("default-group")
-                .version("202202091103")
-                .replicas(2)
-                .build();
-
-        ArenaClient client = new ArenaClient();
-        client.serving().namespace("default-group").update(job);
-    }
-
 }


### PR DESCRIPTION
e.g.

```shell
arena serve custom \
    --namespace=default-group\
    --loglevel=debug\
    --name=fast-style-transfer-3 \
    --temp-dir="empty-0:/opt/logs" \
    --temp-dir-subpath-expr='empty-0:$(ARENA_POD_NAMESPACE)/$(ARENA_POD_NAME)' \
    --gpus=1 \
    --version=alpha \
    --replicas=1 \
    --restful-port=5000 \
    --image=happy365/fast-style-transfer:latest \
    "python app.py"
```
dest yaml
```yaml
        volumeMounts:
        - mountPath: /opt/logs
          name: empty-0
          subPathExpr: $(ARENA_POD_NAMESPACE)/$(ARENA_POD_NAME)
      dnsPolicy: ClusterFirst
      restartPolicy: Always
      schedulerName: default-scheduler
      securityContext: {}
      terminationGracePeriodSeconds: 30
      volumes:
      - emptyDir: {}
        name: empty-0
```