### PR TITLE
Fix panic when pod started failed

### DIFF
--- a/docs/cli/arena_serve_custom.md
+++ b/docs/cli/arena_serve_custom.md
@@ -13,7 +13,7 @@ arena serve custom [flags]
 ### Options
 
 ```
-  -a, --annotation stringArray     the annotations
+  -a, --annotation stringArray     the annotations, usage: "--annotation=key=value" or "--annotation key=value"
       --cpu string                 the request cpu of each replica to run the serve.
   -d, --data stringArray           specify the trained models datasource to mount for serving, like <name_of_datasource>:<mount_point_on_job>
       --data-subpath-expr stringArray  specify the datasource subpath to mount to the job by expression, like <name_of_datasource>:<mount_subpath_expr>

--- a/docs/cli/arena_serve_kfserving.md
+++ b/docs/cli/arena_serve_kfserving.md
@@ -13,7 +13,7 @@ arena serve kfserving [flags]
 ### Options
 
 ```
-  -a, --annotation stringArray     the annotations
+  -a, --annotation stringArray     the annotations, usage: "--annotation=key=value" or "--annotation key=value"
       --canary-percent int         the percent of the desired canary
       --cpu string                 the request cpu of each replica to run the serve.
   -d, --data stringArray           specify the trained models datasource to mount for serving, like <name_of_datasource>:<mount_point_on_job>

--- a/docs/cli/arena_serve_seldon.md
+++ b/docs/cli/arena_serve_seldon.md
@@ -13,7 +13,7 @@ arena serve seldon [flags]
 ### Options
 
 ```
-  -a, --annotation stringArray     the annotations
+  -a, --annotation stringArray     the annotations, usage: "--annotation=key=value" or "--annotation key=value"
       --cpu string                 the request cpu of each replica to run the serve.
   -d, --data stringArray           specify the trained models datasource to mount for serving, like <name_of_datasource>:<mount_point_on_job>
       --data-dir stringArray       specify the trained models datasource on host to mount for serving, like <host_path>:<mount_point_on_job>

--- a/docs/cli/arena_serve_tensorflow.md
+++ b/docs/cli/arena_serve_tensorflow.md
@@ -13,7 +13,7 @@ arena serve tensorflow [flags]
 ### Options
 
 ```
-  -a, --annotation stringArray     the annotations
+  -a, --annotation stringArray     the annotations, usage: "--annotation=key=value" or "--annotation key=value"
       --command string             the command will inject to container's command.
       --cpu string                 the request cpu of each replica to run the serve.
   -d, --data stringArray           specify the trained models datasource to mount for serving, like <name_of_datasource>:<mount_point_on_job>

--- a/docs/cli/arena_serve_tensorrt.md
+++ b/docs/cli/arena_serve_tensorrt.md
@@ -14,7 +14,7 @@ arena serve tensorrt [flags]
 
 ```
       --allow-metrics              Open Metric
-  -a, --annotation stringArray     the annotations
+  -a, --annotation stringArray     the annotations, usage: "--annotation=key=value" or "--annotation key=value"
       --command string             the command will inject to container's command.
       --cpu string                 the request cpu of each replica to run the serve.
   -d, --data stringArray           specify the trained models datasource to mount for serving, like <name_of_datasource>:<mount_point_on_job>

--- a/docs/cli/arena_submit_etjob.md
+++ b/docs/cli/arena_submit_etjob.md
@@ -13,7 +13,7 @@ arena submit etjob [flags]
 ### Options
 
 ```
-  -a, --annotation strings          the annotations
+  -a, --annotation strings          the annotations, usage: "--annotation=key=value" or "--annotation key=value"
       --config-file strings         giving configuration files when submiting jobs,usage:"--config-file <host_path_file>:<container_path_file>"
       --cpu string                  the cpu resource to use for the training, like 1 for 1 core.
   -d, --data strings                specify the datasource to mount to the job, like <name_of_datasource>:<mount_point_on_job>

--- a/docs/cli/arena_submit_horovodjob.md
+++ b/docs/cli/arena_submit_horovodjob.md
@@ -13,7 +13,7 @@ arena submit horovodjob [flags]
 ### Options
 
 ```
-  -a, --annotation strings          the annotations
+  -a, --annotation strings          the annotations, usage: "--annotation=key=value" or "--annotation key=value"
       --config-file strings         giving configuration files when submiting jobs,usage:"--config-file <host_path_file>:<container_path_file>"
       --cpu string                  the cpu resource to use for the training, like 1 for 1 core.
   -d, --data strings                specify the datasource to mount to the job, like <name_of_datasource>:<mount_point_on_job>

--- a/docs/cli/arena_submit_mpijob.md
+++ b/docs/cli/arena_submit_mpijob.md
@@ -13,7 +13,7 @@ arena submit mpijob [flags]
 ### Options
 
 ```
