### PR TITLE
Update installer: package rbgctl into installer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ ARENA_ARTIFACTS_CHART_PATH ?= $(CURRENT_DIR)/arena-artifacts
 # Versions
 GOLANG_VERSION=$(shell grep -e '^go ' go.mod | cut -d ' ' -f 2)
 KUBECTL_VERSION ?= v1.28.4
+RBGCTL_VERSION ?= v0.7.0-alpha.3
 HELM_VERSION ?= $(shell grep -e 'helm.sh/helm/v3 ' go.mod | cut -d ' ' -f 2)
 HELM_UNITTEST_VERSION ?= 0.5.1
 KIND_VERSION ?= v0.23.0
@@ -51,6 +52,7 @@ GOLANGCI_LINT_VERSION ?= v2.1.6
 # Binaries
 ARENA ?= arena-v$(VERSION)-$(OS)-$(ARCH)
 KUBECTL ?= kubectl-$(KUBECTL_VERSION)-$(OS)-$(ARCH)
+RBGCTL ?= kubectl-rbg-$(OS)-$(ARCH)
 HELM ?= helm-$(HELM_VERSION)-$(OS)-$(ARCH)
 KIND ?= $(LOCALBIN)/kind-$(KIND_VERSION)
 ENVTEST ?= $(LOCALBIN)/setup-envtest-$(ENVTEST_VERSION)
@@ -233,13 +235,14 @@ build-dependabot:
 
 .PHONY: arena-installer
 arena-installer: $(ARENA_INSTALLER_TARBALL) ## Build arena installer tarball
-$(ARENA_INSTALLER_TARBALL): arena kubectl helm
+$(ARENA_INSTALLER_TARBALL): arena kubectl helm rbgctl
 	echo "Building arena installer tarball..." && \
 	rm -rf $(TEMPDIR)/$(ARENA_INSTALLER) && \
 	mkdir -p $(TEMPDIR)/$(ARENA_INSTALLER)/bin && \
 	cp $(LOCALBIN)/$(ARENA) $(TEMPDIR)/$(ARENA_INSTALLER)/bin/arena && \
 	cp $(LOCALBIN)/$(KUBECTL) $(TEMPDIR)/$(ARENA_INSTALLER)/bin/kubectl && \
 	cp $(LOCALBIN)/$(HELM) $(TEMPDIR)/$(ARENA_INSTALLER)/bin/helm && \
+	cp $(LOCALBIN)/$(RBGCTL) $(TEMPDIR)/$(ARENA_INSTALLER)/bin/kubectl-rbg && \
 	cp -R charts $(TEMPDIR)/$(ARENA_INSTALLER) && \
 	cp -R arena-artifacts $(TEMPDIR)/$(ARENA_INSTALLER) && \
 	cp arena-gen-kubeconfig.sh $(TEMPDIR)/$(ARENA_INSTALLER)/bin && \
