### PR TITLE
Move policy v1beta1 to v1.

### DIFF
--- a/charts/tfjob/templates/_helpers.tpl
+++ b/charts/tfjob/templates/_helpers.tpl
@@ -24,6 +24,14 @@ If release name contains chart name it will be used as a full name.
 {{- end -}}
 {{- end -}}
 
+{{- define "policy.api" }}
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1" -}}
+v1beta1
+{{- else -}}
+v1
+{{- end }}
+{{- end }}
+
 {{/*
 Create chart name and version as used by the chart label.
 */}}

--- a/charts/tfjob/templates/pdb.yaml
+++ b/charts/tfjob/templates/pdb.yaml
@@ -6,7 +6,7 @@
 {{- if .Values.ps }}
 {{- if .Values.hasGangScheduler }}
 {{- if .Values.enableGangScheduler }}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ .Release.Name }}

--- a/charts/tfjob/templates/pdb.yaml
+++ b/charts/tfjob/templates/pdb.yaml
@@ -6,7 +6,11 @@
 {{- if .Values.ps }}
 {{- if .Values.hasGangScheduler }}
 {{- if .Values.enableGangScheduler }}
+{{- if eq (include "policy.api" .) "v1beta1" -}}
+apiVersion: policy/v1beta1
+{{- else }}
 apiVersion: policy/v1
+{{- end }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ .Release.Name }}


### PR DESCRIPTION
The api policy/v1beta1 will be deprecated in versions greater than kubernetes 1.26.