### PR TITLE
Feat: support affinity policy for kserve and tfjob

### DIFF
--- a/charts/kserve/templates/_helpers.tpl
+++ b/charts/kserve/templates/_helpers.tpl
@@ -79,3 +79,51 @@ See the doc for details. https://kubernetes.io/docs/tasks/run-application/horizo
   {{- false }}
 {{- end }}
 {{- end -}}
+
+{{- define "setAffinityFunction" -}}
+{{- $affinityPolicy := .Values.affinityPolicy -}}
+{{- $affinityConstraint := .Values.affinityConstraint -}}
+
+{{- if eq $affinityPolicy "spread" -}}
+{{- if eq $affinityConstraint "preferred" -}}
+affinity:
+  podAntiAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+      - podAffinityTerm:
+          labelSelector:
+            matchLabels:
+              servingName: "{{ .Values.servingName }}"
+          topologyKey: kubernetes.io/hostname
+        weight: 100
+{{- else if eq $affinityConstraint "required" -}}
+affinity:
+  podAntiAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+    - labelSelector:
+        matchLabels:
+          servingName: "{{ .Values.servingName }}"
+      topologyKey: kubernetes.io/hostname
+{{- end -}}
+
+{{- else if eq $affinityPolicy "binpack" -}}
+{{- if eq $affinityConstraint "preferred" -}}
+affinity:
+  podAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+      - podAffinityTerm:
+          labelSelector:
+            matchLabels:
+              servingName: "{{ .Values.servingName }}"
+          topologyKey: kubernetes.io/hostname
+        weight: 100
+{{- else if eq $affinityConstraint "required" -}}
+affinity:
+  podAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+    - labelSelector:
+        matchLabels:
+          servingName: "{{ .Values.servingName }}"
+      topologyKey: kubernetes.io/hostname
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/kserve/templates/inferenceservice.yaml
+++ b/charts/kserve/templates/inferenceservice.yaml
@@ -27,6 +27,7 @@ metadata:
   name: {{ .Release.Name }}
 spec:
   predictor:
+    {{- include "setAffinityFunction" . | nindent 4 }}
     {{- if eq (include "kserve.isCustomMetrics" .) "false" }}
     {{- if .Values.minReplicas }}
     minReplicas: {{ .Values.minReplicas }}

