### PR TITLE
fix: pytorchjob does not support backoff limit

### DIFF
--- a/charts/pytorchjob/templates/pytorchjob.yaml
+++ b/charts/pytorchjob/templates/pytorchjob.yaml
@@ -31,6 +31,7 @@ spec:
     {{- if .Values.ttlSecondsAfterFinished }}
     ttlSecondsAfterFinished: {{ .Values.ttlSecondsAfterFinished }}
     {{- end }}
+    backoffLimit: {{ .Values.retry }}
 {{- else }}
   {{- if .Values.cleanPodPolicy }}
   cleanPodPolicy: {{ .Values.cleanPodPolicy }}
@@ -41,6 +42,7 @@ spec:
   {{- if .Values.ttlSecondsAfterFinished }}
   ttlSecondsAfterFinished: {{ .Values.ttlSecondsAfterFinished }}
   {{- end }}
+  backoffLimit: {{ .Values.retry }}
 {{- end }}
   pytorchReplicaSpecs:
     Master:


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Arena, check the developer guide:
    https://arena-docs.readthedocs.io/en/latest/
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

## Purpose of this PR

<!-- Provide a clear and concise description of the changes. Explain the motivation behind these changes and link to relevant issues or discussions. -->

**Proposed changes:**

- arena should set `backoffLimit` of pytorchjob when `arena submit pytorchjob --retry <n>`

## Change Category

<!-- Indicate the type of change by marking the applicable boxes. -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

<!-- Provide reasoning for the changes if not already covered in the description above. -->