-  -a, --annotation strings          the annotations
+  -a, --annotation strings          the annotations, usage: "--annotation=key=value" or "--annotation key=value"
       --config-file strings         giving configuration files when submiting jobs,usage:"--config-file <host_path_file>:<container_path_file>"
       --cpu string                  the cpu resource to use for the training, like 1 for 1 core.
   -d, --data strings                specify the datasource to mount to the job, like <name_of_datasource>:<mount_point_on_job>

--- a/docs/cli/arena_submit_pytorchjob.md
+++ b/docs/cli/arena_submit_pytorchjob.md
@@ -13,7 +13,7 @@ arena submit pytorchjob [flags]
 ### Options
 
 ```
-  -a, --annotation strings          the annotations
+  -a, --annotation strings          the annotations, usage: "--annotation=key=value" or "--annotation key=value"
       --clean-task-policy string    How to clean tasks after Training is done, support None, Running, All. (default "None")
       --config-file strings         giving configuration files when submiting jobs,usage:"--config-file <host_path_file>:<container_path_file>"
       --cpu string                  the cpu resource to use for the training, like 1 for 1 core.

--- a/docs/cli/arena_submit_tfjob.md
+++ b/docs/cli/arena_submit_tfjob.md
@@ -13,7 +13,7 @@ arena submit tfjob [flags]
 ### Options
 
 ```
-  -a, --annotation strings           the annotations
+  -a, --annotation strings           the annotations, usage: "--annotation=key=value" or "--annotation key=value"
       --chief                        enable chief, which is required for estimator.
       --chief-cpu string             the cpu resource to use for the Chief, like 1 for 1 core.
       --chief-cpu-limit string       the cpu resource limit to use for the Chief, like 1 for 1 core.      

--- a/docs/serving/tfserving/monitor.md
+++ b/docs/serving/tfserving/monitor.md
@@ -100,7 +100,7 @@ Aliases:
   tensorflow, tf
 
 Flags:
-  -a, --annotation stringArray          specify the annotations
+  -a, --annotation stringArray          specify the annotations, usage: "--annotation=key=value" or "--annotation key=value"
       --command string                  the command will inject to container's command.
       --cpu string                      the request cpu of each replica to run the serve.
   -d, --data stringArray                specify the trained models datasource to mount for serving, like <name_of_datasource>:<mount_point_on_job>

--- a/pkg/apis/utils/pods.go
+++ b/pkg/apis/utils/pods.go
@@ -305,8 +305,11 @@ func GetRunningTimeOfPod(pod *v1.Pod) time.Duration {
 		allContainerStatuses = append(allContainerStatuses, s)
 	}
 	startTime, endTime = getStartTimeAndEndTime(allContainerStatuses)
