### PR TITLE
chore: add .cursor and .qoder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,9 @@ __pycache__/
 cover.out
 
 # IDE files
+.cursor/
 .idea/
+.qoder/
 .vscode/
 
 # MacOS


### PR DESCRIPTION
## Purpose of this PR

This PR adds `.cursor/` and `.qoder/` directories to the `.gitignore` file to ignore IDE-specific files and directories that should not be committed to version control.

**Proposed changes:**

- Add `.cursor/` directory to IDE files section in `.gitignore`.
- Add `.qoder/` directory to IDE files section in `.gitignore`.

## Change Category

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [x] Documentation update

### Rationale

These IDE-specific directories contain user settings, workspace configurations, and AI assistant context that are specific to individual developers' environments and should not be committed to the repository. Adding them to `.gitignore` helps prevent accidental commits of personal development settings.
