### PR TITLE
change kserve prom svc to ClusterIP 

### DIFF
--- a/charts/kserve/templates/inferenceservice.yaml
+++ b/charts/kserve/templates/inferenceservice.yaml
@@ -350,7 +350,6 @@ metadata:
 spec:
   selector:
     serving.kserve.io/inferenceservice: {{ .Release.Name }}
-  clusterIP: None
   ports:
     - name: metric
       protocol: TCP


### PR DESCRIPTION
/kind feature

change kserve prom svc to ClusterIP according to https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/user-guides/getting-started.md