### PR TITLE
fix: failed to sync cache due to status subresouce missed in tfjob CRD

### DIFF
--- a/arena-artifacts/all_crds/v1/tf-operator/kubeflow.org_tfjobs_v1.yaml
+++ b/arena-artifacts/all_crds/v1/tf-operator/kubeflow.org_tfjobs_v1.yaml
@@ -6,7 +6,7 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.15.0
     git-repo: https://github.com/AliyunContainerService/tf-operator
     git-branch: v1.0-aliyun-branch
-    git-commit: a0bb318635fbf624d277e6981e62ba0b46e20ee2
+    git-commit: c36c43433bccfa740b1dec5e0e7cd4091d08fd27
   name: tfjobs.kubeflow.org
 spec:
   group: kubeflow.org
@@ -17,7 +17,14 @@ spec:
     singular: tfjob
   scope: Namespaced
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[-1:].type
+      name: State
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
     schema:
       openAPIV3Schema:
         description: Represents a TFJob resource.
@@ -4358,3 +4365,5 @@ spec:
         type: object
     served: true
     storage: true
+    subresources:
+      status: {}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Arena, check the developer guide:
    https://arena-docs.readthedocs.io/en/latest/
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

## Purpose of this PR

<!-- Provide a clear and concise description of the changes. Explain the motivation behind these changes and link to relevant issues or discussions. -->

Close #1174 

**Proposed changes:**

- Replace TFJob CRD with [kubeflow.org_tfjobs.yaml](https://github.com/AliyunContainerService/tf-operator/blob/c36c43433bccfa740b1dec5e0e7cd4091d08fd27/manifests/base/crds/kubeflow.org_tfjobs.yaml)

## Change Category

<!-- Indicate the type of change by marking the applicable boxes. -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

<!-- Provide reasoning for the changes if not already covered in the description above. -->