### PR TITLE
fix: add ownerReferences to resources created by arena

### DIFF
--- a/pkg/workflow/workflow.go
+++ b/pkg/workflow/workflow.go
@@ -24,8 +24,6 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-
-	"github.com/kubeflow/arena/pkg/apis/types"
 )
 
 /**
@@ -200,13 +198,10 @@ func SubmitJob(name string, trainingType string, namespace string, values interf
 		return err
 	}
 
-	// 6. Patch OwnerReference for tfjob / pytorchjob
-	if trainingType == string(types.TFTrainingJob) ||
-		trainingType == string(types.PytorchTrainingJob) {
-		err := kubectl.PatchOwnerReferenceWithAppInfoFile(name, trainingType, appInfoFileName, namespace)
-		if err != nil {
-			log.Debugf("Failed to patch ownerReference %s due to %v`", name, err)
-		}
+	// 6. Patch OwnerReference for all training job types
+	err = kubectl.PatchOwnerReferenceWithAppInfoFile(name, trainingType, appInfoFileName, namespace)
+	if err != nil {
+		log.Debugf("Failed to patch ownerReference %s due to %v", name, err)
 	}
 
 	// 7. Clean up the template file


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Arena, check the developer guide:
    https://arena-docs.readthedocs.io/en/latest/
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

## Purpose of this PR
Close https://github.com/kubeflow/arena/issues/1339
<!-- Provide a clear and concise description of the changes. Explain the motivation behind these changes and link to relevant issues or discussions. -->

**Proposed changes:**

Call PatchOwnerReferenceWithAppInfoFile to add an ownerReference to all resources, pointing to the training job's CRD.

## Change Category

<!-- Indicate the type of change by marking the applicable boxes. -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

<!-- Provide reasoning for the changes if not already covered in the description above. -->