### PR TITLE
fix(config): support multiple kubeconfig files

### DIFF
--- a/pkg/apis/config/kubeclient.go
+++ b/pkg/apis/config/kubeclient.go
@@ -16,9 +16,7 @@ package config
 import (
 	"os"
 	"os/user"
-	"path"
 	"path/filepath"
-	"strings"
 
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -26,14 +24,17 @@ import (
 )
 
 func initKubeClient(kubeconfig string) (clientcmd.ClientConfig, *rest.Config, *kubernetes.Clientset, error) {
-	var err error
-	kubeconfig, err = setupKubeconfig(kubeconfig)
+	loadingRules, err := buildClientConfigLoadingRules(kubeconfig)
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
-	loadingRules.ExplicitPath = kubeconfig
-	loadingRules.DefaultClientConfig = &clientcmd.DefaultClientConfig
+	if loadingRules.ExplicitPath != "" {
+		// Keep KUBECONFIG in sync so Arena's kubectl subprocesses inherit the
+		// explicitly selected kubeconfig.
+		if err := os.Setenv("KUBECONFIG", loadingRules.ExplicitPath); err != nil {
+			return nil, nil, nil, err
+		}
+	}
 	overrides := clientcmd.ConfigOverrides{}
 	clientConfig := clientcmd.NewInteractiveDeferredLoadingClientConfig(loadingRules, &overrides, os.Stdin)
 	// create rest config
@@ -51,33 +52,39 @@ func initKubeClient(kubeconfig string) (clientcmd.ClientConfig, *rest.Config, *k
 	return clientConfig, restConfig, clientset, nil
 }
 
-func setupKubeconfig(kubeconfig string) (string, error) {
-	// if kubeconfig is null and env "KUBECONFIG" is not null
-	// read kubeconfig from env
+func buildClientConfigLoadingRules(kubeconfig string) (*clientcmd.ClientConfigLoadingRules, error) {
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	loadingRules.DefaultClientConfig = &clientcmd.DefaultClientConfig
+
+	// When kubeconfig is empty, leave ExplicitPath unset so client-go merges
+	// the files listed in KUBECONFIG using its native loading precedence.
+	if kubeconfig != "" {
+		explicitPath, err := setupExplicitKubeconfig(kubeconfig)
+		if err != nil {
+			return nil, err
+		}
+		loadingRules.ExplicitPath = explicitPath
+	}
+
+	return loadingRules, nil
+}
+
+func setupExplicitKubeconfig(kubeconfig string) (string, error) {
 	currentUser, err := user.Current()
 	if err != nil {
 		return kubeconfig, err
 	}
-	switch {
-	case kubeconfig != "":
-		break
-	case os.Getenv("KUBECONFIG") != "":
-		kubeconfig = os.Getenv("KUBECONFIG")
-	default:
-		// if default kubeconfig is invalid,set kubeconfig null value and return it
-		defaultKubeconfig := path.Join(currentUser.HomeDir, ".kube", "config")
-		_, err = os.Stat(defaultKubeconfig)
-		if err != nil {
-			return kubeconfig, nil
-		}
-		kubeconfig = defaultKubeconfig
+
+	if len(kubeconfig) >= 2 && kubeconfig[:2] == "~/" {
+		kubeconfig = filepath.Join(currentUser.HomeDir, kubeconfig[2:])
+	} else if kubeconfig == "~" {
+		kubeconfig = currentUser.HomeDir
+	} else {
+		kubeconfig = filepath.Clean(kubeconfig)
 	}
-	// normalize path
-	kubeconfig = filepath.Clean(kubeconfig)
-	// change ~ to user home dir
-	kubeconfig = strings.ReplaceAll(kubeconfig, "~", currentUser.HomeDir)
-	_ = os.Setenv("KUBECONFIG", kubeconfig)
-	// set env
-	_, err = os.Stat(kubeconfig)
-	return kubeconfig, err
+
+	if _, err = os.Stat(kubeconfig); err != nil {
+		return kubeconfig, err
+	}
+	return kubeconfig, nil
 }

--- a/pkg/apis/config/kubeclient_test.go
+++ b/pkg/apis/config/kubeclient_test.go
@@ -1,0 +1,174 @@
+// Copyright 2024 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"os"
+	"os/user"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestBuildClientConfigLoadingRulesWithExplicitKubeconfig(t *testing.T) {
+	tmpDir := t.TempDir()
+	kubeconfigPath := filepath.Join(tmpDir, "config")
+	t.Setenv("KUBECONFIG", "old-config")
+
+	if err := os.WriteFile(kubeconfigPath, []byte("apiVersion: v1\nkind: Config\n"), 0600); err != nil {
+		t.Fatalf("failed to write temporary kubeconfig: %v", err)
+	}
+
+	rules, err := buildClientConfigLoadingRules(kubeconfigPath)
+	if err != nil {
+		t.Fatalf("buildClientConfigLoadingRules returned error: %v", err)
+	}
+	if rules == nil {
+		t.Fatal("buildClientConfigLoadingRules returned nil rules")
+	}
+	if rules.ExplicitPath != kubeconfigPath {
+		t.Fatalf("expected ExplicitPath %q, got %q", kubeconfigPath, rules.ExplicitPath)
+	}
+	if got := os.Getenv("KUBECONFIG"); got != "old-config" {
+		t.Fatalf("expected KUBECONFIG to stay %q, got %q", "old-config", got)
+	}
+}
+
+func TestInitKubeClientSetsExplicitKubeconfigEnv(t *testing.T) {
+	kubeconfigPath := filepath.Join(t.TempDir(), "config")
+	t.Setenv("KUBECONFIG", "old-config")
+	kubeconfig := []byte(`apiVersion: v1
+kind: Config
+clusters:
+- name: test
+  cluster:
+    server: https://127.0.0.1
+contexts:
+- name: test
+  context:
+    cluster: test
+    user: test
+current-context: test
+users:
+- name: test
+  user:
+    token: test
+`)
+	if err := os.WriteFile(kubeconfigPath, kubeconfig, 0600); err != nil {
+		t.Fatalf("failed to write temporary kubeconfig: %v", err)
+	}
+
+	if _, _, _, err := initKubeClient(kubeconfigPath); err != nil {
+		t.Fatalf("initKubeClient returned error: %v", err)
+	}
+	if got := os.Getenv("KUBECONFIG"); got != kubeconfigPath {
+		t.Fatalf("expected KUBECONFIG %q, got %q", kubeconfigPath, got)
+	}
+}
+
+func TestBuildClientConfigLoadingRulesWithMultipleKubeconfigEnv(t *testing.T) {
+	tmpDir := t.TempDir()
+	kubeconfig1 := filepath.Join(tmpDir, "config1")
+	kubeconfig2 := filepath.Join(tmpDir, "config2")
+
+	for _, path := range []string{kubeconfig1, kubeconfig2} {
+		if err := os.WriteFile(path, []byte("apiVersion: v1\nkind: Config\n"), 0600); err != nil {
+			t.Fatalf("failed to write temporary kubeconfig %s: %v", path, err)
+		}
+	}
+
+	kubeconfigEnv := kubeconfig1 + string(os.PathListSeparator) + kubeconfig2
+	t.Setenv("KUBECONFIG", kubeconfigEnv)
+
+	rules, err := buildClientConfigLoadingRules("")
+	if err != nil {
+		t.Fatalf("buildClientConfigLoadingRules returned error: %v", err)
+	}
+	if rules == nil {
+		t.Fatal("buildClientConfigLoadingRules returned nil rules")
+	}
+	if rules.ExplicitPath != "" {
+		t.Fatalf("expected ExplicitPath to be empty when kubeconfig is not explicitly provided, got %q", rules.ExplicitPath)
+	}
+	expectedPrecedence := []string{kubeconfig1, kubeconfig2}
+	if !reflect.DeepEqual(rules.Precedence, expectedPrecedence) {
+		t.Fatalf("expected Precedence %v, got %v", expectedPrecedence, rules.Precedence)
+	}
+	if got := os.Getenv("KUBECONFIG"); got != kubeconfigEnv {
+		t.Fatalf("expected KUBECONFIG to stay %q, got %q", kubeconfigEnv, got)
+	}
+}
+
+func TestBuildClientConfigLoadingRulesWithMissingExplicitKubeconfig(t *testing.T) {
+	kubeconfigPath := filepath.Join(t.TempDir(), "missing-config")
+
+	rules, err := buildClientConfigLoadingRules(kubeconfigPath)
+	if err == nil {
+		t.Fatalf("expected an error for missing kubeconfig %q", kubeconfigPath)
+	}
+	if rules != nil {
+		t.Fatalf("expected nil rules, got %#v", rules)
+	}
+}
+
+func TestBuildClientConfigLoadingRulesWithoutKubeconfig(t *testing.T) {
+	t.Setenv("KUBECONFIG", "")
+
+	rules, err := buildClientConfigLoadingRules("")
+	if err != nil {
+		t.Fatalf("buildClientConfigLoadingRules returned error: %v", err)
+	}
+	if rules == nil {
+		t.Fatal("buildClientConfigLoadingRules returned nil rules")
+	}
+	if rules.ExplicitPath != "" {
+		t.Fatalf("expected ExplicitPath to be empty, got %q", rules.ExplicitPath)
+	}
+	if got := os.Getenv("KUBECONFIG"); got != "" {
+		t.Fatalf("expected KUBECONFIG to stay empty, got %q", got)
+	}
+}
+
+func TestSetupExplicitKubeconfigExpandsHome(t *testing.T) {
+	currentUser, err := user.Current()
+	if err != nil {
+		t.Fatalf("failed to get current user: %v", err)
+	}
+
+	tests := []struct {
+		name       string
+		kubeconfig string
+	}{
+		{name: "home with trailing separator", kubeconfig: "~/"},
+		{name: "bare home", kubeconfig: "~"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("KUBECONFIG", "old-config")
+
+			got, err := setupExplicitKubeconfig(tt.kubeconfig)
+			if err != nil {
+				t.Fatalf("setupExplicitKubeconfig returned error: %v", err)
+			}
+			if got != currentUser.HomeDir {
+				t.Fatalf("expected expanded path %q, got %q", currentUser.HomeDir, got)
+			}
+			if env := os.Getenv("KUBECONFIG"); env != "old-config" {
+				t.Fatalf("expected KUBECONFIG to stay %q, got %q", "old-config", env)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Purpose of this PR

Fixes #51 by letting Arena use client-go native kubeconfig loading rules when `--config` is not explicitly set.

**Proposed changes:**

- Preserve explicit single-file kubeconfig handling for `--config`.
- Allow `KUBECONFIG=file1:file2:file3` to be parsed through client-go default precedence.
- Add unit tests for explicit kubeconfig and multi-file `KUBECONFIG` loading rules.

## Change Category

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

The previous setup path copied `KUBECONFIG` into `ExplicitPath`, so a path-list such as `file1:file2:file3` was treated as one kubeconfig file and failed with `stat`. Leaving `ExplicitPath` empty for environment-based configuration lets client-go split and merge the list according to Kubernetes native behavior.

## Validation

- `go test ./pkg/apis/config`
- `go test $(go list ./... | rg -v '^github.com/kubeflow/arena/test/e2e$')`

Note: `go test ./...` still fails in the local e2e setup because `/Users/a1021500303/.kube/config` is a directory on this machine.
