### PR TITLE
kep: add arena v2 proposal

### DIFF
--- a/keps/arena-v2/README.md
+++ b/keps/arena-v2/README.md
@@ -1,0 +1,357 @@
+# Arena v2: AI Workload CLI Redesign
+
+## Table of Contents
+
+- [Arena v2: AI Workload CLI Redesign](#arena-v2-ai-workload-cli-redesign)
+  - [Table of Contents](#table-of-contents)
+  - [Summary](#summary)
+  - [Motivation](#motivation)
+    - [Goals](#goals)
+    - [Non-Goals](#non-goals)
+  - [Proposal](#proposal)
+    - [Architecture Overview](#architecture-overview)
+    - [User Stories](#user-stories)
+    - [Notes/Constraints/Caveats](#notesconstraintscaveats)
+  - [Design Details](#design-details)
+    - [Core Design Principles](#core-design-principles)
+      - [1. Simpler maintenance](#1-simpler-maintenance)
+      - [2. Faster iteration](#2-faster-iteration)
+      - [3. Better user experience](#3-better-user-experience)
+      - [4. Fewer failure modes](#4-fewer-failure-modes)
+      - [5. Reduced attack surface](#5-reduced-attack-surface)
+      - [6. Resource lifecycle](#6-resource-lifecycle)
+    - [Detailed Component Comparison](#detailed-component-comparison)
+    - [Test Plan](#test-plan)
+    - [Graduation Criteria](#graduation-criteria)
+    - [Upgrade / Downgrade Strategy](#upgrade--downgrade-strategy)
+    - [Version Skew Strategy](#version-skew-strategy)
+  - [Production Readiness Review Questionnaire](#production-readiness-review-questionnaire)
+    - [Feature Enablement and Rollback](#feature-enablement-and-rollback)
+    - [Rollout, Upgrade and Rollback Planning](#rollout-upgrade-and-rollback-planning)
+    - [Monitoring Requirements](#monitoring-requirements)
+    - [Dependencies](#dependencies)
+    - [Scalability](#scalability)
+    - [Troubleshooting](#troubleshooting)
+  - [References](#references)
+
+## Summary
+
+Arena v2 is a complete architectural redesign of Arena, addressing fundamental limitations in v1 that made the tool difficult to maintain, extend, and use at scale. The redesign eliminates Helm dependencies, reduces code complexity, introduces YAML-first configuration, and replaces shell-outs with direct Kubernetes API calls.
+
+## Motivation
+
+Arena v1, while functional, suffers from architectural decisions that create significant maintenance burden, slow iteration cycles, and poor user experience at scale.
+
+### Goals
+
+Arena v2 addresses fundamental architectural limitations in Arena v1:
+
+1. **Eliminate Helm dependency** — Generate K8s resources directly in Go, not through Helm chart rendering. This removes 24 Helm charts and the entire Helm Go SDK dependency tree.
+
+2. **YAML-first configuration** — v1 is flag-only (40+ CLI flags for a TFJob) and saves **final** helm chart values into configmap. v2 introduces a structured YAML schema where users can version, review, and reuse job configurations as code. CLI flags remain available for quick submissions.
+
+3. **Reduce code complexity** — v1's training submission path spans thousands lines of Go code across `pkg/commands/`, `pkg/training/`, `pkg/argsbuilder/`, `pkg/apis/`, and `pkg/workflow/`.
+
+4. **Direct K8s API usage** — v1 submits jobs through a 6-step pipeline: serialize args → render Helm chart → save to temp file → create ConfigMap → shell out to `kubectl apply` → patch owner references. v2 keeps owner references patches and calls the K8s dynamic client API directly: `kc.CreateUnstructured(ctx, gvr, crd)`. No temp files, no shell-outs.
+
+5. **Type-agnostic CRD generation** — Use `unstructured.Unstructured` instead of operator-specific Go types. This decouples Arena from specific Training Operator API versions and makes the code resilient to operator upgrades.
+
+### Non-Goals
+
+- **Breaking existing v1 workflows** — v2 provides legacy compatibility through the `arena submit` command that maps v1 flags to v2's internal model.
+- **Supporting all v1 features immediately** — v2 implements features incrementally across three phases, prioritizing core training workloads first.
+- **Replacing all Arena binaries immediately** — v2 coexists with v1 during the transition period, using separate binary names (`arena-v2` during development, `arena` as the final build target).
+
+## Proposal
+
+### Architecture Overview
+
+Arena v2 adopts a modular architecture that separates concerns and reduces coupling:
+
+```
+cmd/arena-v2/main.go          → Entry point
+pkg/cli/                       → Cobra commands (root, run, get, list, delete, stop, resume, logs, submit, version, completion)
+pkg/task/                      → Task data model, YAML loader, flag overrides
+pkg/provider/                  → Provider interface + implementations (PyTorchJob, TFJob, MPIJob)
+pkg/client/                    → K8s dynamic + typed client wrapper
+pkg/output/                    → Table formatting for CLI output
+```
+
+**Provider Interface**: Each framework (PyTorchJob, TFJob, MPIJob) implements `provider.Provider`:
+
+- `BuildCRD(task) → *unstructured.Unstructured` — Task spec to Operator CRD
+- `GetJobStatus()` / `GetPods()` / `GetLogPod()` — Read back status
+- `DefaultValues(task)` — Framework-specific defaults
+
+Adding a new operator = implementing this interface. No Helm charts needed.
+
+### User Stories
+
+**Story 1: Data scientist submitting a distributed training job**
+
+As a data scientist, I want to define my training job configuration in a YAML file so that I can version it in Git, review changes with my team, and reuse the same configuration across multiple experiments without retyping 40+ CLI flags.
+
+**Story 2: Platform engineer adding a new framework**
+
+As a platform engineer, I want to add support for a new training framework (e.g., DeepSpeed) by implementing a single Go file rather than creating a Helm chart, argsbuilder, command file, and type definitions across 5+ files.
+
+**Story 3: Operator maintaining backward compatibility**
+
+As an operator maintaining existing CI/CD pipelines, I want to continue using `arena submit tfjob --name my-job --workers 4 --gpus 2 "python train.py"` without rewriting my automation scripts, while the platform team gradually adopts v2's YAML-based workflows.
+
+### Notes/Constraints/Caveats
+
+- v2 is a separate project that lives in the `v2` branch and is built from scratch, it does not import any v1 packages.
+- The `arena-v2` binary name is temporary for development. The final build target is `arena` — the `-v2` suffix is removed once v2 reaches feature parity.
+- v2's legacy `arena submit` command provides v1-style flag-based submission by mapping old flags to v2's internal `Task` model. Users can continue using v1 syntax without rewriting scripts.
+
+## Design Details
+
+### Core Design Principles
+
+#### 1. Simpler maintenance
+
+The tfjob Helm chart template in v1 is 1,323 lines of nested conditionals for PS/Worker/Chief/Evaluator roles. Every field must be duplicated across different blocks (node selectors, tolerations, volumes, init containers, security contexts). In v2, the same logic is a few hundred lines of Go that programmatically constructs corresponding CR fields maps.
+
+#### 2. Faster iteration
+
+Adding a new field in v1 requires changes in 5 places: types struct, argsbuilder, Helm chart `values.yaml`, Helm chart template, and command file. In v2, adding a field requires updating the YAML schema, the Go struct definition, and the provider relative methods.
+
+#### 3. Better user experience
+
+v1's flag-only interface forces users to retype 20-50 flags for every submission. There is no way to save, review, or version job configurations. v2's YAML schema lets users define jobs once in a file, commit to Git, and share with teammates. CLI flags remain available for quick one-off submissions.
+
+#### 4. Fewer failure modes
+
+v1's 6-step submission pipeline has 5 points where temp files or ConfigMaps can leak if the process crashes mid-submission. v2's direct API call is atomic — either the CRD is created or it isn't.
+
+#### 5. Reduced attack surface
+
+v1 shells out to `helm` and `kubectl`, which requires these binaries in `PATH` and exposes command-line injection risks if user input is not properly escaped. v2 uses Go libraries only — no shell execution.
+
+#### 6. Resource lifecycle
+
+A single `arena job run` submission creates multiple K8s resources: the Operator CRD (PyTorchJob/TFJob/MPIJob), optionally a TensorBoard Deployment+Service, and a ConfigMap storing the original YAML and generated manifest. In v1, these resources are tracked via a resource list in the ConfigMap and deleted through a 3-step pipeline (read ConfigMap → delete resources → delete ConfigMap), which risks resource leaks if the list is incomplete or the process crashes mid-delete.
+
+v2 adopts the same pattern: Deletion becomes a single operation and metadata storage (ConfigMap or a new CRD) respects training job CR `ttlSecondsAfterFinished`  — just deleting the top level resource will trigger K8s garbage collection to cascade-delete all owned resources. This eliminates resource leaks and simplifies `arena job delete` to one API call.
+
+```
+PyTorchJob CRD
+  ├── owns → ConfigMap "my-job" (stores original YAML, a new CRD could replace the native ConfigMap)
+  ├── owns → TensorBoard Deployment
+  └── owns → TensorBoard Service
+```
+
+### Detailed Component Comparison
+
+| Aspect | Arena v1 | Arena v2 |
+|--------|----------|----------|
+| **Job submission** | Helm chart rendering + `kubectl apply` shell-out | Direct K8s dynamic client API |
+| **Configuration** | CLI flags only (no YAML) | YAML schema + CLI flags |
+| **Helm dependency** | Yes — `helm.sh/helm/v3` + 24 charts | No |
+| **kubectl dependency** | Yes — shells out to `kubectl apply/delete` | No — uses `client-go` directly |
+| **Training Go code** | thousands of lines | a few thousand lines |
+| **Helm charts** | 24 charts maintained alongside Go code | 0 |
+| **Temp files per submission** | 3 (values.yaml, rendered manifest, app-info) | 0 |
+| **Resource lifecycle** | 3-step delete (read ConfigMap → delete resources → delete ConfigMap) | 1-step delete (delete anchor resource → K8s GC cascades) |
+| **Per-role config (TFJob)** | 40+ CLI flags (e.g., `--worker-image`, `--ps-cpu`, `--chief-memory`) | `chief/ps` block in YAML with independent per-role declaration |
+| **Adding a new operator** | Implement Go types + argsbuilder + command + Helm chart + chart template | Implement `provider.Provider` interface |
+| **Operator version coupling** | Tightly coupled — must update Go types when operator CRD API changes | Loosely coupled — `unstructured.Unstructured` is version-agnostic |
+| **Binary size** | Larger (Helm SDK + transitive deps) | Smaller (only `client-go` + `cobra`) |
+
+### Test Plan
+
+The test plan for Arena v2 includes:
+
+**Unit tests:**
+
+- YAML schema parsing and validation
+- Flag-to-YAML override merging logic
+- Provider CRD generation (PyTorchJob, TFJob, MPIJob)
+- K8s client wrapper error handling
+
+**Integration tests:**
+
+- End-to-end job submission with `--dry-run` flag
+- Legacy `arena submit` command compatibility
+- Multi-operator scenarios (submit PyTorchJob, then query status, then delete)
+
+**E2E tests:**
+
+- Submit real training jobs to a test cluster
+- Verify CRD structure matches operator expectations
+- Test job lifecycle (submit → running → completed/failed)
+- Validate per-role configuration (worker vs master vs PS)
+
+### Graduation Criteria
+
+**Alpha/MVP (Phase 1 - current):**
+
+- v1 remains the default for production use
+- Legacy arena `submit` command for backward compatibility
+- Core training submission (PyTorchJob, MPIJob) with YAML schema
+- Basic command (`arena version`, `arena help`)
+- Display cluster resource info（`arena top`）
+- Basic job manipulates and status queries (`arena job delete`, `arena job get`, `arena job list`, `arena job status`, `arena job logs`), using `arena job` prefix alias to support v1 `arena delete/get/list/status/logs` commands
+- Add new sub-commands
+  - `job`
+    - `run`，launch a training job from a YAML file and CLI flags
+    - `stop`, stop a running training job (operation, not YAML config)
+    - `resume`, resume a stopped training job (operation, not YAML config)
+  - `check`, check if cluster has already installed required CRD
+
+**Beta (Phase 2 - next):**
+
+- Dry-run mode for CRD inspection
+- Advanced features: `lifecycle` policies, `sync`/`init` containers
+- Users begin migrating simple jobs to v2
+- Comprehensive CLI flag coverage matching v1 functionality
+- Output formats: JSON, YAML, wide
+- InferenceTask kind (RBG only)
+  - Add new sub-commands
+    - `serve`
+- Add DeepSpeed support and example
+- TensorFlow provider
+- Ray provider (RayJob CRD)
+
+**Stable (Phase 3 - future):**
+
+- Platform agnostic configuration via `arena configure`
+- v1 is deprecated but still maintained for bug fixes
+- Agent, evaluation, and benchmark task kinds
+- `arena migrate` tool for converting v1 flag-based invocations to v2 YAML files
+- Multi-model pipeline support
+
+### Upgrade / Downgrade Strategy
+
+**Upgrade path:**
+
+- v2 and v1 coexist during the transition period
+- Users can gradually migrate workloads from v1 to v2
+- No breaking changes to existing v1 workflows
+- Legacy `arena submit` command ensures backward compatibility
+
+**Downgrade path:**
+
+- If v2 introduces regressions, users can continue using v1 binary
+- v2 does not modify v1 code or Helm charts
+- Separate binary names (`arena-v2` during development) prevent conflicts
+
+**Migration tooling:**
+
+- Future `arena migrate` command will convert v1 flag-based invocations to v2 YAML files
+- Helps users transition existing automation scripts without manual rewriting
+
+### Version Skew Strategy
+
+**Operator version compatibility:**
+
+- v2 uses `unstructured.Unstructured` for CRD generation, making it version-agnostic
+- No dependency on specific Training Operator API versions
+- Works with Training Operator and MPI Operator
+
+**Kubernetes version compatibility:**
+
+- v2 depends only on `client-go` and `cobra`
+- Supports any Kubernetes version that client-go supports
+- No dependency on Helm or kubectl binaries
+
+## Production Readiness Review Questionnaire
+
+### Feature Enablement and Rollback
+
+**How can this feature be enabled/disabled?**
+
+- v2 is a separate binary (`arena-v2`) during development, allowing users to opt-in
+- Once v2 reaches feature parity, it replaces the v1 binary (`arena`)
+- Users can continue using v1 by not installing v2
+
+**Can the feature be disabled once it has been enabled?**
+
+- Yes, users can simply not use the v2 binary
+- v2 does not modify v1 code or configuration
+- No cluster-level changes are required
+
+### Rollout, Upgrade and Rollback Planning
+
+**How will this be rolled out?**
+
+- v2 is developed in parallel with v1 on the `v2` branch
+- Users can test v2 in non-production environments first
+- Gradual adoption as v2 reaches feature parity with v1
+
+**What is the rollout plan?**
+
+- Phase 1 (current): Core training submission, v1 remains default
+- Phase 2 (next): Advanced features, users begin migrating simple jobs
+- Phase 3 (future): Full feature parity, v1 deprecated
+
+**How will rollback work if something goes wrong?**
+
+- Users can revert to v1 binary at any time
+- v2 does not modify cluster state or v1 configuration
+- No data migration or rollback procedures required
+
+### Monitoring Requirements
+
+**How can an operator determine if the feature is working correctly?**
+
+- v2 provides `--dry-run` flag for inspecting generated CRDs before submission
+- Job submission logs show API calls and responses
+- `arena job get` and `arena job list` commands show job status
+
+**How can this feature be monitored?**
+
+- Kubernetes metrics for created CRDs (PyTorchJob, TFJob, MPIJob)
+- Job completion/failure rates
+- Submission latency (time from CLI invocation to CRD creation)
+
+### Dependencies
+
+**Does this feature depend on any specific services or components?**
+
+- v2 depends only on `client-go` for Kubernetes API access
+- No dependency on Helm, kubectl, or external binaries
+- Requires Training Operator (or compatible operator) to be installed in the cluster
+
+**Are there any new dependencies introduced?**
+
+- No new dependencies beyond `client-go` and `cobra`
+- v2 removes the Helm dependency entirely
+
+### Scalability
+
+**How does this feature scale?**
+
+- v2 generates CRDs locally and submits them to the Kubernetes API
+- No local resource consumption beyond the CLI process
+- Scalability is limited by Kubernetes API server capacity, not v2
+
+**What are the scalability limits?**
+
+- Same as v1: limited by Kubernetes cluster capacity and operator performance
+- v2 may be slightly faster due to elimination of Helm rendering and shell-outs
+
+### Troubleshooting
+
+**How can issues be diagnosed?**
+
+- `--dry-run` flag shows generated CRD before submission
+- Verbose logging mode (if implemented) shows API calls and responses
+- `arena job get <job-name>` shows job status and pod information
+- `arena job logs <job-name>` shows training logs
+
+**What are common failure modes?**
+
+- CRD validation errors (malformed task spec)
+- Kubernetes API errors (permission denied, resource quota exceeded)
+- Operator errors (job submission failed, pod scheduling failed)
+- Network errors (cluster unreachable)
+
+## References
+
+- **Arena v1 codebase**: https://github.com/kubeflow/arena/tree/v0.15.4
+- **YAML schema specification**: `keps/arena-v2/yaml-schema.md` (YAML Schema section)
+- **CLI flag mapping**: `keps/arena-v2/cli-flag-mapping.md` (CLI Override Mapping section)
+- **Kubernetes Training Operator**: https://github.com/kubeflow/training-operator
+- **client-go**: https://github.com/kubernetes/client-go

--- a/keps/arena-v2/cli-flag-mapping.md
+++ b/keps/arena-v2/cli-flag-mapping.md
@@ -1,0 +1,221 @@
+# Arena V1 → V2 Flag Audit
+
+This document maps all arena v1 training CLI flags to arena v2 YAML schema coverage.
+
+**Scope:** `arena submit` training subcommands  
+**Source of truth:** arena v2 YAML Schema + arena v1 CLI
+
+---
+
+## 1. Coverage Summary
+
+| Category | v2 Covered | v2 Missing |
+|----------|-----------|------------|
+| Identity | ✅ name, image, labels, annotations, namespace | — |
+| Resources | ✅ cpus, memory, shm, nvidia.com/gpu, extended resources (`--device`) | — |
+| Scheduling | ✅ node_selector, tolerations, priority, priority_class_name, gang, scheduler_name, affinity (policy/constraint), selector, toleration, queue | — |
+| Data | ✅ storages (PVC) | ❌ hostPath, config-file (ConfigMap mount) |
+| Env | ✅ envs (plain/secretKeyRef/configMapKeyRef), per-role independent declaration | — |
+| Execution | ✅ restart, image_pull_policy, image_pull_secrets, shell, working_dir | — |
+| Lifecycle | ✅ clean_pod_policy, active_deadline, ttl_after_finished, backoff_limit, success_policy | — |
+| Sync | ✅ sync (git/rsync/hdfs) | — |
+| Model | — | ❌ model-name, model-source |
+| TFJob roles | — | ❌ ps, evaluator, chief independent config |
+| MPIJob | ✅ mounts_on_launcher, gpu_topology, run_launcher_as_worker |— |
+| PyTorch | ✅ nproc_per_node | — |
+| Horovod | ✅ ssh_port | — |
+| DeepSpeed | — | (provider not yet implemented) |
+| Ray | — | ❌ entire Ray provider (Phase 3) |
+
+**Legend:** ✅ = designed in arena v2 schema, ❌ = not in schema, — = N/A
+
+---
+
+## 2. Common Submit Flags (shared by most frameworks)
+
+### 2a. Identity
+
+| v1 Flag | Type | Default | v2 YAML | v2 CLI Flag | Status |
+|---------|------|---------|---------|-------------|--------|
+| `--name` | string | required | `name` | `--name` | ✅ |
+| `--image` | string | required | `image` | `--image` | ✅ |
+| `--image-pull-policy` | string | `"Always"` | `image_pull_policy` | `--image-pull-policy` | ✅ |
+| `--image-pull-secret` | string[] | `[]` | `image_pull_secrets` | `--image-pull-secret` | ✅ (reference-only, no auto-create) |
+
+### 2b. Resources
+
+| v1 Flag | Type | Default | v2 YAML | v2 CLI Flag | Status |
+|---------|------|---------|---------|-------------|--------|
+| `--gpus` | int | `0` | `worker.resources.nvidia.com/gpu` | `--gpus` | ✅ |
+| `--cpu` | string | `""` | `worker.resources.cpus` | `--cpus` | ✅ |
+| `--memory` | string | `""` | `worker.resources.memory` | `--mem` | ✅ |
+| `--device` | string[] | `[]` | `worker.resources.<name>` (flat) | `--device` | ✅ e.g. `--device hugepages-2Mi=32Gi` |
+| `--workers` | int | `1` | `worker.replicas` | `--workers` | ✅ |
+
+**Note:** v1 `--device vendor.com/device=count` maps to v2 flat `resources.vendor.com/device: count`.
+
+### 2c. Scheduling
+
+| v1 Flag | Type | Default | v2 YAML | v2 CLI Flag | Status |
+|---------|------|---------|---------|-------------|--------|
+| `--selector` | string[] | `[]` | `scheduling.node_selector` | `--selector` | ✅ |
+| `--toleration` | string[] | `[]` | `scheduling.tolerations` | `--toleration` | ✅ |
+| `-p, --priority` | int | `0` | `scheduling.priority` | `--priority` | ✅ Pod spec priority field |
+| `--priority-class-name` | string | `""` | `scheduling.priority_class_name` | `--priority-class-name` | ✅ Pod spec priorityClassName field |
+| `--gang` | bool | `false` | `scheduling.gang` | `--gang` | ✅ |
+| `--scheduler` | string | `""` | `scheduling.scheduler_name` | `--scheduler-name` | ✅ |
+| `--affinity-policy` | string | `""` | `scheduling.affinity.policy` | `--affinity-policy` | ✅ `none` / `spread` / `binpack` |
+| `--affinity-constraint` | string | `""` | `scheduling.affinity.constraint` | `--affinity-constraint` | ✅ `preferred` / `required` |
+| `--hostNetwork` | bool | `false` | `host_network` | `--host-network` | ✅ (top-level runtime field, not under scheduling) |
+| `--hostIPC` | bool | `false` | `host_ipc` | `--host-ipc` | ✅ (top-level runtime field, not under scheduling) |
+| `--hostPID` | bool | `false` | `host_pid` | `--host-pid` | ✅ (top-level runtime field, not under scheduling) |
+| `--queue` | string | `""` | `scheduling.queue` | — | ✅ (YAML field exists) |
+| `--rdma` | bool | `false` | — | — | ❌ NOT PLANNED |
+
+### 2d. Data and Volumes
+
+| v1 Flag | Type | Default | v2 YAML | v2 CLI Flag | Status |
+|---------|------|---------|---------|-------------|--------|
+| `-d, --data` | string[] | `[]` | `storages[].pvc` + `storages[].mount_path` | `-d, --data` | ✅ |
+| `--data-dir` | string[] | `[]` | `storages[].hostpath` + `storages[].mount_path` | `-d, --data` | ✅ |
+| `--config-file` | string[] | `[]` | — | — | ❌ ConfigMap file mount not in schema |
+
+### 2e. Environment and Labels
+
+| v1 Flag | Type | Default | v2 YAML | v2 CLI Flag | Status |
+|---------|------|---------|---------|-------------|--------|
+| `-e, --env` | string[] | `[]` | `envs` | `-e, --env` | ✅ (plain, secretKeyRef, configMapKeyRef) |
+| `-a, --annotation` | string[] | `[]` | `annotations` | `-a, --annotation` | ✅ |
+| `-l, --label` | string[] | `[]` | `labels` | `-l, --label` | ✅ |
+
+### 2f. Execution
+
+| v1 Flag | Type | Default | v2 YAML | v2 CLI Flag | Status |
+|---------|------|---------|---------|-------------|--------|
+| `--working-dir` | string | image default | `working_dir` | `--working-dir` | ✅ |
+| `--shell` | string | `/bin/sh` | `shell` | `--shell` | ✅ (invalid values fallback to /bin/sh) |
+| `--retry` | int | `0` | `lifecycle.backoff_limit` | `--backoff-limit` | ✅ (v1 `--retry` → v2 `lifecycle.backoff_limit`) |
+
+### 2g. Model Registry
+
+| v1 Flag | Type | Default | v2 YAML | Status |
+|---------|------|---------|---------|--------|
+| `--model-name` | string | `""` | — | ❌ NOT PLANNED (Phase 3+) |
+| `--model-source` | string | `""` | — | ❌ NOT PLANNED (Phase 3+) |
+
+---
+
+## 3. Sync Code Flags
+
+| v1 Flag | Type | Default | v2 YAML | Status |
+|---------|------|---------|---------|--------|
+| `--sync-mode` | string | `""` | `sync[].git/rsync/hdfs` (type key) | ✅ |
+| `--sync-source` | string | `""` | `sync[].git/rsync/hdfs` (value) | ✅ |
+| `--sync-image` | string | `""` | — | ❌ NOT PLANNED (sync uses fixed init container images per type) |
+
+---
+
+## 4. Tensorboard Flags
+
+| v1 Flag | Type | Default | v2 YAML | v2 CLI Flag | Status |
+|---------|------|---------|---------|-------------|--------|
+| `--tensorboard` | bool | `false` | `logging.tensorboard.enabled` | `--tensorboard` | ✅ |
+| `--tensorboard-image` | string | `""` | `logging.tensorboard.image` | `--tensorboard-image` | ✅ |
+| `--logdir` | string | `"/training_logs"` | `logging.tensorboard.logdir` | `--tensorboard-logdir` | ✅ |
+
+---
+
+## 5. Job Lifecycle (common across frameworks, varying defaults)
+
+| v1 Flag | Type | Default | v2 YAML | v2 CLI Flag | Status |
+|---------|------|---------|---------|-------------|--------|
+| `--clean-task-policy` | string | varies | `lifecycle.clean_pod_policy` | `--clean-pod-policy` | ✅ (`None` / `Running` / `All`) |
+| `--running-timeout` | duration | `0` | `lifecycle.active_deadline` | `--active-deadline` | ✅ |
+| `--ttl-after-finished` | duration | `0` | `lifecycle.ttl_after_finished` | `--ttl-after-finished` | ✅ |
+| `--backoff-limit` | int | `6` | `lifecycle.backoff_limit` | `--backoff-limit` | ✅ |
+| `--success-policy` | string | varies | `lifecycle.success_policy` | `--success-policy` | ✅ (`ChiefWorker` / `AllWorkers`, TFJob only) |
+| `--share-memory` | string | `"2Gi"` | `storages[].shm` | `--shm` | ✅ (emptyDir medium: Memory at /dev/shm) |
+
+---
+
+## 6. Framework-Specific Flags
+
+### 6a. TFJob
+
+| v1 Flag | v2 YAML | v2 CLI Flag | Status |
+|---------|---------|-------------|--------|
+| `--ps` (count) | `ps.replicas` | `--ps-count` | ✅ YAML-only |
+| `--ps-image` | `ps.image` | — | ✅ YAML-only |
+| `--ps-cpu`, `--ps-cpu-limit`, `--ps-memory`, `--ps-memory-limit` | `ps.resources` | — | ✅ YAML-only |
+| `--ps-gpus` | `ps.resources.nvidia.com/gpu`) | — | ✅ YAML-only |
+| `--ps-selector` | - | — | ❌ NOT IN SCHEMA |
+| `--ps-affinity-policy` | - | — | ❌ NOT IN SCHEMA |
+| `--chief` (bool) | `chief` | - | ✅ YAML-only |
+| `--chief-cpu`, `--chief-memory`, etc. | chief.resources` | — | ✅ YAML-only |
+| `--chief-selector` | - | — | ❌ NOT IN SCHEMA |
+| `--evaluator` (bool) | `evaluator` | - | ✅ YAML-only |
+| `--evaluator-*` | - | — | ❌ NOT IN SCHEMA |
+| `--worker-image` | `worker.image` | — | ✅ YAML-only |
+| `--worker-port` | — | — | ❌ NOT IN SCHEMA |
+| `--worker-cpu`, `--worker-memory`, etc. | `worker.resources` | — | ✅ YAML-only |
+| `--worker-selector` | - | — | ❌ NOT IN SCHEMA |
+| `--worker-affinity-policy` | - | — | ❌ NOT IN SCHEMA |
+| `--success-policy` | `lifecycle.success_policy` | `--success-policy` | ✅ (moved to lifecycle block) |
+| `--role-sequence` | — | — | ❌ Implementation detail, not user-facing |
+
+### 6b. PyTorchJob
+
+| v1 Flag | v2 YAML | v2 CLI Flag | Status |
+|---------|---------|-------------|--------|
+| `--cpu` | `resources.cpus` | `--cpus` | ✅ |
+| `--memory` | `resources.memory` | `--mem` | ✅ |
+| `--nproc-per-node` | `framework.options.nproc_per_node` | `--nproc-per-node` | ✅ (`auto` / `gpu` / `cpu` / int) |
+
+### 6c. MPIJob
+
+| v1 Flag | v2 YAML | v2 CLI Flag | Status |
+|---------|---------|-------------|--------|
+| `--cpu` | `resources.cpus` | `--cpus` | ✅ |
+| `--memory` | `resources.memory` | `--mem` | ✅ |
+| `--gputopology` | `framework.options.gpu_topology` | `--gpu-topology` | ✅ |
+| `--mounts-on-launcher` | `framework.options.mounts_on_launcher` | `--mounts-on-launcher` | ✅ |
+| (no v1 flag) | `framework.options.run_launcher_as_worker` | — | ❌ CLI flag missing (YAML field exists) |
+
+### 6d. Horovod
+
+| v1 Flag | v2 YAML | v2 CLI Flag | Status |
+|---------|---------|-------------|--------|
+| `--ssh-port` | `framework.options.ssh_port` | — | ✅ (YAML field exists) |
+| `--cpu` | `resources.cpus` | `--cpus` | ✅ |
+| `--memory` | `resources.memory` | `--mem` | ✅ |
+
+### 6e. DeepSpeed
+
+| v1 Flag | v2 YAML | v2 CLI Flag | Status |
+|---------|---------|-------------|--------|
+| `--cpu` | `resources.cpus` | `--cpus` | ✅ |
+| `--memory` | `resources.memory` | `--mem` | ✅ |
+| `--launcher-selector` | `roles[]` (name: launcher, `scheduling.node_selector`) | — | ✅ YAML-only |
+| `--job-restart-policy` | `restart` | `--restart` | ✅ |
+| `--job-backoff-limit` | `lifecycle.backoff_limit` | `--backoff-limit` | ✅ |
+| `--ssh-secret` | — | — | ❌ NOT IN SCHEMA (No ssh_secret is required because the mpi-operator already handles it) |
+| `--launcher-annotation` | `roles[]` (name: launcher, `annotations`) | — | ✅ YAML-only |
+| `--worker-annotation` | `roles[]` (name: worker, `annotations`) | — | ✅ YAML-only |
+
+### 6f. Elastic Training (ETJob)
+
+| v1 Flag | v2 YAML | v2 CLI Flag | Status |
+|---------|---------|-------------|--------|
+| `--max-workers` | — | — | ❌ NOT IN SCHEMA (Phase 3) |
+| `--min-workers` | — | — | ❌ NOT IN SCHEMA (Phase 3) |
+| `--spot-instance` | — | — | ❌ NOT IN SCHEMA (use PriorityClass) |
+| `--max-wait-time` | — | — | ❌ NOT IN SCHEMA |
+| `--launcher-selector` | `roles[]` (name: launcher, `scheduling.node_selector`) | — | ✅ YAML-only |
+| `--job-restart-policy` | `restart` | `--restart` | ✅ |
+| `--worker-restart-policy` | `roles[]` (name: worker, `restart`) | — | ✅ YAML-only |
+| `--job-backoff-limit` | `lifecycle.backoff_limit` | `--backoff-limit` | ✅ |
+| `--ssh-secret` | — | — | ❌ NOT IN SCHEMA |
+
+### 6g. RayJob (Phase 3)
+
+Not mapped here — will be designed when Ray provider is added.

--- a/keps/arena-v2/yaml-schema.md
+++ b/keps/arena-v2/yaml-schema.md
@@ -1,0 +1,620 @@
+
+## YAML Schema
+
+### Minimal Example
+
+```yaml
+version: 0.1.0
+name: my-job
+framework: 
+  name: pytorch
+image: pytorch/pytorch:2.1
+run: python train.py --epochs 10
+worker:
+  replicas: 1
+  resources:
+    nvidia.com/gpu: 1
+```
+
+### Full Schema
+
+```yaml
+# ─── Schema Version ───
+version: 0.1.0                       # Required. Schema version for forward compatibility.
+
+# ─── Identity ───
+name: llm-finetune                   # Required. K8s resource name.
+namespace: ml-team                   # Optional. Default: kubeconfig context.
+description: "experiment run"        # Optional
+labels:                              # Optional
+  team: platform
+annotations:                         # Optional
+  note: "experiment run"
+
+image: nvcr.io/nvidia/pytorch:23.10  # Required. Container image.
+run: torchrun train.py --epochs 10   # Required. Training command, executed via shell.
+shell: /bin/sh                       # Optional. Shell interpreter path. Default: /bin/sh. Invalid values fall back to default.
+working_dir: /root                   # Optional. Container working directory (default: image default)
+
+# ─── Task ───
+framework:                           # Required. String shorthand or object with provider config.
+  name: pytorch                      # Required. Provider name as key (pytorch | tensorflow | mpi | deepspeed | ray)
+  options:                            # Optional
+    nproc_per_node: auto             # auto | gpu | cpu | int → torchrun --nproc-per-node
+
+envs:                                # Optional. Common envs.
+  NCCL_DEBUG: INFO
+  NCCL_IB_DISABLE: "0"
+
+# ─── Scale ───
+worker:                             # Required
+  replicas: 4                       # Required. Worker replicas must be greater than 0
+  envs:                             # Optional
+    NCCL_DEBUG: DEBUG               # Worker: inherited env + NCCL_DEBUG (override/merge)
+  resources:                        # Required
+    nvidia.com/gpu: 8               # Worker: manual specification required
+
+# ─── Sync & Init ───
+sync:                               # Optional
+  - git: https://github.com/org/training-code.git   # git clone
+    branch: main                     # Optional. Override default branch main
+    local_path: /code                # Optional. Override default local_path
+    mounts:                          # Optional. Override storages by name
+    - name: code 
+      mount_path: /workspace
+      sub_path: /
+
+  - rsync: 10.88.29.56::backup/data/logoRecoTrain.zip   # rsync from job's remote source
+    local_path: /workdir             # Optional. Override default local_path
+    mounts:                          # Optional
+    - mount_path: /dataset
+      name: dataset
+
+
+  - hdfs: hdfs://namenode:8020/models/resnet # download from remote hdfs
+    local_path: /workdir             # Optional. Override default local_path
+    mounts:                          # Optional
+    - mount_path: /models
+      name: checkpoints  
+
+# ─── storages ───
+# inject into all pods
+storages:                 # Optional
+  - name: dataset         # Required if storages field is specified.
+    mount_path: /data     # Required if storages field is specified and storage is not shm.
+    sub_path: /data       # Optional
+    pvc: dataset-pvc
+  - name: checkpoints
+    mount_path: /ckpts
+    pvc: ckpt-pvc
+  - name: shm
+    shm: 64Gi
+    # mount_path: /dev/shm # Optional. Default to /dev/shm
+  - name: tmp
+    tmp: 128Gi
+    mount_path: /tmp
+  - name: host
+    hostpath: /runtime-mnt
+    mount_path: /runtime
+
+# ─── Scheduling (K8s-specific) ───
+# inject into all pods
+scheduling:                            # Optional
+  priority: 100                        # Integer → pod spec priority field
+  priority_class_name: high-priority   # String → pod spec priorityClassName field
+  gang: false                          # Gang scheduling (Volcano/coscheduling)
+  scheduler_name: default              # Custom scheduler (optional)
+  queue: low-priority                  # Queue name (optional)
+  node_selector:
+    disktype: ssd
+    zone: us-west-2a
+  tolerations:
+    - key: nvidia.com/gpu
+      operator: Exists
+      effect: NoSchedule
+  affinity:                          # future feature
+    policy: spread                   # none | spread | binpack
+    constraint: preferred            # preferred | required
+    target: pod                      # pod | node
+    rules:
+    - topology_key: nvidia.com/gpu
+      weight: 1
+      match_expressions:
+      - key: foo
+        operator: In
+        values:
+        - bar
+      match_fields:
+      - key: foo
+        operator: In
+        values:
+        - bar
+      match_labels:
+        a: b
+      namespaces: ["a", "b"]
+      namespace_selector:            # Only for target: pod (filter namespaces by label)
+        match_labels:
+          team: platform
+        match_expressions:
+        - key: foo
+          operator: In
+          values:
+          - bar
+
+# ─── Lifecycle ───
+# inject into all pods 
+lifecycle:                           # Optional
+  clean_pod_policy: Running          # None | Running | All
+  active_deadline: 2h                # Max active duration
+  ttl_after_finished: 7d             # Auto-delete after this duration
+  backoff_limit: 6                   # Max restart count
+  success_policy: ChiefWorker        # ChiefWorker | AllWorkers (TFJob only)
+
+# ─── Runtime ───
+# inject into all pods 
+image_pull_policy: Always            # Optional. Always | IfNotPresent | Never
+image_pull_secrets:                  # Optional
+  - registry-secret                  # Reference existing Secret
+service_account: training-sa         # Optional
+restart: OnFailure                   # Optional. Always | OnFailure | Never
+host_network: false                  # Optional. true | false
+host_ipc: false                      # Optional. true | false
+host_pid: false                      # Optional. true | false
+
+# ─── Logging ───
+# create additional pods
+logging:                             # Optional
+  tensorboard:
+    enabled: false
+    logdir: /training_logs             # Required if tensorboard enabled. TensorBoard --logdir arg
+    image: tensorflow/tensorflow:2.15  # Optional. Override default image
+  # wandb:                             # future feature
+  #   enabled: true
+  #   project: my-project
+  #   entity: my-team
+```
+
+### resources
+
+Fields under `worker.resources` are all **Scalar** values, applied identically to both `requests` and `limits` (**Guaranteed QoS**).
+
+```yaml
+worker:
+  resources:
+    nvidia.com/gpu: 8
+    cpu: 32
+    memory: 128Gi
+```
+
+**Why Guaranteed only**: Training workloads are long-running, GPU-intensive jobs that require stable resource guarantees. Burstable QoS (requests < limits) leads to priority eviction under node contention, which is unsuitable for training scenarios.
+
+**Implementation**: When building the CRD, scalar values are written to both `requests` and `limits` in the Pod spec with identical values, ensuring K8s assigns the Guaranteed QoS class.
+
+### image_pull_secrets
+
+`image_pull_secrets` references existing `imagePullSecret` resources by name:
+
+| Form | YAML | Behavior |
+|---|---|---|
+| String | `- registry-secret` | Reference existing `imagePullSecret` by name |
+
+```yaml
+image_pull_secrets:
+  - nvcr-registry                  # Must already exist in the namespace
+  - gcr-creds
+```
+
+Users create imagePullSecrets externally:
+
+```bash
+kubectl create secret docker-registry nvcr-registry \
+  --docker-server=nvcr.io \
+  --docker-username=$NVCR_USER \
+  --docker-password=$NVCR_TOKEN
+```
+
+### Secrets Design Principles
+
+arena-v2 **does not create K8s Secrets** — it only references existing ones. Rationale:
+
+1. **arena-v2 is a client-side tool** (like kubectl). Creating Secrets is a state-mutating operation that conflicts with the "CRD generation only" design.
+2. **Standard K8s ecosystem practice**: External Secrets Operator, Vault Agent, Sealed Secrets, and similar tooling all operate around the reference model.
+3. **v1 also lacks Secret creation** — v1 users are already accustomed to managing Secrets via `kubectl create secret` first.
+4. **Security**: arena-v2 never handles sensitive credentials (read, encode, or transmit). Secrets are managed by cluster administrators or external systems.
+
+**Secret reference via `envs` field (secretKeyRef)**:
+
+```yaml
+envs:
+  HF_TOKEN:
+    secret: my-hf-creds            # Reference existing K8s Secret "my-hf-creds"
+    key: token
+  WANDB_KEY:
+    secret: my-hf-creds
+    key: wandb-key
+  DB_HOST:
+    configmap: db-config
+    key: host
+```
+
+This keeps the YAML schema pure (reference-only declarations) while providing a convenient Secret creation tool.
+
+### envs Value Forms
+
+`envs` values accept three forms:
+
+| Form | YAML | Behavior |
+| --- | --- | --- |
+| Plain | `BATCH_SIZE: "32"` | Literal value in Pod spec |
+| Secret ref | `DB_PASSWORD: {secret: name, key: k}` | `secretKeyRef` to existing K8s Secret |
+| ConfigMap ref | `CONFIG_PATH: {configmap: name, key: k}` | `configMapKeyRef` to existing K8s ConfigMap |
+
+### framework (Provider Selection & Config)
+
+`framework` accepts one form: an **object** where the provider name is the key and its value holds provider-specific settings.
+
+
+**Object form** — provider name as key, config as value:
+```yaml
+framework:
+  name: pytorch
+  options:
+    nproc_per_node: auto             # auto | gpu | cpu | int → torchrun --nproc-per-node
+```
+
+```yaml
+framework:
+  name: mpi
+  options:
+    slots_per_worker: 4              # MPI slots per worker node
+    mounts_on_launcher: true         # Launcher also mounts PVCs (default: false)
+    run_launcher_as_worker: false    # Optional: Launcher also run as worker (default: false)
+    gpu_topology: true               # GPU topology scheduling annotation
+```
+
+```yaml
+framework:
+  name: tensorflow
+  options:
+    ps_count: 2                      # Parameter Server replica count
+    chief: true                      # Enable Chief (default: true for standalone)
+    evaluator: false                 # Enable Evaluator
+```
+
+```yaml
+framework:
+  name: horovod
+  options:
+    ssh_port: 22                     # SSH port for MPI launcher
+```
+
+**Implementation**: `UnmarshalYAML` handles the object form, parsing into a unified `FrameworkConfig` struct. Only one provider key is allowed. Provider-specific fields are strongly typed per provider (no cross-provider field leakage).
+
+**Mapping to replicas**: `framework.tensorflow.options.ps_count` creates PS replicas. `chief` and `evaluator` are booleans that enable/disable those role types entirely.
+
+### lifecycle (Job Lifecycle Policies)
+
+```yaml
+lifecycle:
+  clean_pod_policy: Running          # None | Running | All — which pods to clean after completion
+  active_deadline: 2h                # Max wall-clock duration → activeDeadlineSeconds
+  ttl_after_finished: 7d             # Auto-delete Job after this duration → ttlSecondsAfterFinished
+  backoff_limit: 6                   # Max restart count → backoffLimit
+  success_policy: ChiefWorker        # ChiefWorker | AllWorkers (TFJob only)
+```
+
+`clean_pod_policy` controls which pods the Operator deletes after job completion:
+- `None` — keep all pods
+- `Running` — delete only running pods (failed/succeeded pods remain for log inspection)
+- `All` — delete all pods
+
+**lifecycle vs restart field boundary:**
+- `lifecycle` wraps the training-operator's `RunPolicy` (Job-level policies): `clean_pod_policy`, `backoff_limit`, `ttl_after_finished`, `active_deadline`, `success_policy`.
+- `restart` wraps `ReplicaSpec.RestartPolicy` (Replica-level), which is **not part of** `lifecycle`. The top-level `restart` is injected as the default for all Replicas.
+- Platform-level retries (exit-code-triggered, preemption re-queueing, resource retention) are **outside arena-v2's scope** — they require external controller + queue scheduler integration beyond a client-side tool. `restart` + `backoff_limit` already covers training-operator's pod-level restart.
+
+### run and shell (Command Execution Model)
+
+`run` is the training command string, executed via shell. `shell` specifies the interpreter path:
+
+| `shell` value | K8s Pod Spec Generation | Use Case |
+|---|---|---|
+| Omitted (default `/bin/sh`) | `command: ["/bin/sh", "-c"]`, `args: ["<run>"]` | Most scenarios, consistent with v1 behavior |
+| `/bin/bash` | `command: ["/bin/bash", "-c"]`, `args: ["<run>"]` | Requires bash features (`source`, `[[ ]]`, arrays, etc.) |
+
+**Invalid value handling**: `null`, empty string `""`, and non-existent paths all fall back to the default `/bin/sh`. Exec form (without shell wrapping) is not supported — to call an executable directly, use its absolute path in `run`.
+
+**Why not `sh -c "bash -c ..."` workaround:**
+- **Signal delivery lost**: K8s sends SIGTERM to PID 1 (sh), which by default does not forward to the child bash process, breaking graceful shutdown
+- **Unreliable exit codes**: sh without `set -e` may swallow non-zero exit codes from the bash child, causing K8s to mark the Pod as Succeeded instead of Failed
+- **Nested escaping**: Quotes, `$`, and backslashes in user commands require double-escaping, which is error-prone
+
+**Implementation**: `Shell` is a plain `string` type. The Provider validates during `BuildCRD`: only non-empty absolute paths starting with `/` are used; otherwise it falls back to `/bin/sh`.
+
+### Resource Lifecycle
+
+A single `arena job run` invocation may create multiple K8s resources:
+
+```
+arena job run -f train.yaml
+  ├─ PyTorchJob CRD              ← Primary resource (Operator manages Pod lifecycle)
+  ├─ TensorBoard Deployment+Service ← If logging.tensorboard is enabled
+  └─ ConfigMap (metadata)        ← Stores original YAML + generated manifest
+```
+
+**Design choice: Each task type uses its corresponding top-level resource as the anchor, with all other resources setting ownerReference to it.**
+
+```
+PyTorchJob CRD
+  ├── owns → ConfigMap "my-job" (stores original YAML; a new CRD could replace the native ConfigMap)
+  ├── owns → TensorBoard Deployment
+  └── owns → TensorBoard Service
+```
+
+**Implementation approach:**
+
+1. Create the primary CRD (e.g. PyTorchJob) first to obtain its UID.
+2. Create the ConfigMap with the original YAML and generated manifest, setting `ownerReference` to the CRD.
+3. Create any additional resources (TensorBoard Deployment, Service) with `ownerReference` pointing to the CRD.
+4. On `arena job delete`, delete the CRD — K8s garbage collection cascades to all resources with matching `ownerReference`.
+
+**`arena job delete` implementation (single step):** Delete the primary CRD. K8s GC cascades deletion to all resources that reference it.
+
+**`arena job get` implementation:** Read the ConfigMap by job name to retrieve the original YAML for display.
+
+**Comparison with v1:**
+
+| | v1 (Helm) | v2 (CRD anchor) |
+|---|---|---|
+| Metadata storage | ConfigMap `data.app` | ConfigMap `data.arena-v2.yaml` |
+| Resource tracking | Resource list in ConfigMap | K8s ownerReference (automatic) |
+| `arena job delete` steps | 3 steps: read CM → delete resources → delete CM | **1 step: delete CRD** |
+| Resource leak risk | High (list may be incomplete) | **None (K8s GC handles it)** |
+
+**OwnerReference semantics**: `kubectl get pytorchjob -o yaml` will show ownerReference relationships. This is semantically unconventional but:
+- **Training Operator is unaffected**: the reconciler reads CRD spec/status to manage Pods, not ownerReferences
+- **Transparent to arena CLI users**: users interact via `arena job get/delete`, not direct CRD manipulation
+- **Helm validates this pattern**: Helm release Secrets serve as anchors managing all chart resources — a mature K8s ecosystem pattern
+
+### stop / resume (Operational Pause)
+
+Pause/resume are **operations**, not configuration — they do not belong in the YAML schema. When integrating with queue systems like Kueue, applying a label/annotation on the CRD is sufficient.
+
+```bash
+arena job stop <name>      # Pause task (via label/annotation)
+arena job resume <name>    # Resume task
+```
+
+### worker Field Semantics
+
+`worker` represents the **GPU-using nodes** in a training job. The meaning and mapping of `worker` varies by framework:
+
+| Framework | worker mapping | Uses GPU | Notes |
+|---|---|---|---|
+| pytorch | Master + Worker | Yes | Master also uses GPU, same config as Worker |
+| tensorflow | Worker | Yes | Chief/PS/Evaluator do not use worker's GPU config |
+| mpi | Worker | Yes | Launcher does not use GPU, does not inherit worker's resource config |
+| deepspeed | Worker | Yes | Launcher does not use GPU |
+| horovod | Worker | Yes | Launcher does not use GPU |
+
+**MPI/DeepSpeed/Horovod Launchers do not inherit worker's GPU resources by default** — the Provider automatically sets independent resource config for the Launcher (typically no GPU) during CRD generation, avoiding GPU waste on Launcher pods.
+
+**PyTorch Master vs Worker**: Master uses the same `worker.resources` config (including GPU) as Worker. Master replicas is fixed at 1; Worker replicas = `worker.replicas - 1`.
+
+### sync & init (Code/Data Injection)
+
+**`sync` — high-level data/code injection (sugar for initContainer):**
+
+`sync` supports three source types:
+
+| Type | Source | Init Container |
+|---|---|---|
+| `git` | Git repository URL | `git-sync` clone |
+| `rsync` | Remote storage source | `rsync` |
+| `hdfs` | HDFS path | `hadoop/hadoop` init container with `hdfs get` |
+
+```yaml
+sync:
+  - git: https://github.com/org/training-code.git
+    branch: main                     # Optional. Default: default branch.
+    mounts:
+    - name: code
+      mount_path: /workspace
+      sub_path: /
+
+  - rsync: 10.88.29.56::backup/data/logoRecoTrain.zip    # Rsync from job's remote source
+    mounts:
+    - name: dataset
+      mount_path: /dataset
+
+  - hdfs: hdfs://namenode:8020/models/resnet
+    mounts:
+    - name: checkpoints
+      mount_path: /models
+```
+
+Each entry creates an initContainer + emptyDir volume. The emptyDir is mounted at `mount_path` in both the initContainer and the main container across all pods.
+
+**`init` — generic initContainer injection:**
+
+```yaml
+init:
+  - name: download-model
+    image: busybox
+    run: wget -O /data/model.bin https://example.com/model.bin
+
+  - name: prepare-dataset
+    image: custom-etl:latest
+    run: /prepare.sh
+    shell: /bin/bash                     # Optional, independent of top-level shell
+```
+
+`init[].run` has the same semantics as the top-level `run`: a command string executed via shell. Each init container can independently specify its own `shell` interpreter (defaults to inheriting the top-level `shell` value; falls back to `/bin/sh` if unset).
+
+Init containers generated by `sync` use exec form (CLI auto-generates the command without shell wrapping) — no `run`/`shell` fields needed.
+
+Init containers do not support `envs`, `secrets`, or `resources` configuration.
+
+`sync` and `init` can coexist. `sync` entries are processed before `init` entries.
+
+### worker.replicas → Provider Mapping
+
+```
+User writes: worker.replicas: 4
+  pytorch    → PyTorchJob  { Master(1) + Worker(3) }   = 4 pods
+  tensorflow → TFJob       { Chief(1)  + Worker(4) }   = 5 pods
+  mpi        → MPIJob      { Launcher(1) + Worker(4) }  = 5 pods
+
+User writes: worker.replicas: 1
+  pytorch    → PyTorchJob  { Master(1) }   = 1 pods
+  tensorflow → TFJob       { Chief(1)  + Worker(1) }   = 2 pods
+  mpi        → MPIJob      { Launcher(1) + Worker(1) }  = 2 pods
+
+User writes: worker.replicas: 0 (or omitted), invalid value
+```
+
+### CLI Override Mapping
+
+All YAML schema fields that are expressible as CLI flags are listed below. Flag names strictly follow schema field names. Complex nested types (`sync`, `init`, `storages`, `scheduling.affinity`) are YAML-only.
+
+The `arena job run` command supports three input modes:
+1. **Pure YAML**: `arena job run -f train.yaml`
+2. **YAML + overrides**: `arena job run -f train.yaml --gpus 8 --workers 4`
+3. **Pure flags**: `arena submit pytorch --name job --image pytorch:2.1 --gpus 2 "python train.py"`, `arena submit pytorchjob --name job --image pytorch:2.1 --gpus 2 "python train.py"`
+
+#### Identity
+
+| Flag | Type | YAML Field | Notes |
+|------|------|-----------|-------|
+| `--name` | string | `name` | Required |
+| `-n, --namespace` | string | `namespace` | Default: kubeconfig context |
+| `-l, --label` | stringSlice | `labels` | `KEY=VALUE` repeated |
+| `-a, --annotation` | stringSlice | `annotations` | `KEY=VALUE` repeated |
+
+#### Task
+
+| Flag | Type | YAML Field | Notes |
+|------|------|-----------|-------|
+| `--framework` | string | `framework` | Also first positional arg |
+| `--image` | string | `image` | Required |
+| `--working-dir` | string | `working_dir` | Container working directory |
+| `--shell` | string | `shell` | Shell interpreter path (default: /bin/sh, invalid values fall back to default) |
+| (trailing args after `--`) | string | `run` | The command to execute |
+
+#### Scale
+
+| Flag | Type | YAML Field | Notes |
+|------|------|-----------|-------|
+| `--workers` | int | `worker.replicas` | Worker replica count |
+
+#### Resources
+
+| Flag | Type | YAML Field | Notes |
+|------|------|-----------|-------|
+| `--gpus` | int | `worker.resources.nvidia.com/gpu` | GPU count |
+| `--gpu-type` | string | (node selector hint) | Maps to `nvidia.com/gpu.product` label |
+| `--cpus` | string | `worker.resources.cpus` | e.g. `"4"` |
+| `--mem` | string | `worker.resources.memory` | e.g. `"16Gi"` |
+| `--shm` | string | `storages` (shm type) | e.g. `"8Gi"`, creates emptyDir at /dev/shm |
+| `--device` | stringSlice | `worker.resources.<name>=<count>` | Extended resources, e.g. `--device hugepages-2Mi=32Gi` |
+
+#### Environment
+
+| Flag | Type | YAML Field | Notes |
+|------|------|-----------|-------|
+| `-e, --env` | stringSlice | `envs` | `KEY=VALUE` repeated |
+
+#### Data (storages)
+
+| Flag | Type | YAML Field | Notes |
+|------|------|-----------|-------|
+| `-d, --data` | stringSlice | `storages` | `name:path:pvc` repeated |
+
+#### Scheduling
+
+| Flag | Type | YAML Field | Notes |
+|------|------|-----------|-------|
+| `--priority` | int | `scheduling.priority` | Pod spec priority field |
+| `--priority-class-name` | string | `scheduling.priority_class_name` | Pod spec priorityClassName field |
+| `--gang` | bool | `scheduling.gang` | Gang scheduling |
+| `--scheduler-name` | string | `scheduling.scheduler_name` | Custom scheduler |
+| `--affinity-policy` | string | `scheduling.affinity.policy` | `none` / `spread` / `binpack` |
+| `--affinity-constraint` | string | `scheduling.affinity.constraint` | `preferred` / `required` |
+| `--selector` | stringSlice | `scheduling.node_selector` | `key=value` repeated |
+| `--toleration` | stringSlice | `scheduling.tolerations` | `key:operator:effect` repeated |
+
+#### Lifecycle
+
+| Flag | Type | YAML Field | Notes |
+|------|------|-----------|-------|
+| `--clean-pod-policy` | string | `lifecycle.clean_pod_policy` | `None` / `Running` / `All` |
+| `--active-deadline` | string | `lifecycle.active_deadline` | Duration, e.g. `"2h"` |
+| `--ttl-after-finished` | string | `lifecycle.ttl_after_finished` | Duration, e.g. `"7d"` |
+| `--backoff-limit` | int | `lifecycle.backoff_limit` | Max restart count |
+| `--success-policy` | string | `lifecycle.success_policy` | `ChiefWorker` / `AllWorkers` (TFJob only) |
+
+#### Runtime
+
+| Flag | Type | YAML Field | Notes |
+|------|------|-----------|-------|
+| `--image-pull-policy` | string | `image_pull_policy` | `Always` / `IfNotPresent` / `Never` |
+| `--image-pull-secret` | stringSlice | `image_pull_secrets` | Image pull secret names |
+| `--service-account` | string | `service_account` | ServiceAccount name |
+| `--restart` | string | `restart` | `Always` / `OnFailure` / `Never` |
+| `--host-network` | bool | `host_network` | |
+| `--host-ipc` | bool | `host_ipc` | |
+| `--host-pid` | bool | `host_pid` | |
+
+#### Logging
+
+| Flag | Type | YAML Field | Notes |
+|------|------|-----------|-------|
+| `--tensorboard` | bool | `logging.tensorboard.enabled` | Enable TensorBoard sidecar |
+| `--tensorboard-logdir` | string | `logging.tensorboard.logdir` | `--logdir` argument |
+| `--tensorboard-image` | string | `logging.tensorboard.image` | Override TB container image |
+
+#### Framework Config
+
+Framework-specific flags are validated at runtime — only valid for the matching `--framework`.
+
+| Flag | Type | YAML Field | Framework |
+|------|------|-----------|-----------|
+| `--nproc-per-node` | string | `framework.options.nproc_per_node` | pytorch |
+| `--ps-count` | int | `framework.options.ps_count` | tensorflow |
+| `--chief` | bool | `framework.options.chief` | tensorflow |
+| `--evaluator` | bool | `framework.options.evaluator` | tensorflow |
+| `--slots-per-worker` | int | `framework.options.slots_per_worker` | mpi |
+| `--gpu-topology` | bool | `framework.options.gpu_topology` | mpi |
+| `--mounts-on-launcher` | bool | `framework.options.mounts_on_launcher` | mpi |
+
+#### Meta
+
+| Flag | Type | Notes |
+|------|------|-------|
+| `-f, --file` | string | Path to task YAML file |
+| `--dry-run` | bool | Print generated CRD without submitting |
+
+#### YAML-Only Fields (not expressible as CLI flags)
+
+These schema sections require YAML input due to nested complexity:
+
+- `sync` — git/rsync/hdfs code injection
+- `init` — generic initContainer injection
+- `storages` — PVC/shm/tmp/hostpath storage declarations
+- `scheduling.affinity` — full affinity rules with policy/constraint/target
+- `framework.options` — when multiple provider config fields are needed simultaneously
+
+### Affinity Design Principles
+
+`scheduling.affinity` uses an orthogonal `policy × constraint × target` design:
+
+- **policy**: `none` | `spread` | `binpack` — expresses scheduling intent
+- **constraint**: `preferred` | `required` — maps to K8s preferredDuringScheduling / requiredDuringScheduling
+- **target**: `pod` | `node` — determines whether to generate podAffinity or nodeAffinity
+
+`rules[]` supports full K8s fields: `topology_key`, `match_labels`, `match_expressions`, `match_fields` (node only), `namespaces`, `namespace_selector` (pod only), `weight`.
+
+**Design principles:**
+- No additional fields introduced (e.g. `direction`, `match`, `scope`) — `policy`/`constraint`/`target` already orthogonally cover all semantics
+- Users only need to understand three dimensions: policy (intent) + constraint (strength) + target (object)
+- `rules[]` is a direct mapping of K8s native fields with no extra abstraction


### PR DESCRIPTION
## Purpose of this PR

This PR introduces the Arena v2 design proposal (KEP), documenting a complete architectural redesign of Arena to eliminate Helm dependencies, reduce code complexity, and introduce YAML-first configuration.

**Proposed changes:**

- Add Arena v2 KEP (`keps/arena-v2/README.md`) covering motivation, architecture overview, design principles, user stories, test plan, and graduation criteria
- Add YAML schema specification (`keps/arena-v2/yaml-schema.md`) defining the structured job configuration format for v2
- Add CLI flag mapping (`keps/arena-v2/cli-flag-mapping.md`) documenting v1-to-v2 flag compatibility for the `arena submit` legacy interface
- Add `CLAUDE.md` with project conventions and build instructions for AI-assisted development

## Change Category

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [x] Documentation update

### Rationale

Arena v1 suffers from architectural limitations: a heavy Helm dependency (24 charts + Helm Go SDK), a 6-step submission pipeline with temp file/ConfigMap leak risks, flag-only configuration (40+ flags per job with no versioning), and high code complexity (thousands of lines spread across `pkg/commands/`, `pkg/training/`, `pkg/argsbuilder/`, `pkg/apis/`).

Arena v2 addresses these by:
1. **Generating CRDs directly in Go** using `unstructured.Unstructured` — no Helm, no shell-outs to `kubectl`
2. **Introducing YAML-first configuration** — users can version, review, and reuse job configs as code
3. **Adopting a modular package structure** — `pkg/cli`, `pkg/task`, `pkg/provider`, `pkg/client`, `pkg/output` with clean separation of concerns
4. **Providing backward compatibility** — the `arena submit <type> --flags` interface maps v1 flags to v2's internal model

This PR contains the design documentation only. Implementation will follow in subsequent PRs.