-	if startTime == nil {
+	if startTime == nil && pod.Status.StartTime != nil {
 		startTime = pod.Status.StartTime
+	}
+	if startTime == nil {
+		startTime = &pod.CreationTimestamp
 	}
 	if pod.Status.Phase == v1.PodRunning || endTime == nil {
 		return metav1.Now().Sub(startTime.Time)

--- a/pkg/argsbuilder/evaluatejob.go
+++ b/pkg/argsbuilder/evaluatejob.go
@@ -82,7 +82,7 @@ func (e *EvaluateJobArgsBuilder) AddCommandFlags(command *cobra.Command) {
 	command.Flags().StringVar(&e.args.Memory, "memory", "", "the request memory of each replica to run the evaluate job.")
 
 	command.Flags().StringArrayVarP(&envs, "env", "e", []string{}, "the environment variables")
-	command.Flags().StringArrayVarP(&annotations, "annotation", "a", []string{}, "the annotations")
+	command.Flags().StringArrayVarP(&annotations, "annotation", "a", []string{}, `the annotations, usage: "--annotation=key=value" or "--annotation key=value"`)
 	command.Flags().StringArrayVarP(&labels, "label", "", []string{}, "the labels")
 	command.Flags().StringArrayVar(&tolerations, "toleration", []string{}, `tolerate some k8s nodes with taints,usage: "--toleration key=value:effect,operator" or "--toleration all" `)
 	// add option --selector, it's value will be get from viper

--- a/pkg/argsbuilder/model.go
+++ b/pkg/argsbuilder/model.go
@@ -87,7 +87,7 @@ func (m *ModelArgsBuilder) AddCommandFlags(command *cobra.Command) {
 	command.Flags().StringArrayVarP(&dataset, "data", "d", []string{}, "specify the trained models datasource to mount for serving, like <name_of_datasource>:<mount_point_on_job>")
 	command.Flags().StringArrayVarP(&datadir, "data-dir", "", []string{}, "specify the trained models datasource on host to mount for serving, like <host_path>:<mount_point_on_job>")
 	command.Flags().StringArrayVarP(&envs, "env", "e", []string{}, "the environment variables")
-	command.Flags().StringArrayVarP(&annotations, "annotation", "a", []string{}, "specify the annotations")
+	command.Flags().StringArrayVarP(&annotations, "annotation", "a", []string{}, `specify the annotations, usage: "--annotation=key=value" or "--annotation key=value"`)
 	command.Flags().StringArrayVarP(&labels, "label", "l", []string{}, "specify the labels")
 	command.Flags().StringArrayVarP(&tolerations, "toleration", "", []string{}, `tolerate some k8s nodes with taints,usage: "--toleration key=value:effect,operator" or "--toleration all" `)
 	command.Flags().StringArrayVarP(&selectors, "selector", "", []string{}, `assigning jobs to some k8s particular nodes, usage: "--selector=key=value" or "--selector key=value" `)

--- a/pkg/argsbuilder/serving.go
+++ b/pkg/argsbuilder/serving.go
@@ -133,7 +133,7 @@ func (s *ServingArgsBuilder) AddCommandFlags(command *cobra.Command) {
 	command.Flags().StringArrayVarP(&tempDir, "temp-dir", "", []string{}, "specify the deployment empty dir, like <empty_dir_name>:<mount_point_on_pod>")
 	command.MarkFlagRequired("name")
 
-	command.Flags().StringArrayVarP(&annotations, "annotation", "a", []string{}, "specify the annotations")
+	command.Flags().StringArrayVarP(&annotations, "annotation", "a", []string{}, `specify the annotations, usage: "--annotation=key=value" or "--annotation key=value"`)
 	command.Flags().StringArrayVarP(&labels, "label", "l", []string{}, "specify the labels")
 	command.Flags().StringArrayVarP(&tolerations, "toleration", "", []string{}, `tolerate some k8s nodes with taints,usage: "--toleration key=value:effect,operator" or "--toleration all" `)
 	command.Flags().StringArrayVarP(&selectors, "selector", "", []string{}, `assigning jobs to some k8s particular nodes, usage: "--selector=key=value" or "--selector key=value" `)

--- a/pkg/argsbuilder/submit.go
+++ b/pkg/argsbuilder/submit.go
@@ -111,7 +111,7 @@ func (s *SubmitArgsBuilder) AddCommandFlags(command *cobra.Command) {
 	command.Flags().MarkDeprecated("dataDir", "please use --data-dir instead")
 	command.Flags().StringArrayVar(&dataDir, "data-dir", []string{}, "the data dir. If you specify /data, it means mounting hostpath /data into container path /data")
 	// add option --annotation,its' value will be get from viper
-	command.Flags().StringArrayVarP(&annotations, "annotation", "a", []string{}, "the annotations")
+	command.Flags().StringArrayVarP(&annotations, "annotation", "a", []string{}, `the annotations, usage: "--annotation=key=value" or "--annotation key=value"`)
 	command.Flags().StringArrayVarP(&labels, "label", "l", []string{}, "specify the label")
 	// enable RDMA or not, support hostnetwork for now
 	// add option --rdma

--- a/pkg/argsbuilder/submit_sparkjob.go
+++ b/pkg/argsbuilder/submit_sparkjob.go
@@ -81,7 +81,7 @@ func (s *SubmitSparkJobArgsBuilder) AddCommandFlags(command *cobra.Command) {
 	command.Flags().StringVar(&s.args.Driver.MemoryRequest, "driver-memory-request", "500m", "memory request for driver pod (min is 500m)")
 	command.Flags().IntVar(&s.args.Executor.CPURequest, "executor-cpu-request", 1, "cpu request for executor pod")
 	command.Flags().StringVar(&s.args.Executor.MemoryRequest, "executor-memory-request", "500m", "memory request for executor pod (min is 500m)")
-	command.Flags().StringArrayVarP(&annotations, "annotation", "a", []string{}, "the annotations")
+	command.Flags().StringArrayVarP(&annotations, "annotation", "a", []string{}, `the annotations, usage: "--annotation=key=value" or "--annotation key=value"`)
 	command.Flags().StringArrayVarP(&labels, "label", "l", []string{}, "specify the label")
 	s.AddArgValue("annotation", &annotations).AddArgValue("label", &labels)
 }

--- a/pkg/argsbuilder/submit_volcanojob.go
+++ b/pkg/argsbuilder/submit_volcanojob.go
@@ -96,7 +96,7 @@ func (s *SubmitVolcanoJobArgsBuilder) AddCommandFlags(command *cobra.Command) {
 	command.Flags().IntVar(&s.args.TaskPort, "taskPort", 2222, "the task port number. default value is 2222")
 	command.Flags().MarkDeprecated("taskPort", "please use --task-port instead")
 	command.Flags().IntVar(&s.args.TaskPort, "task-port", 2222, "the task port number. default value is 2222")
-	command.Flags().StringArrayVarP(&annotations, "annotation", "a", []string{}, "the annotations")
+	command.Flags().StringArrayVarP(&annotations, "annotation", "a", []string{}, `the annotations, usage: "--annotation=key=value" or "--annotation key=value"`)
 	command.Flags().StringArrayVarP(&labels, "label", "l", []string{}, "specify the label")
 	s.AddArgValue("annotation", &annotations).AddArgValue("label", &labels)
 }

--- a/pkg/argsbuilder/update_serving.go
+++ b/pkg/argsbuilder/update_serving.go
@@ -80,7 +80,7 @@ func (s *UpdateServingArgsBuilder) AddCommandFlags(command *cobra.Command) {
 	command.Flags().StringVar(&s.args.Memory, "memory", "", "the request memory of each replica to run the serve.")
 	command.Flags().IntVar(&s.args.Replicas, "replicas", 0, "the replicas number of the serve job.")
 	command.Flags().StringArrayVarP(&envs, "env", "e", []string{}, "the environment variables")
-	command.Flags().StringArrayVarP(&annotations, "annotation", "a", []string{}, "specify the annotations")
+	command.Flags().StringArrayVarP(&annotations, "annotation", "a", []string{}, `specify the annotations, usage: "--annotation=key=value" or "--annotation key=value"`)
 	command.Flags().StringArrayVarP(&labels, "label", "l", []string{}, "specify the labels")
 	command.Flags().StringVar(&s.args.Command, "command", "", "the command will inject to container's command.")
 	command.Flags().StringArrayVarP(&selectors, "selector", "", []string{}, `assigning jobs to some k8s particular nodes, usage: "--selector=key=value" or "--selector key=value" `)


### PR DESCRIPTION
when pod started failed,  pod.Status.StartTime could be nil.

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x2136762]

goroutine 1 [running]:
github.com/kubeflow/arena/pkg/apis/utils.GetRunningTimeOfPod(0xc000801000, 0x0)
	/go/src/github.com/kubeflow/arena/pkg/apis/utils/pods.go:312 +0x282
github.com/kubeflow/arena/pkg/apis/utils.GetDurationOfPod(0xc000801000, 0x0)
	/go/src/github.com/kubeflow/arena/pkg/apis/utils/pods.go:350 +0x52
github.com/kubeflow/arena/pkg/training.BuildJobInfo(0x294ad40, 0xc00063e870, 0x266b200, 0x37b5a88, 0x0, 0x0, 0xc00079d498, 0x1, 0x1, 0x1)
	/go/src/github.com/kubeflow/arena/pkg/training/get_advanced.go:121 +0x4c9
github.com/kubeflow/arena/pkg/training.PrintTrainingJob(0x294ad40, 0xc00063e870, 0x266b3c5, 0x4, 0x2660000)
	/go/src/github.com/kubeflow/arena/pkg/training/get.go:178 +0xfe
github.com/kubeflow/arena/pkg/apis/arenaclient.(*TrainingJobClient).GetAndPrint(0xc0004d7c78, 0x7ff7bfeff7fa, 0xc, 0x266bc9d, 0x5, 0x266b3c5, 0x4, 0x2660000, 0x4, 0xc0002180f0)
	/go/src/github.com/kubeflow/arena/pkg/apis/arenaclient/training_client.go:117 +0x25e
github.com/kubeflow/arena/pkg/commands/training.NewGetCommand.func2(0xc0004b5b80, 0xc000218090, 0x1, 0x3, 0x0, 0x0)
	/go/src/github.com/kubeflow/arena/pkg/commands/training/get.go:65 +0x492
github.com/kubeflow/arena/vendor/github.com/spf13/cobra.(*Command).execute(0xc0004b5b80, 0xc000218000, 0x3, 0x3, 0xc0004b5b80, 0xc000218000)
	/go/src/github.com/kubeflow/arena/vendor/github.com/spf13/cobra/command.go:826 +0x453
github.com/kubeflow/arena/vendor/github.com/spf13/cobra.(*Command).ExecuteC(0xc0001ad680, 0x16, 0x0, 0x16)
	/go/src/github.com/kubeflow/arena/vendor/github.com/spf13/cobra/command.go:914 +0x2fb
github.com/kubeflow/arena/vendor/github.com/spf13/cobra.(*Command).Execute(...)
	/go/src/github.com/kubeflow/arena/vendor/github.com/spf13/cobra/command.go:864
main.main()
	/go/src/github.com/kubeflow/arena/cmd/arena/main.go:59 +0x86
```