### PR TITLE
feat(cli): add sub-command 'arena llm' as proxy to kubectl-rbg

### DIFF
--- a/pkg/commands/llm/llm.go
+++ b/pkg/commands/llm/llm.go
@@ -1,0 +1,55 @@
+// Copyright 2026 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package llm
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+
+	"github.com/spf13/cobra"
+)
+
+const rbgBinary = "kubectl-rbg"
+
+// NewLLMCommand returns a cobra command that proxies all args to `kubectl-rbg llm ...`.
+func NewLLMCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:                "llm",
+		Short:              "LLM deployment management commands (powered by kubectl-rbg)",
+		Long:               `Commands for managing LLM model deployments. Requires 'kubectl-rbg' binary to be installed.`,
+		DisableFlagParsing: true,
+		SilenceUsage:       true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runRBG(args)
+		},
+	}
+	return cmd
+}
+
+// runRBG delegates execution to `kubectl-rbg llm <args...>`.
+func runRBG(args []string) error {
+	rbgPath, err := exec.LookPath(rbgBinary)
+	if err != nil {
+		return fmt.Errorf("'%s' binary not found in PATH, please install it first: %w", rbgBinary, err)
+	}
+
+	subArgs := append([]string{"llm"}, args...)
+	c := exec.Command(rbgPath, subArgs...)
+	c.Stdin = os.Stdin
+	c.Stdout = os.Stdout
+	c.Stderr = os.Stderr
+	return c.Run()
+}

--- a/pkg/commands/root.go
+++ b/pkg/commands/root.go
@@ -21,6 +21,7 @@ import (
 	"github.com/kubeflow/arena/pkg/commands/cron"
 	"github.com/kubeflow/arena/pkg/commands/data"
 	"github.com/kubeflow/arena/pkg/commands/evaluate"
+	"github.com/kubeflow/arena/pkg/commands/llm"
 	"github.com/kubeflow/arena/pkg/commands/model"
 	"github.com/kubeflow/arena/pkg/commands/serving"
 	"github.com/kubeflow/arena/pkg/commands/top"
@@ -70,5 +71,6 @@ func NewCommand() *cobra.Command {
 	command.AddCommand(evaluate.NewEvaluateCommand())
 	command.AddCommand(NewWhoamiCommand())
 	command.AddCommand(model.NewModelCommand())
+	command.AddCommand(llm.NewLLMCommand())
 	return command
 }


### PR DESCRIPTION
## Summary

Adds a new `llm` subcommand to the `arena` CLI that proxies all arguments to the `kubectl-rbg` binary. This allows users to access LLM deployment management capabilities through a single unified entry point (`arena llm ...`) without merging the two tools' codebases or resolving dependency conflicts.

## Motivation

`kubectl-rbg` provides LLM-related capabilities (service management, model management, benchmarking, etc.) as a separate CLI tool. Requiring users to remember and switch between two binaries degrades the user experience. This change unifies the entry point while keeping both tools independently maintainable.

## Changes

- `pkg/commands/llm/llm.go` — new file; defines `NewLLMCommand()` which delegates to `kubectl-rbg llm <args...>` via `os/exec`, with stdin/stdout/stderr passthrough and a clear error message if `kubectl-rbg` is not found in `$PATH`
- `pkg/commands/root.go` — registers the new `llm` subcommand

## Usage

```bash
# equivalent to: kubectl-rbg llm svc list
arena llm svc list

# equivalent to: kubectl-rbg llm --help
arena llm --help
```