--- a/charts/tfjob/templates/_helpers.tpl
+++ b/charts/tfjob/templates/_helpers.tpl
@@ -38,3 +38,216 @@ Create chart name and version as used by the chart label.
 {{- define "tfjob.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+
+{{- define "setPSAffinityFunction" -}}
+{{- $affinityPolicy := .Values.affinityPolicy -}}
+{{- $affinityConstraint := .Values.affinityConstraint -}}
+
+{{- if eq $affinityPolicy "spread" -}}
+{{- if eq $affinityConstraint "preferred" -}}
+affinity:
+  podAntiAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          topologyKey: kubernetes.io/hostname
+          labelSelector:
+            matchExpressions:
+              - key: release
+                operator: In
+                values:
+                  - "{{ .Release.Name }}"
+              - key: group-name
+                operator: In
+                values:
+                  - "kubeflow.org"
+              - key: tf-replica-type
+                operator: In
+                values:
+                  - ps
+{{- else if eq $affinityConstraint "required" -}}
+affinity:
+  podAntiAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      - topologyKey: kubernetes.io/hostname
+        labelSelector:
+          matchExpressions:
+            - key: release
+              operator: In
+              values:
+                - "{{ .Release.Name }}"
+            - key: group-name
+              operator: In
+              values:
+                - "kubeflow.org"
+            - key: tf-replica-type
+              operator: In
+              values:
+                - ps
+{{- end -}}
+
+{{- else if eq $affinityPolicy "binpack" -}}
+{{- if eq $affinityConstraint "preferred" -}}
+affinity:
+  podAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+    - weight: 100
+      podAffinityTerm:
+        topologyKey: kubernetes.io/hostname
+        labelSelector:
+          matchExpressions:
+            - key: release
+              operator: In
+              values:
+                - "{{ .Release.Name }}"
+            - key: group-name
+              operator: In
+              values:
+                - "kubeflow.org"
+    - weight: 60
+      podAffinityTerm:
+        topologyKey: kubernetes.io/hostname
+        labelSelector:
+          matchExpressions:
+            - key: tf-replica-type
+              operator: In
+              values:
+                - worker
+    - weight: 30
+      podAffinityTerm:
+        topologyKey: kubernetes.io/hostname
+        labelSelector:
+          matchExpressions:
+            - key: tf-replica-type
+              operator: In
+              values:
+                - ps
+{{- else if eq $affinityConstraint "required" -}}
+affinity:
+  podAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+    - topologyKey: kubernetes.io/hostname
+      labelSelector:
+        matchExpressions:
+          - key: release
+            operator: In
+            values:
+              - "{{ .Release.Name }}"
+          - key: group-name
+            operator: In
+            values:
+              - "kubeflow.org"
+          - key: tf-replica-type
+            operator: In
+            values:
+              - ps
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+
+{{- define "setWorkerAffinityFunction" -}}
+{{- $affinityPolicy := .Values.affinityPolicy -}}
+{{- $affinityConstraint := .Values.affinityConstraint -}}
+
+{{- if eq $affinityPolicy "spread" -}}
+{{- if eq $affinityConstraint "preferred" -}}
+affinity:
+  podAntiAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          topologyKey: kubernetes.io/hostname
+          labelSelector:
+            matchExpressions:
+              - key: release
+                operator: In
+                values:
+                  - "{{ .Release.Name }}"
+              - key: group-name
+                operator: In
+                values:
+                  - "kubeflow.org"
+              - key: tf-replica-type
+                operator: In
+                values:
+                  - worker
+{{- else if eq $affinityConstraint "required" -}}
+affinity:
+  podAntiAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      - topologyKey: kubernetes.io/hostname
+        labelSelector:
+          matchExpressions:
+            - key: release
+              operator: In
+              values:
+                - "{{ .Release.Name }}"
+            - key: group-name
+              operator: In
+              values:
+                - "kubeflow.org"
+            - key: tf-replica-type
+              operator: In
+              values:
+                - worker
+{{- end -}}
+{{- else if eq $affinityPolicy "binpack" -}}
+{{- if eq $affinityConstraint "preferred" -}}
+affinity:
+  podAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+    - weight: 100
+      podAffinityTerm:
+        topologyKey: kubernetes.io/hostname
+        labelSelector:
+          matchExpressions:
+            - key: release
+              operator: In
+              values:
+                - "{{ .Release.Name }}"
+            - key: group-name
+              operator: In
+              values:
+                - "kubeflow.org"
+    - weight: 60
+      podAffinityTerm:
+        topologyKey: kubernetes.io/hostname
+        labelSelector:
+          matchExpressions:
+            - key: tf-replica-type
+              operator: In
+              values:
+                - ps
+    - weight: 30
+      podAffinityTerm:
+        topologyKey: kubernetes.io/hostname
+        labelSelector:
+          matchExpressions:
+            - key: tf-replica-type
+              operator: In
+              values:
+                - worker
+{{- else if eq $affinityConstraint "required" -}}
+affinity:
+  podAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+    - topologyKey: kubernetes.io/hostname
+      labelSelector:
+        matchExpressions:
+          - key: release
+            operator: In
+            values:
+              - "{{ .Release.Name }}"
+          - key: group-name
+            operator: In
+            values:
+              - "kubeflow.org"
+          - key: tf-replica-type
+            operator: In
+            values:
+              - worker
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/tfjob/templates/tfjob.yaml
+++ b/charts/tfjob/templates/tfjob.yaml
@@ -109,42 +109,7 @@ spec:
           {{- end }}
           {{- end }}
           {{- end }}
-          {{- if .Values.binpack }}
-          affinity:
-            podAffinity:
-              preferredDuringSchedulingIgnoredDuringExecution:
-              - weight: 100
-                podAffinityTerm:
-                  topologyKey: kubernetes.io/hostname
-                  labelSelector:
-                    matchExpressions:
-                      - key: release
-                        operator: In
-                        values:
-                          - "{{ .Release.Name }}"
-                      - key: group-name
-                        operator: In
-                        values:
-                          - "kubeflow.org"
-              - weight: 60
-                podAffinityTerm:
-                  topologyKey: kubernetes.io/hostname
-                  labelSelector:
-                    matchExpressions:
-                      - key: tf-replica-type
-                        operator: In
-                        values:
-                          - worker
-              - weight: 30
-                podAffinityTerm:
-                  topologyKey: kubernetes.io/hostname
-                  labelSelector:
-                    matchExpressions:
-                      - key: tf-replica-type
-                        operator: In
-                        values:
-                          - ps      
-          {{- end }}
+          {{- include "setPSAffinityFunction" . | nindent 10 }}
           {{- if .Values.useHostNetwork }}
           {{- if not .Values.useENI }}
           hostNetwork: {{ .Values.useHostNetwork }}
@@ -441,42 +406,7 @@ spec:
           {{- end }}
           {{- end }}
           {{- if .Values.ps }}
-          {{- if .Values.binpack }}
-          affinity:
-            podAffinity:
-              preferredDuringSchedulingIgnoredDuringExecution:
-              - weight: 100
-                podAffinityTerm:
-                  topologyKey: kubernetes.io/hostname
-                  labelSelector:
-                    matchExpressions:
-                      - key: release
-                        operator: In
-                        values:
-                          - "{{ .Release.Name }}"
-                      - key: group-name
-                        operator: In
-                        values:
-                          - "kubeflow.org"
-              - weight: 60
-                podAffinityTerm:
-                  topologyKey: kubernetes.io/hostname
-                  labelSelector:
-                    matchExpressions:
-                      - key: tf-replica-type
-                        operator: In
-                        values:
-                          - ps
-              - weight: 30
-                podAffinityTerm:
-                  topologyKey: kubernetes.io/hostname
-                  labelSelector:
-                    matchExpressions:
-                      - key: tf-replica-type
-                        operator: In
-                        values:
-                          - worker      
-          {{- end }}
+          {{- include "setWorkerAffinityFunction" . | nindent 10 }}
           {{- end }}
           {{- if .Values.useHostNetwork }}
           {{- if not .Values.useENI }}

--- a/pkg/apis/types/serving.go
+++ b/pkg/apis/types/serving.go
@@ -191,12 +191,14 @@ type CommonServingArgs struct {
 	TempDirs           map[string]string `yaml:"tempDirs"`            // --temp-dir
 	ShareMemory        string            `yaml:"shareMemory"`         // --share-memory
 
-	ImagePullSecrets []string          `yaml:"imagePullSecrets"` //--image-pull-secrets
-	HostVolumes      []DataDirVolume   `yaml:"dataDirs"`         // --data-dir
-	NodeSelectors    map[string]string `yaml:"nodeSelectors"`    // --selector
-	Tolerations      []TolerationArgs  `yaml:"tolerations"`      // --toleration
-	Annotations      map[string]string `yaml:"annotations"`
-	Labels           map[string]string `yaml:"labels"` // --label
+	ImagePullSecrets   []string          `yaml:"imagePullSecrets"`   //--image-pull-secrets
+	HostVolumes        []DataDirVolume   `yaml:"dataDirs"`           // --data-dir
+	NodeSelectors      map[string]string `yaml:"nodeSelectors"`      // --selector
+	Tolerations        []TolerationArgs  `yaml:"tolerations"`        // --toleration
+	AffinityPolicy     string            `yaml:"affinityPolicy"`     // --affinity-policy
+	AffinityConstraint string            `yaml:"affinityConstraint"` // --affinity-constraint
+	Annotations        map[string]string `yaml:"annotations"`
+	Labels             map[string]string `yaml:"labels"` // --label
 	// ConfigFiles stores the config file which is existed in client host node
 	// and map it to container,match option --config-file
 	ConfigFiles map[string]map[string]ConfigFileInfo `yaml:"configFiles"`

--- a/pkg/apis/types/submit_tfjob.go
+++ b/pkg/apis/types/submit_tfjob.go
@@ -49,6 +49,10 @@ type SubmitTFJobArgs struct {
 	PSMemoryLimit string `yaml:"psMemoryLimit"`
 	// SuccessPolicy defines the policy to mark the TFJob as succeeded.
 	SuccessPolicy string `yaml:"successPolicy"`
+	// AffinityPolicy defines the affinity policy to schedule pods.
+	AffinityPolicy string `yaml:"affinityPolicy"`
+	// AffinityConstraint defines the affinity constraint rule during scheduling.
+	AffinityConstraint string `yaml:"affinityConstraint"`
 	// CleanPodPolicy stores the cleaning pod policy,match option --clean-task-policy
 	CleanPodPolicy string `yaml:"cleanPodPolicy"`
 	// UseChief stores the using chief or not,match option --chief

--- a/pkg/argsbuilder/serving_kserve.go
+++ b/pkg/argsbuilder/serving_kserve.go
@@ -92,6 +92,8 @@ func (s *KServeArgsBuilder) AddCommandFlags(command *cobra.Command) {
 	command.Flags().Int64Var(&s.args.TimeoutSeconds, "timeout", 0, "the number of seconds to wait before timing out a request to the component.")
 	command.Flags().Int64Var(&s.args.CanaryTrafficPercent, "canary-traffic-percent", -1, "the traffic split percentage between the candidate revision and the last ready revision")
 	command.Flags().StringArrayVar(&securityContext, "security-context", []string{}, `configure a security context, only support runAsUser, runAsGroup, fsGroup, usage: "--security-context runAsUser=1000"`)
+	command.Flags().StringVar(&s.args.AffinityPolicy, "affinity-policy", "none", `specify the pod affinity policy during scheduling, default is none. usage: "--affinity-policy=spread" or "--affinity-policy=binpack"`)
+	command.Flags().StringVar(&s.args.AffinityConstraint, "affinity-constraint", "preferred", `specify the affinity constraint rule during scheduling, default is "preferred". usage: "--affinity-constraint=preferred" or "-affinity-constraint=required"`)
 
 	// Prometheus metrics
 	command.Flags().BoolVar(&s.args.EnablePrometheus, "enable-prometheus", false, "enable prometheus scraping the metrics of inference services")

--- a/pkg/argsbuilder/submit_tfjob.go
+++ b/pkg/argsbuilder/submit_tfjob.go
@@ -136,6 +136,8 @@ func (s *SubmitTFJobArgsBuilder) AddCommandFlags(command *cobra.Command) {
 	command.Flags().StringVar(&s.args.PSMemoryLimit, "ps-memory-limit", "", "the memory resource limit to use for the parameter servers, like 1Gi.")
 
 	command.Flags().StringVar(&s.args.SuccessPolicy, "success-policy", TFJobSuccessPolicyChiefWorker, "Specifies the policy to mark the TFJob as succeeded. Available options are ChiefWorker and AllWorkers. Default to ChiefWorker.")
+	command.Flags().StringVar(&s.args.AffinityPolicy, "affinity-policy", "none", `specify the pod affinity policy during scheduling, default is none. usage: "--affinity-policy=spread" or "--affinity-policy=binpack"`)
+	command.Flags().StringVar(&s.args.AffinityConstraint, "affinity-constraint", "preferred", `specify the affinity constraint rule during scheduling, default is "preferred". usage: "--affinity-constraint=preferred" or "-affinity-constraint=required"`)
 
 	// How to clean up Task
 	command.Flags().StringVar(&s.args.CleanPodPolicy, "cleanTaskPolicy", "Running", "How to clean tasks after Training is done, support Running, None and All.")


### PR DESCRIPTION
This PR introduces two new flags for deploying kserve's isvc through arena:

```
--affinity-policy, which specifies the pod affinity policy. Determines if pods should be dispersed (spread) across nodes or consolidated (pinback) onto a single node.

--affinity-constraint, which specifies the affinity constraint rule during scheduling. Indicates if the affinity rule is strictly required or just preferred.
```

By using these two flags, when deploying kserve's inference service, kserve's predictor instances can be spread across different nodes to avoid single points of failure and ensure high availability, or be deployed on a single node to fully utilize node resources.