### PR TITLE
docs: fix broken links and add CI for checking document build status

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -77,3 +77,19 @@ jobs:
       - name: Build Java SDK
         run: |
           make java-sdk
+
+  build-docs:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.11
+
+      - name: Build docs
+        run: |
+          pip install -r docs/requirements.txt
+          mkdocs build --strict

--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,13 @@
-.kube
 bin/
 Library
+public/
+site/
 tmp/
 sdk/arena-python-sdk/dist/
 sdk/arena-python-sdk/build/
 sdk/arena-python-sdk/arenasdk.egg-info/
-
+.hugo_build.lock
+.kube
 *.tgz
 *.tar.gz
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,1 @@
-mkdocs-material
+mkdocs-material == 9.5.34

--- a/docs/serving/tfserving/update-serving.md
+++ b/docs/serving/tfserving/update-serving.md
@@ -1,6 +1,6 @@
 This recipe suggest how to update the tensorflow serving after it has deployed.
 
-1\. Deploy a tensorflow serving job follow the [submit a tensorflow serving job which uses gpus](tfserving/gpu.md).
+1\. Deploy a tensorflow serving job follow the [submit a tensorflow serving job which uses gpus](gpu.md).
 
 2\. Update the serving.
 

--- a/docs/serving/triton/update-serving.md
+++ b/docs/serving/triton/update-serving.md
@@ -1,6 +1,6 @@
 This recipe suggest how to update the triton serving after it has deployed.
 
-1\. Deploy a triton serving job follow the [submit a nvidia triton serving job which use gpus](triton/serving.md).
+1\. Deploy a triton serving job follow the [submit a nvidia triton serving job which use gpus](serving.md).
 
 2\. Update the serving.
 


### PR DESCRIPTION
**What this PR does / why we need it**:

- Fix broken links in tensorflow/triton serving documentation
- Add CI for checking whether docs can be built correctly without errors and warnings

**Rational**:

There is some broken doc links when building arena documentation:

```bash
$ mkdocs build --strict
INFO    -  Cleaning site directory
INFO    -  Building documentation to directory: /Users/chenyi/code/github.com/kubeflow/arena/site
...
WARNING -  Doc file 'serving/tfserving/update-serving.md' contains a link 'tfserving/gpu.md', but the target 'serving/tfserving/tfserving/gpu.md' is not found among documentation files.
WARNING -  Doc file 'serving/triton/update-serving.md' contains a link 'triton/serving.md', but the target 'serving/triton/triton/serving.md' is not found among documentation files.

Aborted with 2 warnings in strict mode!
```