### PR TITLE
Fix arena serve update bug.

### DIFF
--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -263,7 +263,7 @@ func (m *modelJob) Params() map[string]string {
 	for _, value := range arr {
 		if strings.HasPrefix(value, "--") {
 			kv := strings.Split(value, "=")
-			params[fmt.Sprintf("--%s", kv[0])] = value[len(kv[0])+1:]
+			params[kv[0]] = kv[1]
 		}
 	}
 	return params

--- a/pkg/serving/update.go
+++ b/pkg/serving/update.go
@@ -30,7 +30,7 @@ func UpdateTensorflowServing(args *types.UpdateTensorFlowServingArgs) error {
 			servingArgs := containerArgs[0]
 
 			if strings.HasSuffix(servingArgs, "\n") {
-				servingArgs = servingArgs[:len(servingArgs)-2]
+				servingArgs = strings.TrimSpace(servingArgs[:len(servingArgs)-1])
 			}
 			arr := strings.Split(servingArgs, "--")
 			params := make(map[string]string)
@@ -131,7 +131,7 @@ func UpdateTritonServing(args *types.UpdateTritonServingArgs) error {
 
 		servingArgs := containerArgs[0]
 		if strings.HasSuffix(servingArgs, "\n") {
-			servingArgs = servingArgs[:len(servingArgs)-2]
+			servingArgs = strings.TrimSpace(servingArgs[:len(servingArgs)-1])
 		}
 		arr := strings.Split(servingArgs, "--")
 
@@ -327,7 +327,7 @@ func findAndBuildDeployment(args *types.CommonUpdateServingArgs) (*appsv1.Deploy
 			newEnvs = append(newEnvs, envVar)
 		}
 	}
-	deploy.Spec.Template.Spec.Containers[0].Env = newEnvs
+	deploy.Spec.Template.Spec.Containers[0].Env = append(deploy.Spec.Template.Spec.Containers[0].Env, newEnvs...)
 
 	if args.Command != "" {
 		// commands: sh -c xxx


### PR DESCRIPTION
When I use `arena serve update tf`, the old environment variable would be lost. And the command `$(awk 'BEGIN{printf "%.2f",'$ALIYUN_COM_GPU_MEM_CONTAINER'/'$ALIYUN_COM_GPU_MEM_DEV'}')`would lose a `')'`.