### PR TITLE
feature(tf-operator): make workers, qps and burst configurable

### DIFF
--- a/arena-artifacts/charts/tf-operator/templates/operator-dp.yaml
+++ b/arena-artifacts/charts/tf-operator/templates/operator-dp.yaml
@@ -28,7 +28,9 @@ spec:
         - --alsologtostderr
         - -v=1
         - --monitoring-port=8443
-        - --threadiness=4
+        - --threadiness={{ .Values.controller.workers }}
+        - --qps={{ .Values.controller.clientConnection.qps }}
+        - --burst={{ .Values.controller.clientConnection.burst }}
         env:
         - name: MY_POD_NAMESPACE
           valueFrom:

--- a/arena-artifacts/charts/tf-operator/values.yaml
+++ b/arena-artifacts/charts/tf-operator/values.yaml
@@ -4,3 +4,14 @@
 
 # -- Replicas of tf-operator deployment.
 replicas: 1
+
+# Controller configurations.
+controller:
+  # -- Number of workers for controller.
+  workers: 10
+  # -- Client connection configurations.
+  clientConnection:
+    # -- QPS is the number of queries per second allowed for K8S api server connection.
+    qps: 10
+    # --  Burst allows extra queries to accumulate when a client is exceeding its rate.
+    burst: 30

--- a/arena-artifacts/values.yaml
+++ b/arena-artifacts/values.yaml
@@ -31,9 +31,19 @@ binary:
 tf:
   enabled: true
   image: acs/tf-operator
-  tag: aliyun-f12d01e
+  tag: 2cbb568
   imagePullPolicy: IfNotPresent
   replicas: 1
+  # Controller configurations.
+  controller:
+    # -- Number of workers for controller.
+    workers: 10
+    # -- Client connection configurations.
+    clientConnection:
+      # -- QPS is the number of queries per second allowed for K8S api server connection.
+      qps: 10
+      # --  Burst allows extra queries to accumulate when a client is exceeding its rate.
+      burst: 30
   resources:
     limits:
       cpu: 2


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Arena, check the developer guide:
    https://arena-docs.readthedocs.io/en/latest/
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

## Purpose of this PR

<!-- Provide a clear and concise description of the changes. Explain the motivation behind these changes and link to relevant issues or discussions. -->

**Proposed changes:**
    
- Add controller worker, QPS, and burst configurations to values.yaml
- Update operator deployment to use new configuration values
- Upgrade tf-operator image

## Change Category

<!-- Indicate the type of change by marking the applicable boxes. -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

<!-- Provide reasoning for the changes if not already covered in the description above. -->