### PR TITLE
Fix: tfjob gets stuck in running state when succeeded pods are garbage collected

### DIFF
--- a/arena-artifacts/all_crds/v1/tf-operator/kubeflow.org_tfjobs_v1.yaml
+++ b/arena-artifacts/all_crds/v1/tf-operator/kubeflow.org_tfjobs_v1.yaml
@@ -3,10 +3,10 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.14.0
     git-repo: https://github.com/AliyunContainerService/tf-operator
-    git-branch: v1.0-aliyun-branch
-    git-commit: c36c43433bccfa740b1dec5e0e7cd4091d08fd27
+    git-branch: ack-tf-operator
+    git-commit: f12d01efd919078ee0ae94bbe1d58b1ba416ad43
   name: tfjobs.kubeflow.org
 spec:
   group: kubeflow.org
@@ -4341,6 +4341,10 @@ spec:
                       type: integer
                     failed:
                       description: The number of pods which reached phase Failed.
+                      format: int32
+                      type: integer
+                    pending:
+                      description: The number of pending pods.
                       format: int32
                       type: integer
                     succeeded:

--- a/arena-artifacts/values.yaml
+++ b/arena-artifacts/values.yaml
@@ -31,7 +31,7 @@ binary:
 tf:
   enabled: true
   image: acs/tf-operator
-  tag: aliyun-8d9ac19
+  tag: aliyun-f12d01e
   imagePullPolicy: IfNotPresent
   replicas: 1
   resources:


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Arena, check the developer guide:
    https://arena-docs.readthedocs.io/en/latest/
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

## Purpose of this PR

<!-- Provide a clear and concise description of the changes. Explain the motivation behind these changes and link to relevant issues or discussions. -->

**Proposed changes:**

- Update TFJob CRD and tf-operator image, see https://github.com/AliyunContainerService/tf-operator/pull/44.

## Change Category

<!-- Indicate the type of change by marking the applicable boxes. -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

<!-- Provide reasoning for the changes if not already covered in the description above. -->