### PR TITLE
Fix model serve args bug.

### DIFF
--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -263,7 +263,6 @@ func (m *modelJob) Params() map[string]string {
 	for _, value := range arr {
 		if strings.HasPrefix(value, "--") {
 			kv := strings.Split(value, "=")
-			params[kv[0]] = kv[1]
 			params[fmt.Sprintf("--%s", kv[0])] = value[len(kv[0])+1:]
 		}
 	}

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -264,6 +264,7 @@ func (m *modelJob) Params() map[string]string {
 		if strings.HasPrefix(value, "--") {
 			kv := strings.Split(value, "=")
 			params[kv[0]] = kv[1]
+			params[fmt.Sprintf("--%s", kv[0])] = value[len(kv[0])+1:]
 		}
 	}
 	return params

--- a/pkg/serving/update.go
+++ b/pkg/serving/update.go
@@ -32,17 +32,18 @@ func UpdateTensorflowServing(args *types.UpdateTensorFlowServingArgs) error {
 			if strings.HasSuffix(servingArgs, "\n") {
 				servingArgs = servingArgs[:len(servingArgs)-2]
 			}
-			arr := strings.Split(servingArgs, " ")
-
+			arr := strings.Split(servingArgs, "--")
 			params := make(map[string]string)
-			for i := 1; i < len(arr); i++ {
-				pair := strings.Split(arr[i], "=")
-				if len(pair) == 0 {
+			for index, argItem := range arr {
+				if index == 0 {
 					continue
 				}
-				params[pair[0]] = pair[1]
+				pair := strings.Split(argItem, "=")
+				if len(pair) <= 1 {
+					continue
+				}
+				params[fmt.Sprintf("--%s", pair[0])] = argItem[len(pair[0])+1:]
 			}
-
 			if args.ModelName != "" {
 				params["--model_name"] = args.ModelName
 			}
@@ -132,12 +133,18 @@ func UpdateTritonServing(args *types.UpdateTritonServingArgs) error {
 		if strings.HasSuffix(servingArgs, "\n") {
 			servingArgs = servingArgs[:len(servingArgs)-2]
 		}
-		arr := strings.Split(servingArgs, " ")
+		arr := strings.Split(servingArgs, "--")
 
 		params := make(map[string]string)
-		for i := 1; i < len(arr); i++ {
-			pair := strings.Split(arr[i], "=")
-			params[pair[0]] = pair[1]
+		for index, argItem := range arr {
+			if index == 0 {
+				continue
+			}
+			pair := strings.Split(argItem, "=")
+			if len(pair) <= 1 {
+				continue
+			}
+			params[fmt.Sprintf("--%s", pair[0])] = argItem[len(pair[0])+1:]
 		}
 
 		if args.ModelRepository != "" {


### PR DESCRIPTION
When I use 'arena serve tf' to submit a TfServing, if I want to use '--gpumemory', arena will fill the server args with
'--per_process_gpu_memory_fraction=$(awk 'BEGIN{printf"%.2f",'$ALIYUN_COM_GPU_MEM_CONTAINER'/'$ALIYUN_COM_GPU_MEM_DEV'}')'.
So it will have a panic:
panic: runtime error: index out of range [1] with length 1
And if other unexpected parameters appear, this problem will appear again.