@@ -271,7 +274,6 @@ kubectl: $(LOCALBIN)/$(KUBECTL)
 $(LOCALBIN)/$(KUBECTL): $(LOCALBIN) $(TEMPDIR)
 	$(eval KUBECTL_URL=https://dl.k8s.io/release/$(KUBECTL_VERSION)/bin/$(OS)/$(ARCH)/kubectl)
 	$(eval KUBECTL_SHA_URL=$(KUBECTL_URL).sha256)
-
 	cd $(TEMPDIR) && \
 	echo "Download $(KUBECTL) if not present..." && \
 	if [ ! -f $(KUBECTL) ]; then \
@@ -287,6 +289,27 @@ $(LOCALBIN)/$(KUBECTL): $(LOCALBIN) $(TEMPDIR)
 	chmod +x $(KUBECTL) && \
 	cp $(KUBECTL) $(LOCALBIN) && \
 	echo "Successfully installed kubectl to $(LOCALBIN)/$(KUBECTL)."
+
+.PHONY: rbgctl
+rbgctl: $(LOCALBIN)/$(RBGCTL)
+$(LOCALBIN)/$(RBGCTL): $(LOCALBIN) $(TEMPDIR)
+	$(eval RBGCTL_URL=https://github.com/sgl-project/rbg/releases/download/$(RBGCTL_VERSION)/kubectl-rbg-$(OS)-$(ARCH))
+	$(eval RBGCTL_SHA_URL=$(RBGCTL_URL).sha256)
+	cd $(TEMPDIR) && \
+	echo "Download $(RBGCTL) if not present..." && \
+	if [ ! -f $(RBGCTL) ]; then \
+		curl -sSLo $(RBGCTL) $(RBGCTL_URL); \
+	fi && \
+	echo "Download $(RBGCTL).sha256 if not present..." && \
+	if [ ! -f $(RBGCTL).sha256 ]; then \
+		curl -sSLo $(RBGCTL).sha256 $(RBGCTL_SHA_URL); \
+	fi && \
+	echo "Verifying checksum..." && \
+	echo -n "$$(awk '{print $$1}' $(RBGCTL).sha256)  $(RBGCTL)" | shasum -a 256 --check --quiet || (echo "Checksum verification failed, exiting." && false) && \
+	echo "Make rbgctl executable and move it to bin directory..." && \
+	chmod +x $(RBGCTL) && \
+	cp $(RBGCTL) $(LOCALBIN) && \
+	echo "Successfully installed rbgctl to $(LOCALBIN)/$(RBGCTL)."
 
 .PHONY: helm
 helm: $(LOCALBIN)/$(HELM)

--- a/install.sh
+++ b/install.sh
@@ -84,6 +84,14 @@ function set_sudo() {
     fi
 }
 
+# install rbgctl and rename arena-rbg
+function install_rbgctl() {
+    logger "debug" "start to install arena-rbg"
+    ${sudo_prefix} rm -rf /usr/local/bin/arena-rbg
+    ${sudo_prefix} cp $SCRIPT_DIR/bin/kubectl-rbg /usr/local/bin/arena-rbg
+    logger "debug" "succeed to install arena-rbg"
+}
+
 # install kubectl and rename arena-kubectl
 # install helm and rename arena-helm
 function install_kubectl_and_helm() {
@@ -278,6 +286,7 @@ function install_binary_on_master() {
 
 function binary() {
     install_kubectl_and_helm
+    install_rbgctl
     custom_charts
     install_arena_and_charts
     install_arena_gen_kubeconfig

--- a/pkg/commands/llm/llm.go
+++ b/pkg/commands/llm/llm.go
@@ -22,14 +22,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const rbgBinary = "kubectl-rbg"
+const rbgBinary = "arena-rbg"
 
-// NewLLMCommand returns a cobra command that proxies all args to `kubectl-rbg llm ...`.
+// NewLLMCommand returns a cobra command that proxies all args to `arena-rbg llm ...`.
 func NewLLMCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:                "llm",
-		Short:              "LLM deployment management commands (powered by kubectl-rbg)",
-		Long:               `Commands for managing LLM model deployments. Requires 'kubectl-rbg' binary to be installed.`,
+		Short:              "LLM deployment management commands (powered by arena-rbg)",
+		Long:               `Commands for managing LLM model deployments. Requires 'arena-rbg' binary to be installed.`,
 		DisableFlagParsing: true,
 		SilenceUsage:       true,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -39,7 +39,7 @@ func NewLLMCommand() *cobra.Command {
 	return cmd
 }
 
-// runRBG delegates execution to `kubectl-rbg llm <args...>`.
+// runRBG delegates execution to `arena-rbg llm <args...>`.
 func runRBG(args []string) error {
 	rbgPath, err := exec.LookPath(rbgBinary)
 	if err != nil {


### PR DESCRIPTION
## Summary

Integrate kubectl-rbg (rbgctl) into arena installer, enabling users to install arena-rbg via install.sh in one step.

## Changes

### Makefile
- Add `RBGCTL_VERSION` variable (v0.7.0-alpha.3)
- Add `rbgctl` target to download kubectl-rbg from GitHub with sha256 checksum verification
- Update `arena-installer` target to package kubectl-rbg into installer tarball

### install.sh
- Add `install_rbgctl()` function to install kubectl-rbg as /usr/local/bin/arena-rbg
- Invoke `install_rbgctl` in `binary()` function

### pkg/commands/llm/llm.go
- Change binary name from `kubectl-rbg` to `arena-rbg`
- Update related comments and messages

## Benefits

- Unified installation experience: users can install all required components via install.sh
- Automatic verification: sha256 checksum verification ensures integrity when downloading rbgctl
- Naming consistency: use arena-rbg to maintain consistency with arena-kubectl and arena-helm