### PR TITLE
fix: service account should use release namespace

### DIFF
--- a/arena-artifacts/charts/elastic-job-supervisor/templates/rbac.yaml
+++ b/arena-artifacts/charts/elastic-job-supervisor/templates/rbac.yaml
@@ -46,12 +46,12 @@ rules:
   - '*'
   verbs:
   - '*'
+
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: elastic-job-supervisor
-  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "arena.labels" . | nindent 4 }}
 roleRef:

--- a/arena-artifacts/charts/tf-operator/templates/operator-rbac.yaml
+++ b/arena-artifacts/charts/tf-operator/templates/operator-rbac.yaml
@@ -2,38 +2,22 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  name: tf-job-operator
+  namespace: {{ .Release.Namespace }}
   labels:
     app: tf-job-operator
     kustomize.component: tf-job-operator
     {{- include "arena.labels" . | nindent 4 }}
-  name: tf-job-operator
-  namespace: arena-system
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  labels:
-    app: tf-job-operator
-    kustomize.component: tf-job-operator
-    {{- include "arena.labels" . | nindent 4 }}
-  name: tf-job-operator
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: tf-job-operator
-subjects:
-  - kind: ServiceAccount
-    name: tf-job-operator
-    namespace: arena-system
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  name: tf-job-operator
   labels:
     app: tf-job-operator
     kustomize.component: tf-job-operator
     {{- include "arena.labels" . | nindent 4 }}
-  name: tf-job-operator
 rules:
   - apiGroups:
       - tensorflow.org
@@ -98,3 +82,21 @@ rules:
       - patch
       - update
       - watch
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: tf-job-operator
+  labels:
+    app: tf-job-operator
+    kustomize.component: tf-job-operator
+    {{- include "arena.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tf-job-operator
+subjects:
+- kind: ServiceAccount
+  name: tf-job-operator
+  namespace: {{ .Release.Namespace }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Arena, check the developer guide:
    https://arena-docs.readthedocs.io/en/latest/
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

## Purpose of this PR

<!-- Provide a clear and concise description of the changes. Explain the motivation behind these changes and link to relevant issues or discussions. -->

**Proposed changes:**

- Use release namespace instead of using fixed namespace `arena-system`
- Remove namespace field from cluster scoped resource

## Change Category

<!-- Indicate the type of change by marking the applicable boxes. -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

<!-- Provide reasoning for the changes if not already covered in the description above. -->