### PR TITLE
Feature/kserve custom metrics prometheus

### DIFF
--- a/charts/kserve/templates/_helpers.tpl
+++ b/charts/kserve/templates/_helpers.tpl
@@ -60,3 +60,22 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+
+{{/*
+Support scale according to custom metrics
+See the doc for details. https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#scaling-on-custom-metrics
+*/}}
+{{- define "kserve.isCustomMetrics" -}}
+{{- if .Values.scaleMetric }}
+    {{- $supportedMetrics := list "cpu" "memory" "rps" "concurrency"}}
+    {{- $metrics := .Values.scaleMetric | lower }}
+    {{- if has $metrics $supportedMetrics }}
+        {{- false }}
+    {{- else }}
+        {{- true }}
+    {{- end -}}
+{{- else }}
+  {{- false }}
+{{- end }}
+{{- end -}}

--- a/charts/kserve/templates/inferenceservice.yaml
+++ b/charts/kserve/templates/inferenceservice.yaml
@@ -8,6 +8,12 @@ metadata:
   {{- range $key, $value := .Values.annotations }}
     {{ $key }}: {{ $value | quote }}
   {{- end }}
+  {{- if eq (include "kserve.isCustomMetrics" .) "true" }}
+    serving.kserve.io/autoscalerClass: external
+  {{- end }}
+  {{- if .Values.enablePrometheus }}
+    serving.kserve.io/enable-prometheus-scraping: "true"
+  {{- end }}
   labels:
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}
@@ -21,7 +27,10 @@ metadata:
   name: {{ .Release.Name }}
 spec:
   predictor:
+    {{- if eq (include "kserve.isCustomMetrics" .) "false" }}
+    {{- if .Values.minReplicas }}
     minReplicas: {{ .Values.minReplicas }}
+    {{- end }}
     {{- if .Values.maxReplicas }}
     maxReplicas: {{ .Values.maxReplicas }}
     {{- end }}
@@ -31,6 +40,7 @@ spec:
     {{- if .Values.scaleMetric }}
     scaleMetric: {{ .Values.scaleMetric }}
     {{- end }}
+    {{- end}}
     {{- if .Values.containerConcurrency }}
     containerConcurrency: {{ .Values.containerConcurrency }}
     {{- end }}
@@ -299,3 +309,68 @@ spec:
           name: {{ $releaseName }}-{{ $containerPathKey }}
       {{- end }}
       {{- end }}
+---
+{{- if eq (include "kserve.isCustomMetrics" .) "true" }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ .Release.Name }}-hpa
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name:  {{ .Release.Name }}-predictor
+  {{- if .Values.minReplicas }}
+  minReplicas: {{ .Values.minReplicas }}
+  {{- end }}
+  {{- if .Values.maxReplicas }}
+  maxReplicas: {{ .Values.maxReplicas }}
+  {{- end }}
+  metrics:
+    - type: Pods
+      pods:
+        metric:
+          {{- if .Values.scaleMetric }}
+          name: {{ .Values.scaleMetric }}
+          {{- end }}
+        target:
+          type: Utilization
+          {{- if .Values.scaleTarget }}
+          averageValue: {{ .Values.scaleTarget }}
+          {{- end}}
+{{- end }}
+---
+{{- if .Values.enablePrometheus }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-metric-svc
+  labels:
+    isvc: {{ .Release.Name }}
+spec:
+  selector:
+    serving.kserve.io/inferenceservice: {{ .Release.Name }}
+  clusterIP: None
+  ports:
+    - name: metric
+      protocol: TCP
+      port: {{ .Values.metricsPort}}
+      targetPort: {{ .Values.metricsPort}}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ .Release.Name }}-svcmonitor
+  annotations:
+    arms.prometheus.io/discovery: 'true'
+spec:
+  selector:
+    matchLabels:
+      isvc: {{ .Release.Name }}
+  namespaceSelector:
+    any: true
+  endpoints:
+    - port: metric
+      path: /metrics
+      interval: 15s
+{{- end }}

--- a/pkg/apis/types/serving.go
+++ b/pkg/apis/types/serving.go
@@ -245,6 +245,8 @@ type KServeArgs struct {
 	TimeoutSeconds       int64        `yaml:"timeout"`                        // --timeout
 	CanaryTrafficPercent int64        `yaml:"canaryTrafficPercent,omitempty"` // --canary-traffic-percent
 	Port                 int          `yaml:"port"`                           // --port
+	EnablePrometheus     bool         `yaml:"enablePrometheus,omitempty"`     //--enable-prometheus
+	MetricsPort          int          `yaml:"metricsPort,omitempty"`          //--metrics-port
 	CommonServingArgs    `yaml:",inline"`
 }
 

--- a/pkg/argsbuilder/serving_kserve.go
+++ b/pkg/argsbuilder/serving_kserve.go
@@ -91,6 +91,10 @@ func (s *KServeArgsBuilder) AddCommandFlags(command *cobra.Command) {
 	command.Flags().Int64Var(&s.args.TimeoutSeconds, "timeout", 0, "the number of seconds to wait before timing out a request to the component.")
 	command.Flags().Int64Var(&s.args.CanaryTrafficPercent, "canary-traffic-percent", -1, "the traffic split percentage between the candidate revision and the last ready revision")
 
+	// Prometheus metrics
+	command.Flags().BoolVar(&s.args.EnablePrometheus, "enable-prometheus", false, "enable prometheus scraping the metrics of inference services")
+	command.Flags().IntVar(&s.args.MetricsPort, "metrics-port", 8080, "the port which inference services expose metrics, default: 8080")
+
 	s.AddArgValue(KServeModelFormat, &modelFormat)
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:

## Features
### 1. KServe support autoscaling according custom metrics by HPA
### 2. KServe support expose metrics automatically by `--enable-prometheus` & `--metrics-port`