### PR TITLE
Add ownerReference for configmap and tensorboard

### DIFF
--- a/arena-artifacts/all_crds/v1/et-operator/kai.alibabacloud.com_trainingjobs.yaml
+++ b/arena-artifacts/all_crds/v1/et-operator/kai.alibabacloud.com_trainingjobs.yaml
@@ -6,7 +6,7 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.6.0
     git-repo: https://github.com/AliyunContainerService/et-operator.git
     git-branch: master
-    git-commit: "1499985"
+    git-commit: "8aff240"
   creationTimestamp: null
   name: trainingjobs.kai.alibabacloud.com
 spec:

--- a/arena-artifacts/values.yaml
+++ b/arena-artifacts/values.yaml
@@ -91,7 +91,7 @@ pytorch:
 et:
   enabled: true
   image: acs/et-operator
-  tag: v0.1.3-aliyun-0d6b825
+  tag: v0.1.3-aliyun-8aff240
   imagePullPolicy: IfNotPresent
   resources:
     limits:

--- a/charts/etjob/CHANGELOG.md
+++ b/charts/etjob/CHANGELOG.md
@@ -10,3 +10,7 @@
 
 * change image repo from kube-ai to acs
 
+### 0.3.1
+
+* update gitImage
+

--- a/charts/etjob/Chart.yaml
+++ b/charts/etjob/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for ETJob
 name: etjob
-version: 0.3.0
+version: 0.3.1

--- a/charts/etjob/values.yaml
+++ b/charts/etjob/values.yaml
@@ -10,7 +10,7 @@ gpuCount: 0 # user define
 # rsync image
 rsyncImage: registry.cn-zhangjiakou.aliyuncs.com/acs/rsync:v3.1.0-aliyun
 # git sync image
-gitImage: registry.cn-zhangjiakou.aliyuncs.com/acs/git-sync:v3.1.1
+gitImage: registry.cn-zhangjiakou.aliyuncs.com/acs/git-sync:v3.3.5
 
 shmSize: 2Gi
 privileged: false

--- a/charts/pytorchjob/CHANGELOG.md
+++ b/charts/pytorchjob/CHANGELOG.md
@@ -33,3 +33,7 @@
 ### 0.5.0
 
 * Support ActiveDeadlineSeconds,TTLSecondsAfterFinished
+
+### 0.5.1
+
+* Add service labels

--- a/charts/pytorchjob/Chart.yaml
+++ b/charts/pytorchjob/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for PyTorchJob
 name: pytorchjob
-version: 0.5.0
+version: 0.5.1

--- a/charts/pytorchjob/templates/ingress.yaml
+++ b/charts/pytorchjob/templates/ingress.yaml
@@ -11,6 +11,10 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
     createdBy: "PyTorchJob"
+    controller-name: pytorch-operator
+    group-name: kubeflow.org
+    job-name: { { .Release.Name } }
+    pytorch-job-name: { { .Release.Name } }
 spec:
   rules:
     - http:

--- a/charts/pytorchjob/templates/service.yaml
+++ b/charts/pytorchjob/templates/service.yaml
@@ -10,6 +10,10 @@ metadata:
     heritage: {{ .Release.Service }}
     role: tensorboard
     createdBy: "PyTorchJob"
+    controller-name: pytorch-operator
+    group-name: kubeflow.org
+    job-name: {{ .Release.Name }}
+    pytorch-job-name: {{ .Release.Name }}
 spec:
   type: {{ .Values.tensorboardServiceType }}
   ports:

--- a/charts/tfjob/CHANGELOG.md
+++ b/charts/tfjob/CHANGELOG.md
@@ -168,3 +168,7 @@
 ### 0.39.0
 
 * Support TTLSecondsAfterFinished
+
+### 0.39.1
+
+* Add service labels

--- a/charts/tfjob/Chart.yaml
+++ b/charts/tfjob/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for TFJob
 name: tfjob
-version: 0.39.0
+version: 0.39.1

--- a/charts/tfjob/templates/ingress.yaml
+++ b/charts/tfjob/templates/ingress.yaml
@@ -12,6 +12,8 @@ metadata:
     heritage: {{ .Release.Service }}
     role: tensorboard
     createdBy: "TFJob"
+    group-name: kubeflow.org
+    tf-job-name: { { .Release.Name } }
 spec:
   rules:
     - http:

--- a/charts/tfjob/templates/service.yaml
+++ b/charts/tfjob/templates/service.yaml
@@ -11,6 +11,8 @@ metadata:
     heritage: {{ .Release.Service }}
     role: tensorboard
     createdBy: "TFJob"
+    group-name: kubeflow.org
+    tf-job-name: {{ .Release.Name }}
 spec:
   type: {{ .Values.tensorboardServiceType }}
   ports:


### PR DESCRIPTION
add ownerReference  for configmap and tensorboard:
1. patch configmap ownerReference.
2. patch deployment/tensorboard ownerReference.
3. add label in service/tensorboard, and job operator will add ownerReferences.
see: https://github.com/AliyunContainerService/tf-operator/blob/b81dfd7a95c21f0f9bf6e8030d591edd9415c1e9/pkg/control/service_ref_manager.go#L140

and fix etjob gitImage which didn't exist before.


