### PR TITLE
fix(cron-operator): reconcile worker hangs due to invalid cron expression

### DIFF
--- a/arena-artifacts/charts/cron-operator/templates/operator-dp.yaml
+++ b/arena-artifacts/charts/cron-operator/templates/operator-dp.yaml
@@ -30,6 +30,7 @@ spec:
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         args: 
         - --workloads=Cron
+        - --max-reconciles=10
         ports:
         - containerPort: 8443
           name: metrics

--- a/arena-artifacts/values.yaml
+++ b/arena-artifacts/values.yaml
@@ -123,7 +123,7 @@ et:
 cron:
   enabled: true
   image: acs/cron-operator
-  tag: aliyun-0f570ce
+  tag: aliyun-7421146f
   imagePullPolicy: IfNotPresent
   replicas: 1
   # -- Whether to use host timezone in the container.


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Arena, check the developer guide:
    https://arena-docs.readthedocs.io/en/latest/
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

## Purpose of this PR

<!-- Provide a clear and concise description of the changes. Explain the motivation behind these changes and link to relevant issues or discussions. -->

**Proposed changes:**

- feature(cron-operator): increase reconcile worker threads from 3 (default) to 10
- fix(cron-operator): reconcile worker hangs due to invalid cron expression

## Change Category

<!-- Indicate the type of change by marking the applicable boxes. -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

<!-- Provide reasoning for the changes if not already covered in the description above. -->