### PR TITLE
Bump client-java from 10.0.1 to 11.0.1

### DIFF
--- a/sdk/arena-java-sdk/pom.xml
+++ b/sdk/arena-java-sdk/pom.xml
@@ -18,7 +18,7 @@
         <dependency>
             <groupId>io.kubernetes</groupId>
             <artifactId>client-java</artifactId>
-            <version>10.0.1</version>
+            <version>11.0.1</version>
             <exclusions>
                 <exclusion>
                     <groupId>io.sundr</groupId>


### PR DESCRIPTION
**What this PR does / why we need it**:

- Bump client-java from 10.0.1 to 11.0.1