### PR TITLE
Fix arena java sdk env bug.

### DIFF
--- a/sdk/arena-java-sdk/src/main/java/com/github/kubeflow/arena/utils/Command.java
+++ b/sdk/arena-java-sdk/src/main/java/com/github/kubeflow/arena/utils/Command.java
@@ -5,6 +5,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.List;
+
 import com.github.kubeflow.arena.exceptions.ExitCodeException;
 import org.apache.commons.lang3.StringUtils;
 
@@ -77,7 +80,19 @@ public class Command {
     public static String execCommand(String... cmd) throws IOException {
         String cmdString = StringUtils.join(cmd, " ");
         System.out.printf("exec command: [%s]\n",cmdString);
-        return new Command(cmd).run();
+        return new Command(newCommandBuild(cmd)).run();
+    }
+
+    private static String[] newCommandBuild(String... cmd) {
+        List<String> newCommand = new ArrayList<String>();
+        for (String s : cmd) {
+            if (s.contains("--env") || s.contains("--annotation") || s.contains("--label")){
+                newCommand.add(s.replaceAll("\"",""));
+            } else {
+                newCommand.add(s);
+            }
+        }
+        return newCommand.toArray(new String[newCommand.size()]);
     }
 
 }

--- a/sdk/arena-java-sdk/src/main/java/com/github/kubeflow/arena/utils/Command.java
+++ b/sdk/arena-java-sdk/src/main/java/com/github/kubeflow/arena/utils/Command.java
@@ -80,7 +80,7 @@ public class Command {
     public static String execCommand(String... cmd) throws IOException {
         String cmdString = StringUtils.join(cmd, " ");
         System.out.printf("exec command: [%s]\n",cmdString);
-        return new Command(newCommandBuild(cmd)).run();
+        return String.format("exec command: [%s]\n", cmdString) + new Command(newCommandBuild(cmd)).run();
     }
 
     private static String[] newCommandBuild(String... cmd) {


### PR DESCRIPTION
When I use arena java sdk to submit tfjob with a json env, it will be submit error because parse value to YAML have error.
But I discover if I replace the character '\"' to none, it would be work. Because the java exec command with these characters  is not the right format.