### PR TITLE
Add value.yaml for Alibaba Cloud ACK@Edge

### DIFF
--- a/arena-artifacts/edge-value.yaml
+++ b/arena-artifacts/edge-value.yaml
@@ -1,0 +1,150 @@
+# Default values for arena-artifacts on Alibaba Cloud ACK@Edge.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# global configuration for all subcharts
+global:
+  # pull image by aliyun vpc network
+  pullImageByVPCNetwork: false
+  # the prefix of all image
+  imagePrefix: registry.cn-zhangjiakou.aliyuncs.com
+  # the cluster type
+  clusterProfile: "Default"
+  # specfiy the nodeSelector for all operator pods
+  nodeSelector:
+    alibabacloud.com/is-edge-worker: "false"
+  namespace: "arena-system"
+
+# arena binary installer
+binary:
+  enabled: false
+  masterCount: 3
+  retry: 3
+  hostNetwork: true
+  rdma: true
+  image: acs/arena-deploy-manager
+  tag: latest
+  imagePullPolicy: IfNotPresent
+
+# tf-operator
+tf:
+  enabled: true
+  image: acs/tf_operator
+  tag: v1.0-aliyun-b81dfd7
+  imagePullPolicy: IfNotPresent
+  resources:
+    limits:
+      cpu: 200m
+      memory: 2Gi
+    requests:
+      cpu: 100m
+      memory: 256Mi
+  nodeSelector:
+    alibabacloud.com/is-edge-worker: "false"
+# tf-dashboard
+tfdashboard:
+  enabled: true
+  image: acs/tf_operator
+  tag: v1.0-aliyun-84c8c66
+  imagePullPolicy: IfNotPresent
+  resources:
+    limits:
+      cpu: 200m
+      memory: 2Gi
+    requests:
+      cpu: 50m
+      memory: 256Mi
+  nodeSelector:
+    alibabacloud.com/is-edge-worker: "false"
+
+# mpi-operator
+mpi:
+  enabled: true
+  image: acs/mpi-operator
+  tag: v0.1.0-aliyun-cc4b2b5
+  kubectlDelivery:
+    image: acs/kubectl-delivery
+    tag: v0.1.0
+  imagePullPolicy: IfNotPresent
+  resources:
+    limits:
+      cpu: 200m
+      memory: 2Gi
+    requests:
+      cpu: 100m
+      memory: 256Mi
+  nodeSelector:
+    alibabacloud.com/is-edge-worker: "false"
+
+# pytorch-operator
+pytorch:
+  enabled: true
+  image: acs/pytorch-operator
+  tag: v1.0-aliyun-eaeb50c
+  imagePullPolicy: IfNotPresent
+  resources:
+    limits:
+      cpu: 200m
+      memory: 2Gi
+    requests:
+      cpu: 100m
+      memory: 256Mi
+  nodeSelector:
+    alibabacloud.com/is-edge-worker: "false"
+
+# et-operator
+et:
+  enabled: true
+  image: acs/et-operator
+  tag: v0.1.3-aliyun-8aff240
+  imagePullPolicy: IfNotPresent
+  resources:
+    limits:
+      cpu: 200m
+      memory: 2Gi
+    requests:
+      cpu: 100m
+      memory: 256Mi
+  nodeSelector:
+    alibabacloud.com/is-edge-worker: "false"
+
+# cron-operator
+cron:
+  enabled: true
+  image: acs/cron-operator
+  tag: v0.1.1
+  imagePullPolicy: IfNotPresent
+  resources:
+    limits:
+      cpu: 200m
+      memory: 2Gi
+    requests:
+      cpu: 100m
+      memory: 256Mi
+  nodeSelector:
+    alibabacloud.com/is-edge-worker: "false"
+
+# gpu-exporter
+exporter:
+  enabled: false
+  image: acs/gpu-prometheus-exporter
+  tag: v1.0.1-b2c2f9b
+  imagePullPolicy: IfNotPresent
+  nodeSelector:
+    alibabacloud.com/is-edge-worker: "false"
+
+# elastic-job-supervisor
+elastic-job-supervisor:
+  enabled: true
+  image: acs/elastic-job-supervisor
+  tag: v0.1.1-71871cc-aliyun
+  imagePullPolicy: IfNotPresent
+  resources:
+    limits:
+      cpu: 300m
+      memory: 500Mi
+    requests:
+      cpu: 100m
+      memory: 300Mi
+  nodeSelector:
+    alibabacloud.com/is-edge-worker: "false"


### PR DESCRIPTION
In Alibaba Cloud ACK@Edge, we aim to schedule each Kubeflow operator component to cloud nodes on ECS, so I set a nodeSelector with the value of 'alibabacloud.com/is-edge-worker: "false"' in the installer's values.