### PR TITLE
fix(workflow): make job deletion idempotent

### DIFF
--- a/pkg/workflow/workflow.go
+++ b/pkg/workflow/workflow.go
@@ -43,12 +43,16 @@ func DeleteJob(name, namespace, trainingType string) error {
 	if err != nil {
 		log.Warnf("Failed to UninstallAppsWithAppInfoFile due to %v", err)
 		log.Warnln("manually delete the following resource:")
+		return err
 	}
 
+	// Manual deletion is required because serving, evaluation, and analysis job configmaps do not have an owner reference.
+	// Repeated deletion is idempotent because NotFound errors are ignored.
 	err = kubectl.DeleteAppConfigMap(jobName, namespace)
 	if err != nil {
 		log.Warningf("Delete configmap %s failed, please clean it manually due to %v.", jobName, err)
 		log.Warningf("Please run `kubectl delete -n %s cm %s`", namespace, jobName)
+		return err
 	}
 
 	return nil
@@ -125,7 +129,7 @@ func SubmitOps(name string, trainingType string, namespace string, values interf
 }
 
 /**
-*	Submit training job
+*	Submit training, serving, evaluation and analysis job
 **/
 
 func SubmitJob(name string, trainingType string, namespace string, values interface{}, chart string, options ...string) error {


### PR DESCRIPTION
## Purpose of this PR

Make training job deletion idempotent. Currently, if `UninstallAppsWithAppInfoFile` fails, the job metadata configmap is still deleted without protection. This causes `arena` to lose the ability to find and delete the remaining resources, leaving orphaned jobs that can never be cleaned up through arena.

**Proposed changes:**

- Return error immediately when `UninstallAppsWithAppInfoFile` fails, preventing subsequent configmap deletion and preserving the ability to retry
- Return error when `DeleteAppConfigMap` fails, ensuring the caller is aware of incomplete cleanup (important for serving/evaluate/model jobs whose configmaps lack ownerReference)
- Fix `SubmitJob` comment to accurately reflect all job types it handles

## Change Category

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

The original `DeleteJob` silently continued past failures in both `UninstallAppsWithAppInfoFile` and `DeleteAppConfigMap`, treating them as warnings. This caused two issues:

1. **Orphaned resources**: When resource uninstall partially fails, the configmap (containing the appInfo resource manifest) is deleted. Without appInfo, arena can never locate and delete the remaining resources. The only option is manual `kubectl` cleanup.

2. **False success**: When configmap deletion fails but resource deletion succeeds, the function returns `nil`, misleading the user into thinking cleanup is complete. This can cause subsequent job creation with the same name to fail due to the lingering configmap.

The fix ensures errors propagate immediately, making deletion safe to retry. This applies uniformly to all job types (training, serving, evaluate, and model analyze).