### PR TITLE
Fix evaluatejob job yaml in charts.

### DIFF
--- a/charts/evaluatejob/templates/job.yaml
+++ b/charts/evaluatejob/templates/job.yaml
@@ -117,12 +117,12 @@ spec:
           - name: code-sync
             mountPath: /code
         {{- end }}
-        {{- if ne (len .Values.imagePullSecrets) 0 }}
-        imagePullSecrets:
-        {{- range $imagePullSecret := .Values.imagePullSecrets }}
-          - name: "{{ $imagePullSecret }}"
-        {{- end }}
-        {{- end }}
+      {{- if ne (len .Values.imagePullSecrets) 0 }}
+      imagePullSecrets:
+      {{- range $imagePullSecret := .Values.imagePullSecrets }}
+        - name: "{{ $imagePullSecret }}"
+      {{- end }}
+      {{- end }}
       containers:
         - name: evaluatejob
           {{- if .Values.image }}


### PR DESCRIPTION
The rendering of imagePullSecrets in the chart does not conform to the format.