### PR TITLE
fix get kserve job panic

### DIFF
--- a/pkg/apis/arenaclient/serving_client.go
+++ b/pkg/apis/arenaclient/serving_client.go
@@ -84,8 +84,11 @@ func (t *ServingJobClient) GetAndPrint(jobName, version string, jobType types.Se
 	}
 
 	// Search model version associated with the job
-	jobLabels := job.GetLabels()
-	mv := searchModelVersionByJobLabels(t.namespace, t.configer, jobLabels)
+	var mv *types.ModelVersion
+	if job.Deployment() != nil {
+		jobLabels := job.GetLabels()
+		mv = searchModelVersionByJobLabels(t.namespace, t.configer, jobLabels)
+	}
 	serving.PrintServingJob(job, mv, utils.TransferPrintFormat(format))
 	return nil
 }


### PR DESCRIPTION
/kind  bugfix

Run command `serve get qwen --type kserve`

Output errors:
```
报错内容：goroutine 1 [running]:
github.com/kubeflow/arena/pkg/serving.(*servingJob).GetLabels(...)
        /Users/baizi/Documents/code/src/github.com/kubeflow/arena/pkg/serving/serving.go:321
github.com/kubeflow/arena/pkg/apis/arenaclient.(*ServingJobClient).GetAndPrint(0x14000c8fbc0, {0x16efeb584, 0x4}, {0x0, 0x0}, {0x10263e759, 0x6}, {0x10263c896, 0x4})
        /Users/baizi/Documents/code/src/github.com/kubeflow/arena/pkg/apis/arenaclient/serving_client.go:90 +0x310
github.com/kubeflow/arena/pkg/commands/serving.NewGetCommand.func2(0x1400029c800?, {0x14000983bf0?, 0x4?, 0x10263c8c2?})
        /Users/baizi/Documents/code/src/github.com/kubeflow/arena/pkg/commands/serving/get.go:60 +0x244
github.com/kubeflow/arena/vendor/github.com/spf13/cobra.(*Command).execute(0x140008da008, {0x14000983b90, 0x3, 0x3})
        /Users/baizi/Documents/code/src/github.com/kubeflow/arena/vendor/github.com/spf13/cobra/command.go:940 +0x654
github.com/kubeflow/arena/vendor/github.com/spf13/cobra.(*Command).ExecuteC(0x14000434c08)
        /Users/baizi/Documents/code/src/github.com/kubeflow/arena/vendor/github.com/spf13/cobra/command.go:1068 +0x320
github.com/kubeflow/arena/vendor/github.com/spf13/cobra.(*Command).Execute(0x1400008c6f8?)
        /Users/baizi/Documents/code/src/github.com/kubeflow/arena/vendor/github.com/spf13/cobra/command.go:992 +0x1c
main.main()
        /Users/baizi/Documents/code/src/github.com/kubeflow/arena/cmd/arena/main.go:63 +0x300
```