### PR TITLE
support config request resources in kserve runtime

### DIFF
--- a/charts/kserve/templates/inferenceservice.yaml
+++ b/charts/kserve/templates/inferenceservice.yaml
@@ -103,6 +103,12 @@ spec:
           aliyun.com/gpu-core.percentage: {{ .Values.gpuCore }}
           {{- end }}
         requests:
+          {{- if .Values.cpu }}
+          cpu: {{ .Values.cpu }}
+          {{- end }}
+          {{- if .Values.memory }}
+          memory: {{ .Values.memory }}
+          {{- end }}
           {{- if gt (int $gpuCount) 0}}
           nvidia.com/gpu: {{ .Values.gpuCount }}
           {{- end }}
@@ -171,6 +177,12 @@ spec:
           {{- end }}
         resources:
           requests:
+            {{- if .Values.cpu }}
+            cpu: {{ .Values.cpu }}
+            {{- end }}
+            {{- if .Values.memory }}
+            memory: {{ .Values.memory }}
+            {{- end }}
             {{- if gt (int $gpuCount) 0}}
             nvidia.com/gpu: {{ .Values.gpuCount }}
             {{- end }}

--- a/pkg/serving/update.go
+++ b/pkg/serving/update.go
@@ -563,6 +563,19 @@ func setInferenceServiceForCustomModel(args *types.UpdateKServeArgs, inferenceSe
 		inferenceService.Spec.Predictor.Containers[0].Image = args.Image
 	}
 
+	// set resources requests
+	resourceRequests := inferenceService.Spec.Predictor.Containers[0].Resources.Requests
+	if resourceRequests == nil {
+		resourceRequests = make(map[v1.ResourceName]resource.Quantity)
+	}
+	if args.Cpu != "" {
+		resourceRequests[v1.ResourceCPU] = resource.MustParse(args.Cpu)
+	}
+	if args.Memory != "" {
+		resourceRequests[v1.ResourceMemory] = resource.MustParse(args.Memory)
+	}
+	inferenceService.Spec.Predictor.Containers[0].Resources.Requests = resourceRequests
+
 	// set resources limits
 	resourceLimits := inferenceService.Spec.Predictor.Containers[0].Resources.Limits
 	if resourceLimits == nil {


### PR DESCRIPTION
/kind feature

The default request resource of kserve is 
```
requests:
          cpu: 1
          memory: 2Gi
```
So, if set `--cpu=500m --memory=1Gi` by command line, the inference pod can not running.

## Release Note
```
If the user sets `--cpu=xxx --memory=xxx` through the command line, the request and limit resources need to be configured at the same time.
```