### PR TITLE
kep: update arena v2 proposal

### DIFF
--- a/keps/arena-v2/README.md
+++ b/keps/arena-v2/README.md
@@ -21,6 +21,8 @@
       - [5. Reduced attack surface](#5-reduced-attack-surface)
       - [6. Resource lifecycle](#6-resource-lifecycle)
     - [Detailed Component Comparison](#detailed-component-comparison)
+    - [Migration Notes](#migration-notes)
+      - [PyTorch: `worker.replicas` (v2) vs `--workers` (v1)](#pytorch-workerreplicas-v2-vs---workers-v1)
     - [Test Plan](#test-plan)
     - [Graduation Criteria](#graduation-criteria)
     - [Upgrade / Downgrade Strategy](#upgrade--downgrade-strategy)
@@ -36,7 +38,7 @@
 
 ## Summary
 
-Arena v2 is a complete architectural redesign of Arena, addressing fundamental limitations in v1 that made the tool difficult to maintain, extend, and use at scale. The redesign eliminates Helm dependencies, reduces code complexity, introduces YAML-first configuration, and replaces shell-outs with direct Kubernetes API calls.
+Arena v2 is a complete architectural redesign of Arena, addressing fundamental limitations in v1 that make the tool difficult to maintain, extend, and use at scale. The redesign eliminates Helm dependencies, reduces code complexity, introduces YAML-first configuration, and replaces shell-outs with direct Kubernetes API calls.
 
 ## Motivation
 
@@ -46,13 +48,13 @@ Arena v1, while functional, suffers from architectural decisions that create sig
 
 Arena v2 addresses fundamental architectural limitations in Arena v1:
 
-1. **Eliminate Helm dependency** — Generate K8s resources directly in Go, not through Helm chart rendering. This removes 24 Helm charts and the entire Helm Go SDK dependency tree.
+1. **Eliminate Helm dependency** — Generate K8s resources directly in Go, not through Helm chart rendering. This removes 23 Helm charts and the entire Helm Go SDK dependency tree.
 
-2. **YAML-first configuration** — v1 is flag-only (40+ CLI flags for a TFJob) and saves **final** helm chart values into configmap. v2 introduces a structured YAML schema where users can version, review, and reuse job configurations as code. CLI flags remain available for quick submissions.
+2. **YAML-first configuration** — v1 is flag-only (40+ CLI flags for a TFJob) and saves **final** Helm chart values into a ConfigMap. v2 introduces a structured YAML schema where users can version, review, and reuse job configurations as code. CLI flags remain available for quick submissions.
 
-3. **Reduce code complexity** — v1's training submission path spans thousands lines of Go code across `pkg/commands/`, `pkg/training/`, `pkg/argsbuilder/`, `pkg/apis/`, and `pkg/workflow/`.
+3. **Reduce code complexity** — v1's training submission path spans thousands of lines of Go code across `pkg/commands/`, `pkg/training/`, `pkg/argsbuilder/`, `pkg/apis/`, and `pkg/workflow/`.
 
-4. **Direct K8s API usage** — v1 submits jobs through a 6-step pipeline: serialize args → render Helm chart → save to temp file → create ConfigMap → shell out to `kubectl apply` → patch owner references. v2 keeps owner references patches and calls the K8s dynamic client API directly: `kc.CreateUnstructured(ctx, gvr, crd)`. No temp files, no shell-outs.
+4. **Direct K8s API usage** — v1 submits jobs through a 6-step pipeline: serialize args → render Helm chart → save to temp files → create ConfigMap → shell out to `kubectl apply` → patch owner references. v2 adds owner references to created resources and calls the K8s dynamic client API directly: `kc.CreateUnstructured(ctx, gvr, crd)`. No temp files, no shell-outs.
 
 5. **Type-agnostic CRD generation** — Use `unstructured.Unstructured` instead of operator-specific Go types. This decouples Arena from specific Training Operator API versions and makes the code resilient to operator upgrades.
 
@@ -70,14 +72,14 @@ Arena v2 adopts a modular architecture that separates concerns and reduces coupl
 
 ```
 cmd/arena-v2/main.go          → Entry point
-pkg/cli/                       → Cobra commands (root, run, get, list, delete, stop, resume, logs, submit, version, completion)
+pkg/cli/                       → Cobra commands (root, status, top, check, job, submit, version, completion)
 pkg/task/                      → Task data model, YAML loader, flag overrides
-pkg/provider/                  → Provider interface + implementations (PyTorchJob, TFJob, MPIJob)
+pkg/provider/                  → Provider interface + implementations (PyTorchJob, MPIJob)
 pkg/client/                    → K8s dynamic + typed client wrapper
 pkg/output/                    → Table formatting for CLI output
 ```
 
-**Provider Interface**: Each framework (PyTorchJob, TFJob, MPIJob) implements `provider.Provider`:
+**Provider Interface**: Each framework (PyTorchJob, MPIJob) implements `provider.Provider`:
 
 - `BuildCRD(task) → *unstructured.Unstructured` — Task spec to Operator CRD
 - `GetJobStatus()` / `GetPods()` / `GetLogPod()` — Read back status
@@ -97,11 +99,11 @@ As a platform engineer, I want to add support for a new training framework (e.g.
 
 **Story 3: Operator maintaining backward compatibility**
 
-As an operator maintaining existing CI/CD pipelines, I want to continue using `arena submit tfjob --name my-job --workers 4 --gpus 2 "python train.py"` without rewriting my automation scripts, while the platform team gradually adopts v2's YAML-based workflows.
+As a cluster operator maintaining existing CI/CD pipelines, I want to continue using `arena submit pytorchjob --name my-job --workers 4 --gpus 2 "python train.py"` without rewriting my automation scripts, while the platform team gradually adopts v2's YAML-based workflows.
 
 ### Notes/Constraints/Caveats
 
-- v2 is a separate project that lives in the `v2` branch and is built from scratch, it does not import any v1 packages.
+- v2 is a separate project that lives in the `v2` branch and is built from scratch. It does not import any v1 packages.
 - The `arena-v2` binary name is temporary for development. The final build target is `arena` — the `-v2` suffix is removed once v2 reaches feature parity.
 - v2's legacy `arena submit` command provides v1-style flag-based submission by mapping old flags to v2's internal `Task` model. Users can continue using v1 syntax without rewriting scripts.
 
@@ -111,11 +113,11 @@ As an operator maintaining existing CI/CD pipelines, I want to continue using `a
 
 #### 1. Simpler maintenance
 
-The tfjob Helm chart template in v1 is 1,323 lines of nested conditionals for PS/Worker/Chief/Evaluator roles. Every field must be duplicated across different blocks (node selectors, tolerations, volumes, init containers, security contexts). In v2, the same logic is a few hundred lines of Go that programmatically constructs corresponding CR fields maps.
+The tfjob Helm chart template in v1 is 1,323 lines of nested conditionals for PS/Worker/Chief/Evaluator roles. Every field must be duplicated across different blocks (node selectors, tolerations, volumes, init containers, security contexts). In v2, the same logic is a few hundred lines of Go that programmatically constructs corresponding CR field maps.
 
 #### 2. Faster iteration
 
-Adding a new field in v1 requires changes in 5 places: types struct, argsbuilder, Helm chart `values.yaml`, Helm chart template, and command file. In v2, adding a field requires updating the YAML schema, the Go struct definition, and the provider relative methods.
+Adding a new field in v1 requires changes in five places: types struct, argsbuilder, Helm chart `values.yaml`, Helm chart template, and command file. In v2, adding a field requires updating the YAML schema, the Go struct definition, and the provider's relevant methods.
 
 #### 3. Better user experience
 
@@ -131,13 +133,13 @@ v1 shells out to `helm` and `kubectl`, which requires these binaries in `PATH` a
 
 #### 6. Resource lifecycle
 
-A single `arena job run` submission creates multiple K8s resources: the Operator CRD (PyTorchJob/TFJob/MPIJob), optionally a TensorBoard Deployment+Service, and a ConfigMap storing the original YAML and generated manifest. In v1, these resources are tracked via a resource list in the ConfigMap and deleted through a 3-step pipeline (read ConfigMap → delete resources → delete ConfigMap), which risks resource leaks if the list is incomplete or the process crashes mid-delete.
+A single `arena job run` submission creates multiple K8s resources: the Operator CRD (PyTorchJob/MPIJob), optionally a TensorBoard Deployment+Service, and a ConfigMap storing the original YAML and generated manifest. In v1, these resources are tracked via a resource list in the ConfigMap and deleted through a 3-step pipeline (read ConfigMap → delete resources → delete ConfigMap), which risks resource leaks if the list is incomplete or the process crashes mid-delete.
 
-v2 adopts the same pattern: Deletion becomes a single operation and metadata storage (ConfigMap or a new CRD) respects training job CR `ttlSecondsAfterFinished`  — just deleting the top level resource will trigger K8s garbage collection to cascade-delete all owned resources. This eliminates resource leaks and simplifies `arena job delete` to one API call.
+v2 adopts a different pattern: deletion is simplified to a single operation. Deleting the top-level training job CR triggers K8s garbage collection to cascade-delete all owned resources. This eliminates resource leaks and simplifies `arena job delete` to a single API call. Likewise, all owned resources are cleaned up alongside the training job CR when its `ttlSecondsAfterFinished` expires.
 
 ```
 PyTorchJob CRD
-  ├── owns → ConfigMap "my-job" (stores original YAML, a new CRD could replace the native ConfigMap)
+  ├── owns → ConfigMap "my-job" (stores effective training job YAML; a new CRD could replace the native ConfigMap)
   ├── owns → TensorBoard Deployment
   └── owns → TensorBoard Service
 ```
@@ -148,16 +150,30 @@ PyTorchJob CRD
 |--------|----------|----------|
 | **Job submission** | Helm chart rendering + `kubectl apply` shell-out | Direct K8s dynamic client API |
 | **Configuration** | CLI flags only (no YAML) | YAML schema + CLI flags |
-| **Helm dependency** | Yes — `helm.sh/helm/v3` + 24 charts | No |
+| **Helm dependency** | Yes — `helm.sh/helm/v3` + 23 charts | No |
 | **kubectl dependency** | Yes — shells out to `kubectl apply/delete` | No — uses `client-go` directly |
-| **Training Go code** | thousands of lines | a few thousand lines |
-| **Helm charts** | 24 charts maintained alongside Go code | 0 |
+| **Training Go code** | thousands of lines | a few hundred lines |
+| **Helm charts** | 23 charts maintained alongside Go code | 0 |
 | **Temp files per submission** | 3 (values.yaml, rendered manifest, app-info) | 0 |
 | **Resource lifecycle** | 3-step delete (read ConfigMap → delete resources → delete ConfigMap) | 1-step delete (delete anchor resource → K8s GC cascades) |
-| **Per-role config (TFJob)** | 40+ CLI flags (e.g., `--worker-image`, `--ps-cpu`, `--chief-memory`) | `chief/ps` block in YAML with independent per-role declaration |
+| **Per-role config** | 40+ CLI flags (e.g., `--worker-image`, `--ps-cpu`, `--chief-memory`) | `chief/ps/evaluator/launcher/master/worker` block in YAML with independent per-role declaration |
 | **Adding a new operator** | Implement Go types + argsbuilder + command + Helm chart + chart template | Implement `provider.Provider` interface |
 | **Operator version coupling** | Tightly coupled — must update Go types when operator CRD API changes | Loosely coupled — `unstructured.Unstructured` is version-agnostic |
 | **Binary size** | Larger (Helm SDK + transitive deps) | Smaller (only `client-go` + `cobra`) |
+
+### Migration Notes
+
+#### PyTorch: `worker.replicas` (v2) vs `--workers` (v1)
+
+> **PyTorch-specific:** Only v1's PyTorch submit path subtracts the master from `--workers`.
+
+**Key difference:** v1's `--workers=N` includes the master (internally decremented by 1), while v2's `worker.replicas=N` excludes it — the master is always an additional Pod.
+
+**Migration formula:** `worker.replicas = --workers - 1`. Since `--workers` is always ≥ 1, when `--workers` is 1, `worker.replicas` would be 0, which violates the > 0 constraint. In this case, omit the worker block and specify the master block instead.
+
+In v2, the PyTorch master is fixed at 1 replica, inherits worker config by default if `master` block is omitted, and can be independently configured via the `master` block. **Total GPU-using replicas** = `worker.replicas + 1`.
+
+For framework-specific mappings across all providers, see the [worker.replicas → Provider Mapping](yaml-schema.md#workerreplicas--provider-mapping) section in the YAML schema specification.
 
 ### Test Plan
 
@@ -167,7 +183,7 @@ The test plan for Arena v2 includes:
 
 - YAML schema parsing and validation
 - Flag-to-YAML override merging logic
-- Provider CRD generation (PyTorchJob, TFJob, MPIJob)
+- Provider CRD generation (PyTorchJob, MPIJob)
 - K8s client wrapper error handling
 
 **Integration tests:**
@@ -188,39 +204,40 @@ The test plan for Arena v2 includes:
 **Alpha/MVP (Phase 1 - current):**
 
 - v1 remains the default for production use
-- Legacy arena `submit` command for backward compatibility
 - Core training submission (PyTorchJob, MPIJob) with YAML schema
-- Basic command (`arena version`, `arena help`)
-- Display cluster resource info（`arena top`）
-- Basic job manipulates and status queries (`arena job delete`, `arena job get`, `arena job list`, `arena job status`, `arena job logs`), using `arena job` prefix alias to support v1 `arena delete/get/list/status/logs` commands
+  - without `scheduling` semantics support
+- Basic commands (`arena version`, `arena help`)
+- Display cluster resource info (`arena top`)
+- Supports basic job manipulations and status queries (e.g., `arena job delete`, `arena job get`, `arena job list`, `arena job status`, `arena job logs`). The `arena job` prefix provides equivalent functionality to v1 `arena delete/get/list/status/logs` commands.
 - Add new sub-commands
   - `job`
-    - `run`，launch a training job from a YAML file and CLI flags
-    - `stop`, stop a running training job (operation, not YAML config)
-    - `resume`, resume a stopped training job (operation, not YAML config)
-  - `check`, check if cluster has already installed required CRD
+    - `run`, launch a training job from a YAML file
+    - `suspend`, suspend a running training job (operation, not YAML config)
+    - `resume`, resume a suspended training job (operation, not YAML config)
+  - `check`, check if the cluster has the required CRD installed
+- Dry-run mode for CRD inspection
 
 **Beta (Phase 2 - next):**
 
-- Dry-run mode for CRD inspection
-- Advanced features: `lifecycle` policies, `sync`/`init` containers
+- Legacy `arena submit` command for backward compatibility
+- Support `scheduling` semantics
 - Users begin migrating simple jobs to v2
 - Comprehensive CLI flag coverage matching v1 functionality
 - Output formats: JSON, YAML, wide
-- InferenceTask kind (RBG only)
+- InferenceTask kind (planned to use [RBG](https://github.com/sgl-project/rbg) for orchestration)
   - Add new sub-commands
     - `serve`
-- Add DeepSpeed support and example
-- TensorFlow provider
-- Ray provider (RayJob CRD)
+- Add DeepSpeed, TensorFlow, Ray support and examples
+- Support overriding stable YAML fields via CLI flags (such as `name`, `worker.replicas`, etc.)
 
 **Stable (Phase 3 - future):**
 
-- Platform agnostic configuration via `arena configure`
+- Support overriding the entire YAML schema via CLI flags
+- Platform-agnostic configuration via `arena configure`
 - v1 is deprecated but still maintained for bug fixes
 - Agent, evaluation, and benchmark task kinds
 - `arena migrate` tool for converting v1 flag-based invocations to v2 YAML files
-- Multi-model pipeline support
+- Add Horovod support and examples
 
 ### Upgrade / Downgrade Strategy
 
@@ -263,7 +280,7 @@ The test plan for Arena v2 includes:
 **How can this feature be enabled/disabled?**
 
 - v2 is a separate binary (`arena-v2`) during development, allowing users to opt-in
-- Once v2 reaches feature parity, it replaces the v1 binary (`arena`)
+- Once v2 reaches feature parity, it replaces the `arena` v1 binary
 - Users can continue using v1 by not installing v2
 
 **Can the feature be disabled once it has been enabled?**
@@ -276,7 +293,7 @@ The test plan for Arena v2 includes:
 
 **How will this be rolled out?**
 
-- v2 is developed in parallel with v1 on the `v2` branch
+- v2 is being developed in the `v2` branch, in parallel with v1
 - Users can test v2 in non-production environments first
 - Gradual adoption as v2 reaches feature parity with v1
 
@@ -288,7 +305,7 @@ The test plan for Arena v2 includes:
 
 **How will rollback work if something goes wrong?**
 
-- Users can revert to v1 binary at any time
+- Users can revert to the v1 binary at any time
 - v2 does not modify cluster state or v1 configuration
 - No data migration or rollback procedures required
 
@@ -302,7 +319,7 @@ The test plan for Arena v2 includes:
 
 **How can this feature be monitored?**
 
-- Kubernetes metrics for created CRDs (PyTorchJob, TFJob, MPIJob)
+- Kubernetes metrics for created CRDs (PyTorchJob, MPIJob)
 - Job completion/failure rates
 - Submission latency (time from CLI invocation to CRD creation)
 
@@ -312,7 +329,7 @@ The test plan for Arena v2 includes:
 
 - v2 depends only on `client-go` for Kubernetes API access
 - No dependency on Helm, kubectl, or external binaries
-- Requires Training Operator (or compatible operator) to be installed in the cluster
+- Training Operator and MPI Operator are mandatory. KubeRay will become a requirement when Ray support is added.
 
 **Are there any new dependencies introduced?**
 
@@ -352,6 +369,7 @@ The test plan for Arena v2 includes:
 
 - **Arena v1 codebase**: https://github.com/kubeflow/arena/tree/v0.15.4
 - **YAML schema specification**: `keps/arena-v2/yaml-schema.md` (YAML Schema section)
-- **CLI flag mapping**: `keps/arena-v2/cli-flag-mapping.md` (CLI Override Mapping section)
-- **Kubernetes Training Operator**: https://github.com/kubeflow/training-operator
+- **CLI flag mapping**: `keps/arena-v2/cli-flag-mapping.md`
+- **Kubeflow Trainer**: https://github.com/kubeflow/trainer/tree/release-1.9
+- **Kubeflow MPI Operator**: https://github.com/kubeflow/mpi-operator/tree/master
 - **client-go**: https://github.com/kubernetes/client-go

--- a/keps/arena-v2/README.md
+++ b/keps/arena-v2/README.md
@@ -197,7 +197,11 @@ The test plan for Arena v2 includes:
 - Submit real training jobs to a test cluster
 - Verify CRD structure matches operator expectations
 - Test job lifecycle (submit → running → completed/failed)
-- Validate per-role configuration (worker vs master vs PS)
+- Validate per-role configuration (worker vs. master vs. launcher)
+  - PyTorch job with only `master` specified (`worker` omitted; single-node mode)
+  - PyTorch job with both `worker` and `master` specified (multi-node mode)
+  - MPI job using default CPU-only launcher (no explicit `launcher` block)
+  - MPI job with both `worker` and `launcher` specified
 
 ### Graduation Criteria
 
@@ -224,7 +228,7 @@ The test plan for Arena v2 includes:
 - Users begin migrating simple jobs to v2
 - Comprehensive CLI flag coverage matching v1 functionality
 - Output formats: JSON, YAML, wide
-- InferenceTask kind (planned to use [RBG](https://github.com/sgl-project/rbg) for orchestration)
+- InferenceTask kind (planned to leverage [RBG](https://github.com/sgl-project/rbg) for serving orchestration)
   - Add new sub-commands
     - `serve`
 - Add DeepSpeed, TensorFlow, Ray support and examples

--- a/keps/arena-v2/cli-flag-mapping.md
+++ b/keps/arena-v2/cli-flag-mapping.md
@@ -1,107 +1,110 @@
-# Arena V1 → V2 Flag Audit
+# Arena V1 Flag → V2 YAML Schema Audit
 
 This document maps all arena v1 training CLI flags to arena v2 YAML schema coverage.
 
-**Scope:** `arena submit` training subcommands  
+**Scope:** v1 `arena submit` flags → v2 `arena job run` YAML schema
 **Source of truth:** arena v2 YAML Schema + arena v1 CLI
+
+> **Note:** v2 CLI flag-to-YAML override mechanism will be designed separately as a generic `--set`-style approach (similar to Helm). This document tracks v1 flag → v2 YAML schema coverage only.
 
 ---
 
 ## 1. Coverage Summary
 
-| Category | v2 Covered | v2 Missing |
+| Category | v2 Covered | v2 Missing / Notes |
 |----------|-----------|------------|
-| Identity | ✅ name, image, labels, annotations, namespace | — |
-| Resources | ✅ cpus, memory, shm, nvidia.com/gpu, extended resources (`--device`) | — |
-| Scheduling | ✅ node_selector, tolerations, priority, priority_class_name, gang, scheduler_name, affinity (policy/constraint), selector, toleration, queue | — |
-| Data | ✅ storages (PVC) | ❌ hostPath, config-file (ConfigMap mount) |
-| Env | ✅ envs (plain/secretKeyRef/configMapKeyRef), per-role independent declaration | — |
+| Identity | ✅ name, labels, annotations, namespace | — |
+| Resources | ✅ cpu, memory, nvidia.com/gpu, extended resources (`--device`) | — |
+| Scheduling | ✅ node_selector, tolerations, priority, priority_class_name, gang, scheduler_name, affinity (policy/constraint/target/rules), queue | not yet implemented |
+| Data | ✅ storages (PVC, hostPath, tmp, shm, configmap, secret) | — |
+| Env | ✅ envs (plain/secretKeyRef/configMapKeyRef) | — |
 | Execution | ✅ restart, image_pull_policy, image_pull_secrets, shell, working_dir | — |
 | Lifecycle | ✅ clean_pod_policy, active_deadline, ttl_after_finished, backoff_limit, success_policy | — |
 | Sync | ✅ sync (git/rsync/hdfs) | — |
-| Model | — | ❌ model-name, model-source |
-| TFJob roles | — | ❌ ps, evaluator, chief independent config |
-| MPIJob | ✅ mounts_on_launcher, gpu_topology, run_launcher_as_worker |— |
+| Model | ❌ | — |
+| TFJob roles | ✅ | provider not yet implemented |
+| MPIJob | ✅ mounts_on_launcher, run_launcher_as_worker, slots_per_worker | — |
 | PyTorch | ✅ nproc_per_node | — |
-| Horovod | ✅ ssh_port | — |
-| DeepSpeed | — | (provider not yet implemented) |
-| Ray | — | ❌ entire Ray provider (Phase 3) |
+| Horovod | ✅ | provider not yet implemented |
+| DeepSpeed | ✅ | provider not yet implemented |
+| Ray | ✅ (framework placeholder only) | provider not yet implemented |
 
 **Legend:** ✅ = designed in arena v2 schema, ❌ = not in schema, — = N/A
 
 ---
 
-## 2. Common Submit Flags (shared by most frameworks)
+## 2. Common Job Run Flags (shared by most frameworks)
 
 ### 2a. Identity
 
-| v1 Flag | Type | Default | v2 YAML | v2 CLI Flag | Status |
-|---------|------|---------|---------|-------------|--------|
-| `--name` | string | required | `name` | `--name` | ✅ |
-| `--image` | string | required | `image` | `--image` | ✅ |
-| `--image-pull-policy` | string | `"Always"` | `image_pull_policy` | `--image-pull-policy` | ✅ |
-| `--image-pull-secret` | string[] | `[]` | `image_pull_secrets` | `--image-pull-secret` | ✅ (reference-only, no auto-create) |
+| v1 Flag | Type | Default | v2 YAML | Status |
+|---------|------|---------|---------|--------|
+| `--name` | string | required | `name` | ✅ |
+| `--namespace` | string | optional | `namespace` | ✅ |
 
 ### 2b. Resources
 
-| v1 Flag | Type | Default | v2 YAML | v2 CLI Flag | Status |
-|---------|------|---------|---------|-------------|--------|
-| `--gpus` | int | `0` | `worker.resources.nvidia.com/gpu` | `--gpus` | ✅ |
-| `--cpu` | string | `""` | `worker.resources.cpus` | `--cpus` | ✅ |
-| `--memory` | string | `""` | `worker.resources.memory` | `--mem` | ✅ |
-| `--device` | string[] | `[]` | `worker.resources.<name>` (flat) | `--device` | ✅ e.g. `--device hugepages-2Mi=32Gi` |
-| `--workers` | int | `1` | `worker.replicas` | `--workers` | ✅ |
+| v1 Flag | Type | Default | v2 YAML | Status |
+|---------|------|---------|---------|--------|
+| `--gpus` | int | `0` | `nvidia.com/gpu` field in `worker.resources` block | ✅ |
+| `--cpu` | string | `""` | `worker.resources.cpu` | ✅ |
+| `--memory` | string | `""` | `worker.resources.memory` | ✅ |
+| `--device` | string[] | `[]` | `<device-name>` field in `worker.resources` block | ✅ e.g. `--device hugepages-2Mi=32Gi` |
+| `--workers` | int | `1` | `worker.replicas` | ✅ (see the [Migration Notes](README.md#migration-notes) section) |
 
-**Note:** v1 `--device vendor.com/device=count` maps to v2 flat `resources.vendor.com/device: count`.
+**Note:** v1 `--device vendor.com/device=count` maps to v2 flat `vendor.com/device: count` field in `resources` block.
 
 ### 2c. Scheduling
 
-| v1 Flag | Type | Default | v2 YAML | v2 CLI Flag | Status |
-|---------|------|---------|---------|-------------|--------|
-| `--selector` | string[] | `[]` | `scheduling.node_selector` | `--selector` | ✅ |
-| `--toleration` | string[] | `[]` | `scheduling.tolerations` | `--toleration` | ✅ |
-| `-p, --priority` | int | `0` | `scheduling.priority` | `--priority` | ✅ Pod spec priority field |
-| `--priority-class-name` | string | `""` | `scheduling.priority_class_name` | `--priority-class-name` | ✅ Pod spec priorityClassName field |
-| `--gang` | bool | `false` | `scheduling.gang` | `--gang` | ✅ |
-| `--scheduler` | string | `""` | `scheduling.scheduler_name` | `--scheduler-name` | ✅ |
-| `--affinity-policy` | string | `""` | `scheduling.affinity.policy` | `--affinity-policy` | ✅ `none` / `spread` / `binpack` |
-| `--affinity-constraint` | string | `""` | `scheduling.affinity.constraint` | `--affinity-constraint` | ✅ `preferred` / `required` |
-| `--hostNetwork` | bool | `false` | `host_network` | `--host-network` | ✅ (top-level runtime field, not under scheduling) |
-| `--hostIPC` | bool | `false` | `host_ipc` | `--host-ipc` | ✅ (top-level runtime field, not under scheduling) |
-| `--hostPID` | bool | `false` | `host_pid` | `--host-pid` | ✅ (top-level runtime field, not under scheduling) |
-| `--queue` | string | `""` | `scheduling.queue` | — | ✅ (YAML field exists) |
-| `--rdma` | bool | `false` | — | — | ❌ NOT PLANNED |
+| v1 Flag | Type | Default | v2 YAML | Status |
+|---------|------|---------|---------|--------|
+| `--selector` | string[] | `[]` | `scheduling.node_selector` | ✅ |
+| `--toleration` | string[] | `[]` | `scheduling.tolerations` | ✅ |
+| `-p, --priority` | int | `0` | `scheduling.priority` | ✅ Pod spec priority field |
+| `--priority-class-name` | string | `""` | `scheduling.priority_class_name` | ✅ Pod spec priorityClassName field |
+| `--gang` | bool | `false` | `scheduling.gang.enabled` | ✅ |
+| `--scheduler` | string | `""` | `scheduling.scheduler_name` | ✅ |
+| `--affinity-policy` | string | `""` | `scheduling.affinity.policy` | ✅ `none` / `spread` / `binpack` |
+| `--affinity-constraint` | string | `""` | `scheduling.affinity.constraint` | ✅ `preferred` / `required` |
+| `--queue` | string | `""` | `scheduling.queue` | ✅ (YAML field exists) |
+| `--rdma` | bool | `false` | — | ❌ NOT PLANNED |
 
 ### 2d. Data and Volumes
 
-| v1 Flag | Type | Default | v2 YAML | v2 CLI Flag | Status |
-|---------|------|---------|---------|-------------|--------|
-| `-d, --data` | string[] | `[]` | `storages[].pvc` + `storages[].mount_path` | `-d, --data` | ✅ |
-| `--data-dir` | string[] | `[]` | `storages[].hostpath` + `storages[].mount_path` | `-d, --data` | ✅ |
-| `--config-file` | string[] | `[]` | — | — | ❌ ConfigMap file mount not in schema |
+| v1 Flag | Type | Default | v2 YAML | Status |
+|---------|------|---------|---------|--------|
+| `-d, --data` | string[] | `[]` | `storages[].pvc` + `storages[].mount_path` | ✅ |
+| `--data-dir` | string[] | `[]` | `storages[].hostpath` + `storages[].mount_path` | ✅ |
+| `--config-file` | string[] | `[]` | `storages[].configmap + storages[].mount_path` | ✅ |
+| `--share-memory` | string | `"2Gi"` | `storages[].shm` | ✅ (emptyDir medium: Memory at /dev/shm) |
 
 ### 2e. Environment and Labels
 
-| v1 Flag | Type | Default | v2 YAML | v2 CLI Flag | Status |
-|---------|------|---------|---------|-------------|--------|
-| `-e, --env` | string[] | `[]` | `envs` | `-e, --env` | ✅ (plain, secretKeyRef, configMapKeyRef) |
-| `-a, --annotation` | string[] | `[]` | `annotations` | `-a, --annotation` | ✅ |
-| `-l, --label` | string[] | `[]` | `labels` | `-l, --label` | ✅ |
+| v1 Flag | Type | Default | v2 YAML | Status |
+|---------|------|---------|---------|--------|
+| `-e, --env` | string[] | `[]` | `envs` | ✅ (plain, secretKeyRef, configMapKeyRef) |
+| `-a, --annotation` | string[] | `[]` | `annotations` | ✅ |
+| `-l, --label` | string[] | `[]` | `labels` | ✅ |
 
 ### 2f. Execution
 
-| v1 Flag | Type | Default | v2 YAML | v2 CLI Flag | Status |
-|---------|------|---------|---------|-------------|--------|
-| `--working-dir` | string | image default | `working_dir` | `--working-dir` | ✅ |
-| `--shell` | string | `/bin/sh` | `shell` | `--shell` | ✅ (invalid values fallback to /bin/sh) |
-| `--retry` | int | `0` | `lifecycle.backoff_limit` | `--backoff-limit` | ✅ (v1 `--retry` → v2 `lifecycle.backoff_limit`) |
+| v1 Flag | Type | Default | v2 YAML | Status |
+|---------|------|---------|---------|--------|
+| `--working-dir` | string | image default | `working_dir` | ✅ |
+| `--shell` | string | `/bin/sh` | `shell` | ✅ (invalid values fall back to /bin/sh) |
+| `--image` | string | required | `image` | ✅ |
+| `--image-pull-policy` | string | `"Always"` | `image_pull_policy` | ✅ |
+| `--image-pull-secret` | string[] | `[]` | `image_pull_secrets` | ✅ (reference-only, no auto-create) |
+| `--hostNetwork` | bool | `false` | `host_network` | ✅ |
+| `--hostIPC` | bool | `false` | `host_ipc` | ✅ |
+| `--hostPID` | bool | `false` | `host_pid` | ✅ |
 
 ### 2g. Model Registry
 
 | v1 Flag | Type | Default | v2 YAML | Status |
 |---------|------|---------|---------|--------|
-| `--model-name` | string | `""` | — | ❌ NOT PLANNED (Phase 3+) |
-| `--model-source` | string | `""` | — | ❌ NOT PLANNED (Phase 3+) |
+| `--model-name` | string | `""` | — | ❌ NOT PLANNED |
+| `--model-source` | string | `""` | — | ❌ NOT PLANNED |
 
 ---
 
@@ -111,30 +114,30 @@ This document maps all arena v1 training CLI flags to arena v2 YAML schema cover
 |---------|------|---------|---------|--------|
 | `--sync-mode` | string | `""` | `sync[].git/rsync/hdfs` (type key) | ✅ |
 | `--sync-source` | string | `""` | `sync[].git/rsync/hdfs` (value) | ✅ |
-| `--sync-image` | string | `""` | — | ❌ NOT PLANNED (sync uses fixed init container images per type) |
+| `--sync-image` | string | `""` | `sync[].<git/rsync/hdfs>.image` | ✅ |
 
 ---
 
 ## 4. Tensorboard Flags
 
-| v1 Flag | Type | Default | v2 YAML | v2 CLI Flag | Status |
-|---------|------|---------|---------|-------------|--------|
-| `--tensorboard` | bool | `false` | `logging.tensorboard.enabled` | `--tensorboard` | ✅ |
-| `--tensorboard-image` | string | `""` | `logging.tensorboard.image` | `--tensorboard-image` | ✅ |
-| `--logdir` | string | `"/training_logs"` | `logging.tensorboard.logdir` | `--tensorboard-logdir` | ✅ |
+| v1 Flag | Type | Default | v2 YAML | Status |
+|---------|------|---------|---------|--------|
+| `--tensorboard` | bool | `false` | `logging.tensorboard.enabled` | ✅ |
+| `--tensorboard-image` | string | `""` | `logging.tensorboard.image` | ✅ |
+| `--logdir` | string | `"/training_logs"` | `logging.tensorboard.logdir` | ✅ |
 
 ---
 
-## 5. Job Lifecycle (common across frameworks, varying defaults)
+## 5. Job Lifecycle
 
-| v1 Flag | Type | Default | v2 YAML | v2 CLI Flag | Status |
-|---------|------|---------|---------|-------------|--------|
-| `--clean-task-policy` | string | varies | `lifecycle.clean_pod_policy` | `--clean-pod-policy` | ✅ (`None` / `Running` / `All`) |
-| `--running-timeout` | duration | `0` | `lifecycle.active_deadline` | `--active-deadline` | ✅ |
-| `--ttl-after-finished` | duration | `0` | `lifecycle.ttl_after_finished` | `--ttl-after-finished` | ✅ |
-| `--backoff-limit` | int | `6` | `lifecycle.backoff_limit` | `--backoff-limit` | ✅ |
-| `--success-policy` | string | varies | `lifecycle.success_policy` | `--success-policy` | ✅ (`ChiefWorker` / `AllWorkers`, TFJob only) |
-| `--share-memory` | string | `"2Gi"` | `storages[].shm` | `--shm` | ✅ (emptyDir medium: Memory at /dev/shm) |
+| v1 Flag | Type | Default | v2 YAML | Status |
+|---------|------|---------|---------|--------|
+| `--clean-task-policy` | string | varies | `lifecycle.clean_pod_policy` | ✅ (`None` / `Running` / `All`) |
+| `--running-timeout` | duration | `0` | `lifecycle.active_deadline` | ✅ |
+| `--ttl-after-finished` | duration | `0` | `lifecycle.ttl_after_finished` | ✅ |
+| `--job-backoff-limit` | int | `6` | `lifecycle.backoff_limit` | ✅ (use v2 `lifecycle.backoff_limit` default value) |
+| `--retry` (redundant, functions identically to `--job-backoff-limit`) | int | `0` | `lifecycle.backoff_limit` | ✅ (use v2 `lifecycle.backoff_limit` default value) |
+| `--success-policy` | string | varies | `lifecycle.success_policy` | ✅ (`ChiefWorker` / `AllWorkers`, TFJob only) |
 
 ---
 
@@ -142,80 +145,71 @@ This document maps all arena v1 training CLI flags to arena v2 YAML schema cover
 
 ### 6a. TFJob
 
-| v1 Flag | v2 YAML | v2 CLI Flag | Status |
-|---------|---------|-------------|--------|
-| `--ps` (count) | `ps.replicas` | `--ps-count` | ✅ YAML-only |
-| `--ps-image` | `ps.image` | — | ✅ YAML-only |
-| `--ps-cpu`, `--ps-cpu-limit`, `--ps-memory`, `--ps-memory-limit` | `ps.resources` | — | ✅ YAML-only |
-| `--ps-gpus` | `ps.resources.nvidia.com/gpu`) | — | ✅ YAML-only |
-| `--ps-selector` | - | — | ❌ NOT IN SCHEMA |
-| `--ps-affinity-policy` | - | — | ❌ NOT IN SCHEMA |
-| `--chief` (bool) | `chief` | - | ✅ YAML-only |
-| `--chief-cpu`, `--chief-memory`, etc. | chief.resources` | — | ✅ YAML-only |
-| `--chief-selector` | - | — | ❌ NOT IN SCHEMA |
-| `--evaluator` (bool) | `evaluator` | - | ✅ YAML-only |
-| `--evaluator-*` | - | — | ❌ NOT IN SCHEMA |
-| `--worker-image` | `worker.image` | — | ✅ YAML-only |
-| `--worker-port` | — | — | ❌ NOT IN SCHEMA |
-| `--worker-cpu`, `--worker-memory`, etc. | `worker.resources` | — | ✅ YAML-only |
-| `--worker-selector` | - | — | ❌ NOT IN SCHEMA |
-| `--worker-affinity-policy` | - | — | ❌ NOT IN SCHEMA |
-| `--success-policy` | `lifecycle.success_policy` | `--success-policy` | ✅ (moved to lifecycle block) |
-| `--role-sequence` | — | — | ❌ Implementation detail, not user-facing |
+| v1 Flag | v2 YAML | Status |
+|---------|---------|--------|
+| `--ps` (count) | `ps.replicas` | ✅ |
+| `--ps-image` | — | ❌ not yet implemented |
+| `--ps-cpu`, `--ps-cpu-limit`, `--ps-memory`, `--ps-memory-limit` | `ps.resources` | ✅ |
+| `--ps-gpus` | `ps.resources.nvidia.com/gpu` | ✅ |
+| `--ps-selector` | — | ❌ not yet implemented |
+| `--ps-affinity-policy` | — | ❌ not yet implemented |
+| `--chief` (bool) | `chief` | ✅ |
+| `--chief-cpu`, `--chief-memory`, etc. | `chief.resources` | ✅ |
+| `--chief-selector` | — | ❌ not yet implemented |
+| `--evaluator` (bool) | `evaluator` | ✅ |
+| `--evaluator-cpu`, `--evaluator-memory`, etc | `evaluator.resources` | ✅ |
+| `--evaluator-selector` | — | ❌ not yet implemented |
+| `--worker-image` | — | ❌ not yet implemented |
+| `--worker-port` | — | ❌ not yet implemented |
+| `--worker-cpu`, `--worker-memory`, etc. | `worker.resources` | ✅ |
+| `--worker-selector` | — | ❌ not yet implemented |
+| `--worker-affinity-policy` | — | ❌ not yet implemented |
+| `--success-policy` | `lifecycle.success_policy` | ✅ (moved to lifecycle block) |
+| `--role-sequence` | — | ❌ Implementation detail, not user-facing |
 
 ### 6b. PyTorchJob
 
-| v1 Flag | v2 YAML | v2 CLI Flag | Status |
-|---------|---------|-------------|--------|
-| `--cpu` | `resources.cpus` | `--cpus` | ✅ |
-| `--memory` | `resources.memory` | `--mem` | ✅ |
-| `--nproc-per-node` | `framework.options.nproc_per_node` | `--nproc-per-node` | ✅ (`auto` / `gpu` / `cpu` / int) |
+| v1 Flag | v2 YAML | Status |
+|---------|---------|--------|
+| `--cpu` | worker and master `resources.cpu` | ✅ |
+| `--memory` | worker and master `resources.memory` | ✅ |
+| `--nproc-per-node` | `framework.options.nproc_per_node` | ✅ (`auto` / `gpu` / `cpu` / int) |
 
 ### 6c. MPIJob
 
-| v1 Flag | v2 YAML | v2 CLI Flag | Status |
-|---------|---------|-------------|--------|
-| `--cpu` | `resources.cpus` | `--cpus` | ✅ |
-| `--memory` | `resources.memory` | `--mem` | ✅ |
-| `--gputopology` | `framework.options.gpu_topology` | `--gpu-topology` | ✅ |
-| `--mounts-on-launcher` | `framework.options.mounts_on_launcher` | `--mounts-on-launcher` | ✅ |
-| (no v1 flag) | `framework.options.run_launcher_as_worker` | — | ❌ CLI flag missing (YAML field exists) |
+| v1 Flag | v2 YAML | Status |
+|---------|---------|--------|
+| `--cpu` | `worker.resources.cpu` | ✅ |
+| `--memory` | `worker.resources.memory` | ✅ |
+| `--gputopology` | `worker.resources`, `labels` | ✅ |
+| `--mounts-on-launcher` | `framework.options.mounts_on_launcher` | ✅ |
+| (no v1 flag) | `framework.options.run_launcher_as_worker` | ✅ (YAML field exists, no v1 equivalent) |
+| (no v1 flag) | `framework.options.slots_per_worker` | ✅ (YAML field exists, no v1 equivalent) |
 
 ### 6d. Horovod
 
-| v1 Flag | v2 YAML | v2 CLI Flag | Status |
-|---------|---------|-------------|--------|
-| `--ssh-port` | `framework.options.ssh_port` | — | ✅ (YAML field exists) |
-| `--cpu` | `resources.cpus` | `--cpus` | ✅ |
-| `--memory` | `resources.memory` | `--mem` | ✅ |
+| v1 Flag | v2 YAML | Status |
+|---------|---------|--------|
+| `--ssh-port` | — | ❌ NOT IN SCHEMA (always use port 22) |
+| `--cpu` | `worker.resources.cpu` | ✅ |
+| `--memory` | `worker.resources.memory` | ✅ |
 
 ### 6e. DeepSpeed
 
-| v1 Flag | v2 YAML | v2 CLI Flag | Status |
-|---------|---------|-------------|--------|
-| `--cpu` | `resources.cpus` | `--cpus` | ✅ |
-| `--memory` | `resources.memory` | `--mem` | ✅ |
-| `--launcher-selector` | `roles[]` (name: launcher, `scheduling.node_selector`) | — | ✅ YAML-only |
-| `--job-restart-policy` | `restart` | `--restart` | ✅ |
-| `--job-backoff-limit` | `lifecycle.backoff_limit` | `--backoff-limit` | ✅ |
-| `--ssh-secret` | — | — | ❌ NOT IN SCHEMA (No ssh_secret is required because the mpi-operator already handles it) |
-| `--launcher-annotation` | `roles[]` (name: launcher, `annotations`) | — | ✅ YAML-only |
-| `--worker-annotation` | `roles[]` (name: worker, `annotations`) | — | ✅ YAML-only |
+| v1 Flag | v2 YAML | Status |
+|---------|---------|--------|
+| `--cpu` | `worker.resources.cpu` | ✅ |
+| `--memory` | `worker.resources.memory` | ✅ |
+| `--launcher-selector` | — | ❌ not yet implemented |
+| `--job-restart-policy` | `restart` | ✅ |
+| `--ssh-secret` | — | ❌ NOT IN SCHEMA (No ssh secret is required because the MPI Operator already handles it) |
+| `--launcher-annotation` | — | ❌ not yet implemented |
+| `--worker-annotation` | — | ❌ not yet implemented |
 
-### 6f. Elastic Training (ETJob)
-
-| v1 Flag | v2 YAML | v2 CLI Flag | Status |
-|---------|---------|-------------|--------|
-| `--max-workers` | — | — | ❌ NOT IN SCHEMA (Phase 3) |
-| `--min-workers` | — | — | ❌ NOT IN SCHEMA (Phase 3) |
-| `--spot-instance` | — | — | ❌ NOT IN SCHEMA (use PriorityClass) |
-| `--max-wait-time` | — | — | ❌ NOT IN SCHEMA |
-| `--launcher-selector` | `roles[]` (name: launcher, `scheduling.node_selector`) | — | ✅ YAML-only |
-| `--job-restart-policy` | `restart` | `--restart` | ✅ |
-| `--worker-restart-policy` | `roles[]` (name: worker, `restart`) | — | ✅ YAML-only |
-| `--job-backoff-limit` | `lifecycle.backoff_limit` | `--backoff-limit` | ✅ |
-| `--ssh-secret` | — | — | ❌ NOT IN SCHEMA |
-
-### 6g. RayJob (Phase 3)
+### 6f. RayJob
 
 Not mapped here — will be designed when Ray provider is added.
+
+### 6g. Elastic Training (ETJob)
+
+Not mapped here and not planned.

--- a/keps/arena-v2/cli-flag-mapping.md
+++ b/keps/arena-v2/cli-flag-mapping.md
@@ -5,7 +5,7 @@ This document maps all arena v1 training CLI flags to arena v2 YAML schema cover
 **Scope:** v1 `arena submit` flags → v2 `arena job run` YAML schema
 **Source of truth:** arena v2 YAML Schema + arena v1 CLI
 
-> **Note:** v2 CLI flag-to-YAML override mechanism will be designed separately as a generic `--set`-style approach (similar to Helm). This document tracks v1 flag → v2 YAML schema coverage only.
+> **Note:** v2 CLI flag-to-YAML override mechanism will be designed separately as a generic `--set`-style approach (similar to Helm). This document tracks v1 flag → v2 YAML schema coverage and implementation status.
 
 ---
 
@@ -16,16 +16,16 @@ This document maps all arena v1 training CLI flags to arena v2 YAML schema cover
 | Identity | ✅ name, labels, annotations, namespace | — |
 | Resources | ✅ cpu, memory, nvidia.com/gpu, extended resources (`--device`) | — |
 | Scheduling | ✅ node_selector, tolerations, priority, priority_class_name, gang, scheduler_name, affinity (policy/constraint/target/rules), queue | not yet implemented |
-| Data | ✅ storages (PVC, hostPath, tmp, shm, configmap, secret) | — |
+| Data | ✅ storages (PVC, hostpath, tmp, shm, configmap, secret) | — |
 | Env | ✅ envs (plain/secretKeyRef/configMapKeyRef) | — |
 | Execution | ✅ restart, image_pull_policy, image_pull_secrets, shell, working_dir | — |
 | Lifecycle | ✅ clean_pod_policy, active_deadline, ttl_after_finished, backoff_limit, success_policy | — |
 | Sync | ✅ sync (git/rsync/hdfs) | — |
-| Model | ❌ | — |
+| Model | ❌ |  not planned |
 | TFJob roles | ✅ | provider not yet implemented |
 | MPIJob | ✅ mounts_on_launcher, run_launcher_as_worker, slots_per_worker | — |
 | PyTorch | ✅ nproc_per_node | — |
-| Horovod | ✅ | provider not yet implemented |
+| Horovod | ✅ cpu, memory | ❌ `--ssh-port` not in schema (always use port 22); provider not yet implemented |
 | DeepSpeed | ✅ | provider not yet implemented |
 | Ray | ✅ (framework placeholder only) | provider not yet implemented |
 
@@ -181,7 +181,7 @@ This document maps all arena v1 training CLI flags to arena v2 YAML schema cover
 |---------|---------|--------|
 | `--cpu` | `worker.resources.cpu` | ✅ |
 | `--memory` | `worker.resources.memory` | ✅ |
-| `--gputopology` | `worker.resources`, `labels` | ✅ |
+| `--gputopology` | `host_network` + `worker.resources` + `labels` (`gpu-topology` / `gpu-topology-replica`) | ✅ |
 | `--mounts-on-launcher` | `framework.options.mounts_on_launcher` | ✅ |
 | (no v1 flag) | `framework.options.run_launcher_as_worker` | ✅ (YAML field exists, no v1 equivalent) |
 | (no v1 flag) | `framework.options.slots_per_worker` | ✅ (YAML field exists, no v1 equivalent) |

--- a/keps/arena-v2/yaml-schema.md
+++ b/keps/arena-v2/yaml-schema.md
@@ -46,7 +46,7 @@ envs:                                # Optional. Common envs.
   NCCL_IB_DISABLE: "0"
 
 # ─── Scale ───
-worker:                             # Required for non-PyTorch frameworks
+worker:                             # Required for MPI-based frameworks
   replicas: 4                       # Required if the worker block is present. Must be > 0 if specified.
   envs:                             # Optional
     NCCL_DEBUG: DEBUG               # Merges with top-level envs (worker value overrides)
@@ -55,9 +55,8 @@ worker:                             # Required for non-PyTorch frameworks
     cpu: 32
     memory: 128Gi
 
-# Other fields, such as launcher, chief, ps, or evaluator, may be available depending on the framework. 
-# Settings for replicas, resources, and environment variables may vary accordingly. 
-# Please refer to the framework-specific configuration documentation for more details.
+# For framework-specific role blocks (launcher, chief, ps, evaluator) and their default behaviors,
+# see the framework-specific configuration section below.
 master:                             # Only valid for PyTorch. Required if the worker block is omitted.
   replicas: 1                       # Optional. Master replicas must be 1.
   envs:                             # Optional
@@ -170,7 +169,7 @@ lifecycle:                           # Optional
   active_deadline: 2h                # Max active duration
   ttl_after_finished: 7d             # Auto-delete after this duration
   backoff_limit: 6                   # Max restart count
-  success_policy: ChiefWorker        # ChiefWorker | AllWorkers (TFJob only)
+  success_policy: ChiefWorker        # ChiefWorker | AllWorkers (TFJob only; ignored for other frameworks in Alpha, will be rejected by validation in Beta)
 
 # ─── Runtime ───
 # inject into all pods 
@@ -198,7 +197,7 @@ logging:                             # Optional
 
 ### resources
 
-Fields under `worker.resources` are all **scalar** values, applied identically to both `requests` and `limits` (**Guaranteed QoS**).
+Fields under `worker.resources` are all **scalar** values, applied identically to both `requests` and `limits`. When both `cpu` and `memory` are specified, this guarantees the **Guaranteed QoS** class; GPU-only specs without CPU/memory do not qualify for Guaranteed QoS in Kubernetes.
 
 ```yaml
 worker:
@@ -208,7 +207,7 @@ worker:
     memory: 128Gi
 ```
 
-**Implementation**: When building the CRD, user-specified scalar values are written to both `requests` and `limits` in the Pod spec with identical values, ensuring K8s assigns the Guaranteed QoS class.
+**Implementation**: When building the CRD, user-specified scalar values are written to both `requests` and `limits` in the Pod spec with identical values. K8s assigns the Guaranteed QoS class only when both CPU and memory are specified with equal requests and limits.
 
 **Why Guaranteed only**: Training workloads are long-running, GPU-intensive jobs that require stable resource guarantees. Burstable QoS (requests < limits) leads to priority eviction under node contention, which is unsuitable for training scenarios.
 
@@ -306,16 +305,16 @@ worker:     # Required
 framework:
   name: tensorflow
 
-worker:     # Required
+worker:     # Optional if another role block is specified. If this block is omitted, no pods will be created.
   ...
 
-chief:      # Optional. If this block is omitted, no pods will be created.
+chief:      # Optional if another role block is specified. If this block is omitted, no pods will be created.
   ...
 
-ps:         # Optional. If this block is omitted, no pods will be created.
+ps:         # Optional if another role block is specified. If this block is omitted, no pods will be created.
   ...
 
-evaluator:  # Optional. If this block is omitted, no pods will be created.
+evaluator:  # Optional if another role block is specified. If this block is omitted, no pods will be created.
   ...
 
 ```
@@ -345,6 +344,20 @@ launcher:   # Optional. Defaults to a CPU-only configuration (replicas fixed to 
   ...
 ```
 
+**GPU-using** roles vary by training framework, as shown in the framework-specific mapping table below.
+
+| Framework | GPU-using roles | Notes |
+|---|---|---|
+| pytorch | master/worker | master inherits worker's image, resources, and envs by default; replicas fixed to 1 |
+| mpi | worker | launcher does not use GPU, does not inherit worker's config |
+| tensorflow | worker/chief/evaluator | chief/ps/evaluator do not inherit worker's config |
+| deepspeed | worker | launcher does not use GPU, does not inherit worker's config |
+| horovod | worker | launcher does not use GPU, does not inherit worker's config |
+
+**MPI/DeepSpeed/Horovod Launchers do not inherit worker's config by default** — the Provider automatically sets independent resource config for the Launcher (typically no GPU) during CRD generation, avoiding GPU waste on Launcher pods.
+
+**PyTorch Master vs Worker**: Master inherits the worker's image, resources, and envs by default. Master replica count is fixed at 1; **total GPU-using replicas** = `worker.replicas + 1`.
+
 ### lifecycle (Job Lifecycle Policies)
 
 ```yaml
@@ -353,7 +366,7 @@ lifecycle:
   active_deadline: 2h                # Max wall-clock duration → activeDeadlineSeconds
   ttl_after_finished: 7d             # Auto-delete Job after this duration → ttlSecondsAfterFinished
   backoff_limit: 6                   # Max restart count → backoffLimit
-  success_policy: ChiefWorker        # ChiefWorker | AllWorkers (TFJob only)
+  success_policy: ChiefWorker        # ChiefWorker | AllWorkers (TFJob only; ignored for other frameworks in Alpha, will be rejected by validation in Beta)
 ```
 
 `clean_pod_policy` controls which pods the Operator deletes after job completion:
@@ -437,22 +450,6 @@ arena job suspend <name>      # Suspend task
 arena job resume <name>    # Resume task
 ```
 
-### worker Field Semantics
-
-`worker` represents the **GPU-using worker nodes** in a training job. Its framework-specific mapping is shown below:
-
-| Framework | worker mapping | Uses GPU | Notes |
-|---|---|---|---|
-| pytorch | Worker | Yes | Master defaults to use the same config as Worker except for replicas |
-| tensorflow | Worker | Yes | Chief/PS/Evaluator do not inherit worker's config |
-| mpi | Worker | Yes | Launcher does not use GPU, does not inherit worker's config |
-| deepspeed | Worker | Yes | Launcher does not use GPU, does not inherit worker's config |
-| horovod | Worker | Yes | Launcher does not use GPU, does not inherit worker's config |
-
-**MPI/DeepSpeed/Horovod Launchers do not inherit worker's config by default** — the Provider automatically sets independent resource config for the Launcher (typically no GPU) during CRD generation, avoiding GPU waste on Launcher pods.
-
-**PyTorch Master vs Worker**: Master runs as Worker. Master replica count is fixed at 1; **total GPU-using replicas** = `worker.replicas + 1`.
-
 ### sync & init (Code/Data Injection)
 
 **`sync` — high-level data/code injection (sugar for initContainer):**
@@ -489,6 +486,25 @@ sync:
 ```
 
 Each entry creates an initContainer and volumes inherited from `storages`. The `mounts` field overrides these inherited configurations by name, and the final volumes are mounted at `mount_path` in both the initContainer and main container across all pods.
+
+**Override-by-name example:**
+
+```yaml
+storages:
+  - name: dataset
+    mount_path: /data                # Default mount path from storages
+    pvc: dataset-pvc
+
+sync:
+  - git: https://github.com/org/code.git
+    local_path: /code
+    mounts:
+    - name: dataset                  # Matches storages entry → overrides mount_path to /dataset
+      mount_path: /dataset
+    - name: code                     # No matching storages entry → a new emptyDir volume is appended
+      tmp: 1Gi
+      mount_path: /code
+```
 
 **`init` — generic initContainer injection:**
 

--- a/keps/arena-v2/yaml-schema.md
+++ b/keps/arena-v2/yaml-schema.md
@@ -1,4 +1,3 @@
-
 ## YAML Schema
 
 ### Minimal Example
@@ -6,7 +5,7 @@
 ```yaml
 version: 0.1.0
 name: my-job
-framework: 
+framework:
   name: pytorch
 image: pytorch/pytorch:2.1
 run: python train.py --epochs 10
@@ -33,12 +32,12 @@ annotations:                         # Optional
 
 image: nvcr.io/nvidia/pytorch:23.10  # Required. Container image.
 run: torchrun train.py --epochs 10   # Required. Training command, executed via shell.
-shell: /bin/sh                       # Optional. Shell interpreter path. Default: /bin/sh. Invalid values fall back to default.
+shell: /bin/sh                       # Optional. Shell interpreter path. Default: /bin/sh. Empty and null values fall back to the default.
 working_dir: /root                   # Optional. Container working directory (default: image default)
 
 # ─── Task ───
-framework:                           # Required. String shorthand or object with provider config.
-  name: pytorch                      # Required. Provider name as key (pytorch | tensorflow | mpi | deepspeed | ray)
+framework:                           # Required. Object with provider config.
+  name: pytorch                      # Required. (pytorch | mpi | tensorflow | horovod | ray | deepspeed)
   options:                            # Optional
     nproc_per_node: auto             # auto | gpu | cpu | int → torchrun --nproc-per-node
 
@@ -47,62 +46,85 @@ envs:                                # Optional. Common envs.
   NCCL_IB_DISABLE: "0"
 
 # ─── Scale ───
-worker:                             # Required
-  replicas: 4                       # Required. Worker replicas must be greater than 0
+worker:                             # Required for non-PyTorch frameworks
+  replicas: 4                       # Required if the worker block is present. Must be > 0 if specified.
   envs:                             # Optional
-    NCCL_DEBUG: DEBUG               # Worker: inherited env + NCCL_DEBUG (override/merge)
-  resources:                        # Required
-    nvidia.com/gpu: 8               # Worker: manual specification required
+    NCCL_DEBUG: DEBUG               # Merges with top-level envs (worker value overrides)
+  resources:                        # Recommended, but not required. Pod resources will be unset if this block is omitted.
+    nvidia.com/gpu: 8
+    cpu: 32
+    memory: 128Gi
+
+# Other fields, such as launcher, chief, ps, or evaluator, may be available depending on the framework. 
+# Settings for replicas, resources, and environment variables may vary accordingly. 
+# Please refer to the framework-specific configuration documentation for more details.
+master:                             # Only valid for PyTorch. Required if the worker block is omitted.
+  replicas: 1                       # Optional. Master replicas must be 1.
+  envs:                             # Optional
+    NCCL_DEBUG: DEBUG               # Merges with top-level envs (master value overrides)
+  resources:                        # Optional
+    nvidia.com/gpu: 8               # Optional
 
 # ─── Sync & Init ───
-sync:                               # Optional
+sync:                                # Optional
   - git: https://github.com/org/training-code.git   # git clone
-    branch: main                     # Optional. Override default branch main
-    local_path: /code                # Optional. Override default local_path
+    branch: main                     # Optional. Default: main.
+    local_path: /code                # Required
+    image: git-sync:v3.3.5           # Optional
     mounts:                          # Optional. Override storages by name
-    - name: code 
-      mount_path: /workspace
-      sub_path: /
+    - name: code                     # A new storage entry will be appended if no matching entry is found in the storages block
+      tmp: 1Gi
+      mount_path: /code
 
-  - rsync: 10.88.29.56::backup/data/logoRecoTrain.zip   # rsync from job's remote source
-    local_path: /workdir             # Optional. Override default local_path
-    mounts:                          # Optional
-    - mount_path: /dataset
-      name: dataset
+  - rsync: 10.88.29.56::backup/data/logoRecoTrain.zip   # rsync from a remote source
+    local_path: /dataset            # Required
+    image: rsync:v3.1.0-aliyun       # Optional
+    mounts:                          # Optional. Override storages by name
+    - name: dataset                  # Override the 'dataset' storage defined in storages
+      mount_path: /dataset           # Mounted at /dataset instead of its default /data
 
-
-  - hdfs: hdfs://namenode:8020/models/resnet # download from remote hdfs
-    local_path: /workdir             # Optional. Override default local_path
-    mounts:                          # Optional
-    - mount_path: /models
-      name: checkpoints  
+  - hdfs: hdfs://namenode:8020/models/resnet # download from a remote HDFS path
+    local_path: /models            # Required
+    image: apache/hadoop:3.5.0       # Optional
+    mounts:                          # Optional. Override storages by name
+    - name: checkpoints
+      mount_path: /models
 
 # ─── storages ───
 # inject into all pods
 storages:                 # Optional
-  - name: dataset         # Required if storages field is specified.
-    mount_path: /data     # Required if storages field is specified and storage is not shm.
+  - name: dataset         # Required
+    mount_path: /data     # Required if the storage type is not shm.
     sub_path: /data       # Optional
-    pvc: dataset-pvc
+    pvc: dataset-pvc      # Exactly one storage type is required. (pvc | shm | tmp | hostpath | configmap | secret)
   - name: checkpoints
     mount_path: /ckpts
     pvc: ckpt-pvc
   - name: shm
-    shm: 64Gi
-    # mount_path: /dev/shm # Optional. Default to /dev/shm
+    shm: 64Gi             # Optional. Default: 2Gi
+    # mount_path: /dev/shm # Optional. Default: /dev/shm
   - name: tmp
     tmp: 128Gi
     mount_path: /tmp
   - name: host
     hostpath: /runtime-mnt
     mount_path: /runtime
+  - name: conf
+    configmap: foo
+    key: conf.yaml       # Optional. Omitting key mounts the entire ConfigMap as a folder.
+    mount_path: /app/conf.yaml  # If key is specified, it represents the exact target file name; otherwise, it represents the directory name.
+  - name: credentials
+    secret: bar
+    key: id_rsa          # Optional. Omitting key mounts the entire Secret as a folder.
+    mount_path: /root/.ssh/id_rsa  # If key is specified, it represents the exact target file name; otherwise, it represents the directory name.
 
 # ─── Scheduling (K8s-specific) ───
 # inject into all pods
 scheduling:                            # Optional
   priority: 100                        # Integer → pod spec priority field
   priority_class_name: high-priority   # String → pod spec priorityClassName field
-  gang: false                          # Gang scheduling (Volcano/coscheduling)
+  gang:                                # Gang scheduling (Volcano/coscheduling)
+    enabled: false                          
   scheduler_name: default              # Custom scheduler (optional)
   queue: low-priority                  # Queue name (optional)
   node_selector:
@@ -112,34 +134,34 @@ scheduling:                            # Optional
     - key: nvidia.com/gpu
       operator: Exists
       effect: NoSchedule
-  affinity:                          # future feature
-    policy: spread                   # none | spread | binpack
-    constraint: preferred            # preferred | required
-    target: pod                      # pod | node
-    rules:
-    - topology_key: nvidia.com/gpu
-      weight: 1
+  affinity:                          # Optional
+    policy: spread                   # Optional. Default: none. (none | spread | binpack)
+    constraint: preferred            # Optional. Default: preferred. (preferred | required)
+    target: node                     # Required if policy is not none. (pod | node)
+    rules:                           # Required if policy is not none.
+    - weight: 1                      # Only for constraint: preferred
+      # topology_key: nvidia.com/gpu   # Only for target: pod
       match_expressions:
       - key: foo
         operator: In
         values:
         - bar
-      match_fields:
+      match_fields:                   # Only for target: node
       - key: foo
         operator: In
         values:
         - bar
       match_labels:
         a: b
-      namespaces: ["a", "b"]
-      namespace_selector:            # Only for target: pod (filter namespaces by label)
-        match_labels:
-          team: platform
-        match_expressions:
-        - key: foo
-          operator: In
-          values:
-          - bar
+      # namespaces: ["a", "b"]         # Only for target: pod (filter namespaces by name)
+      # namespace_selector:            # Only for target: pod (filter namespaces by label)
+      #   match_labels:
+      #     team: platform
+      #   match_expressions:
+      #   - key: foo
+      #     operator: In
+      #     values:
+      #     - bar
 
 # ─── Lifecycle ───
 # inject into all pods 
@@ -176,7 +198,7 @@ logging:                             # Optional
 
 ### resources
 
-Fields under `worker.resources` are all **Scalar** values, applied identically to both `requests` and `limits` (**Guaranteed QoS**).
+Fields under `worker.resources` are all **scalar** values, applied identically to both `requests` and `limits` (**Guaranteed QoS**).
 
 ```yaml
 worker:
@@ -186,9 +208,9 @@ worker:
     memory: 128Gi
 ```
 
-**Why Guaranteed only**: Training workloads are long-running, GPU-intensive jobs that require stable resource guarantees. Burstable QoS (requests < limits) leads to priority eviction under node contention, which is unsuitable for training scenarios.
+**Implementation**: When building the CRD, user-specified scalar values are written to both `requests` and `limits` in the Pod spec with identical values, ensuring K8s assigns the Guaranteed QoS class.
 
-**Implementation**: When building the CRD, scalar values are written to both `requests` and `limits` in the Pod spec with identical values, ensuring K8s assigns the Guaranteed QoS class.
+**Why Guaranteed only**: Training workloads are long-running, GPU-intensive jobs that require stable resource guarantees. Burstable QoS (requests < limits) leads to priority eviction under node contention, which is unsuitable for training scenarios.
 
 ### image_pull_secrets
 
@@ -220,7 +242,7 @@ arena-v2 **does not create K8s Secrets** — it only references existing ones. R
 1. **arena-v2 is a client-side tool** (like kubectl). Creating Secrets is a state-mutating operation that conflicts with the "CRD generation only" design.
 2. **Standard K8s ecosystem practice**: External Secrets Operator, Vault Agent, Sealed Secrets, and similar tooling all operate around the reference model.
 3. **v1 also lacks Secret creation** — v1 users are already accustomed to managing Secrets via `kubectl create secret` first.
-4. **Security**: arena-v2 never handles sensitive credentials (read, encode, or transmit). Secrets are managed by cluster administrators or external systems.
+4. **Security**: arena-v2 never reads, encodes, or transmits sensitive credentials. Secrets are managed by cluster administrators or external systems.
 
 **Secret reference via `envs` field (secretKeyRef)**:
 
@@ -237,8 +259,6 @@ envs:
     key: host
 ```
 
-This keeps the YAML schema pure (reference-only declarations) while providing a convenient Secret creation tool.
-
 ### envs Value Forms
 
 `envs` values accept three forms:
@@ -249,17 +269,22 @@ This keeps the YAML schema pure (reference-only declarations) while providing a 
 | Secret ref | `DB_PASSWORD: {secret: name, key: k}` | `secretKeyRef` to existing K8s Secret |
 | ConfigMap ref | `CONFIG_PATH: {configmap: name, key: k}` | `configMapKeyRef` to existing K8s ConfigMap |
 
-### framework (Provider Selection & Config)
+### framework-specific configuration
 
-`framework` accepts one form: an **object** where the provider name is the key and its value holds provider-specific settings.
+`framework` accepts one form: an **object** where the `name` key holds the provider name, and the `options` key contains provider-specific settings.
 
+Different training frameworks have different roles, and the default behaviors for replicas, envs, and resources vary accordingly. The corresponding configurations and descriptions are shown below.
 
-**Object form** — provider name as key, config as value:
 ```yaml
 framework:
   name: pytorch
   options:
     nproc_per_node: auto             # auto | gpu | cpu | int → torchrun --nproc-per-node
+
+worker:                              # Optional if the master block is specified.
+  ...
+master:                              # Required if the worker block is omitted. If the master block is omitted while the worker block is specified, it inherits the worker configuration (replicas fixed to 1). Otherwise, it uses its own configuration.
+  ...
 ```
 
 ```yaml
@@ -268,29 +293,57 @@ framework:
   options:
     slots_per_worker: 4              # MPI slots per worker node
     mounts_on_launcher: true         # Launcher also mounts PVCs (default: false)
-    run_launcher_as_worker: false    # Optional: Launcher also run as worker (default: false)
-    gpu_topology: true               # GPU topology scheduling annotation
+    run_launcher_as_worker: false    # Optional: Launcher also runs as worker (default: false)
+
+launcher:   # Optional. Defaults to a CPU-only configuration (replicas fixed to 1) if omitted. Uses its own configuration if specified.
+  ...
+worker:     # Required
+  ...
+```
+
+```yaml
+# Due to TensorFlow's diverse distributed strategies, roles (chief, worker, ps, evaluator) must be explicitly specified; no defaults are applied.
+framework:
+  name: tensorflow
+
+worker:     # Required
+  ...
+
+chief:      # Optional. If this block is omitted, no pods will be created.
+  ...
+
+ps:         # Optional. If this block is omitted, no pods will be created.
+  ...
+
+evaluator:  # Optional. If this block is omitted, no pods will be created.
+  ...
+
 ```
 
 ```yaml
 framework:
-  name: tensorflow
-  options:
-    ps_count: 2                      # Parameter Server replica count
-    chief: true                      # Enable Chief (default: true for standalone)
-    evaluator: false                 # Enable Evaluator
+  name: deepspeed
+
+worker:     # Required
+  ...
+launcher:   # Optional. Defaults to a CPU-only configuration (replicas fixed to 1) if omitted. Uses its own configuration if specified.
+  ...
+```
+
+```yaml
+framework:
+  name: ray # No detailed design for Ray — currently a placeholder
 ```
 
 ```yaml
 framework:
   name: horovod
-  options:
-    ssh_port: 22                     # SSH port for MPI launcher
+
+worker:     # Required
+  ...
+launcher:   # Optional. Defaults to a CPU-only configuration (replicas fixed to 1) if omitted. Uses its own configuration if specified.
+  ...
 ```
-
-**Implementation**: `UnmarshalYAML` handles the object form, parsing into a unified `FrameworkConfig` struct. Only one provider key is allowed. Provider-specific fields are strongly typed per provider (no cross-provider field leakage).
-
-**Mapping to replicas**: `framework.tensorflow.options.ps_count` creates PS replicas. `chief` and `evaluator` are booleans that enable/disable those role types entirely.
 
 ### lifecycle (Job Lifecycle Policies)
 
@@ -322,14 +375,12 @@ lifecycle:
 | Omitted (default `/bin/sh`) | `command: ["/bin/sh", "-c"]`, `args: ["<run>"]` | Most scenarios, consistent with v1 behavior |
 | `/bin/bash` | `command: ["/bin/bash", "-c"]`, `args: ["<run>"]` | Requires bash features (`source`, `[[ ]]`, arrays, etc.) |
 
-**Invalid value handling**: `null`, empty string `""`, and non-existent paths all fall back to the default `/bin/sh`. Exec form (without shell wrapping) is not supported — to call an executable directly, use its absolute path in `run`.
+**Invalid value handling**: `null` and empty string `""` both fall back to the default `/bin/sh`.
 
 **Why not `sh -c "bash -c ..."` workaround:**
 - **Signal delivery lost**: K8s sends SIGTERM to PID 1 (sh), which by default does not forward to the child bash process, breaking graceful shutdown
 - **Unreliable exit codes**: sh without `set -e` may swallow non-zero exit codes from the bash child, causing K8s to mark the Pod as Succeeded instead of Failed
 - **Nested escaping**: Quotes, `$`, and backslashes in user commands require double-escaping, which is error-prone
-
-**Implementation**: `Shell` is a plain `string` type. The Provider validates during `BuildCRD`: only non-empty absolute paths starting with `/` are used; otherwise it falls back to `/bin/sh`.
 
 ### Resource Lifecycle
 
@@ -339,10 +390,10 @@ A single `arena job run` invocation may create multiple K8s resources:
 arena job run -f train.yaml
   ├─ PyTorchJob CRD              ← Primary resource (Operator manages Pod lifecycle)
   ├─ TensorBoard Deployment+Service ← If logging.tensorboard is enabled
-  └─ ConfigMap (metadata)        ← Stores original YAML + generated manifest
+  └─ ConfigMap (metadata)        ← Stores effective training job YAML
 ```
 
-**Design choice: Each task type uses its corresponding top-level resource as the anchor, with all other resources setting ownerReference to it.**
+**Design choice: Each task type uses its corresponding top-level resource as the anchor, with all other resources setting ownerReferences to it.**
 
 ```
 PyTorchJob CRD
@@ -354,9 +405,9 @@ PyTorchJob CRD
 **Implementation approach:**
 
 1. Create the primary CRD (e.g. PyTorchJob) first to obtain its UID.
-2. Create the ConfigMap with the original YAML and generated manifest, setting `ownerReference` to the CRD.
-3. Create any additional resources (TensorBoard Deployment, Service) with `ownerReference` pointing to the CRD.
-4. On `arena job delete`, delete the CRD — K8s garbage collection cascades to all resources with matching `ownerReference`.
+2. Create the ConfigMap with the original YAML and generated manifest, setting `ownerReferences` to the CRD.
+3. Create any additional resources (TensorBoard Deployment, Service) with `ownerReferences` pointing to the CRD.
+4. On `arena job delete`, delete the CRD — K8s garbage collection cascades to all resources with matching `ownerReferences`.
 
 **`arena job delete` implementation (single step):** Delete the primary CRD. K8s GC cascades deletion to all resources that reference it.
 
@@ -367,39 +418,40 @@ PyTorchJob CRD
 | | v1 (Helm) | v2 (CRD anchor) |
 |---|---|---|
 | Metadata storage | ConfigMap `data.app` | ConfigMap `data.arena-v2.yaml` |
-| Resource tracking | Resource list in ConfigMap | K8s ownerReference (automatic) |
+| Resource tracking | Resource list in ConfigMap | K8s ownerReferences (automatic) |
 | `arena job delete` steps | 3 steps: read CM → delete resources → delete CM | **1 step: delete CRD** |
 | Resource leak risk | High (list may be incomplete) | **None (K8s GC handles it)** |
 
-**OwnerReference semantics**: `kubectl get pytorchjob -o yaml` will show ownerReference relationships. This is semantically unconventional but:
+**OwnerReferences semantics**: `kubectl get configmap -o yaml` will show ownerReferences relationships.
+
 - **Training Operator is unaffected**: the reconciler reads CRD spec/status to manage Pods, not ownerReferences
 - **Transparent to arena CLI users**: users interact via `arena job get/delete`, not direct CRD manipulation
-- **Helm validates this pattern**: Helm release Secrets serve as anchors managing all chart resources — a mature K8s ecosystem pattern
+- **Helm uses this pattern**: Helm release Secrets serve as anchors managing all chart resources — a mature K8s ecosystem pattern
 
-### stop / resume (Operational Pause)
+### suspend / resume (Operational Pause)
 
-Pause/resume are **operations**, not configuration — they do not belong in the YAML schema. When integrating with queue systems like Kueue, applying a label/annotation on the CRD is sufficient.
+Pause/resume are **operations**, not configuration — they do not belong in the YAML schema. When integrating with queue systems like Kueue, applying a label/annotation on the CRD or patching `runPolicy.suspend` is sufficient.
 
 ```bash
-arena job stop <name>      # Pause task (via label/annotation)
+arena job suspend <name>      # Suspend task
 arena job resume <name>    # Resume task
 ```
 
 ### worker Field Semantics
 
-`worker` represents the **GPU-using nodes** in a training job. The meaning and mapping of `worker` varies by framework:
+`worker` represents the **GPU-using worker nodes** in a training job. Its framework-specific mapping is shown below:
 
 | Framework | worker mapping | Uses GPU | Notes |
 |---|---|---|---|
-| pytorch | Master + Worker | Yes | Master also uses GPU, same config as Worker |
-| tensorflow | Worker | Yes | Chief/PS/Evaluator do not use worker's GPU config |
-| mpi | Worker | Yes | Launcher does not use GPU, does not inherit worker's resource config |
-| deepspeed | Worker | Yes | Launcher does not use GPU |
-| horovod | Worker | Yes | Launcher does not use GPU |
+| pytorch | Worker | Yes | Master defaults to use the same config as Worker except for replicas |
+| tensorflow | Worker | Yes | Chief/PS/Evaluator do not inherit worker's config |
+| mpi | Worker | Yes | Launcher does not use GPU, does not inherit worker's config |
+| deepspeed | Worker | Yes | Launcher does not use GPU, does not inherit worker's config |
+| horovod | Worker | Yes | Launcher does not use GPU, does not inherit worker's config |
 
-**MPI/DeepSpeed/Horovod Launchers do not inherit worker's GPU resources by default** — the Provider automatically sets independent resource config for the Launcher (typically no GPU) during CRD generation, avoiding GPU waste on Launcher pods.
+**MPI/DeepSpeed/Horovod Launchers do not inherit worker's config by default** — the Provider automatically sets independent resource config for the Launcher (typically no GPU) during CRD generation, avoiding GPU waste on Launcher pods.
 
-**PyTorch Master vs Worker**: Master uses the same `worker.resources` config (including GPU) as Worker. Master replicas is fixed at 1; Worker replicas = `worker.replicas - 1`.
+**PyTorch Master vs Worker**: Master runs as Worker. Master replica count is fixed at 1; **total GPU-using replicas** = `worker.replicas + 1`.
 
 ### sync & init (Code/Data Injection)
 
@@ -411,29 +463,32 @@ arena job resume <name>    # Resume task
 |---|---|---|
 | `git` | Git repository URL | `git-sync` clone |
 | `rsync` | Remote storage source | `rsync` |
-| `hdfs` | HDFS path | `hadoop/hadoop` init container with `hdfs get` |
+| `hdfs` | HDFS path | `apache/hadoop` init container with `hdfs dfs -get` |
 
 ```yaml
 sync:
   - git: https://github.com/org/training-code.git
-    branch: main                     # Optional. Default: default branch.
+    branch: main                     # Optional. Default: main.
+    local_path: /workspace
     mounts:
     - name: code
       mount_path: /workspace
       sub_path: /
 
-  - rsync: 10.88.29.56::backup/data/logoRecoTrain.zip    # Rsync from job's remote source
+  - rsync: 10.88.29.56::backup/data/logoRecoTrain.zip    # rsync from a remote source
+    local_path: /dataset
     mounts:
     - name: dataset
       mount_path: /dataset
 
   - hdfs: hdfs://namenode:8020/models/resnet
+    local_path: /models
     mounts:
     - name: checkpoints
       mount_path: /models
 ```
 
-Each entry creates an initContainer + emptyDir volume. The emptyDir is mounted at `mount_path` in both the initContainer and the main container across all pods.
+Each entry creates an initContainer and volumes inherited from `storages`. The `mounts` field overrides these inherited configurations by name, and the final volumes are mounted at `mount_path` in both the initContainer and main container across all pods.
 
 **`init` — generic initContainer injection:**
 
@@ -442,18 +497,20 @@ init:
   - name: download-model
     image: busybox
     run: wget -O /data/model.bin https://example.com/model.bin
+    mounts:
+    - name: data
+      mount_path: /data
 
   - name: prepare-dataset
     image: custom-etl:latest
     run: /prepare.sh
-    shell: /bin/bash                     # Optional, independent of top-level shell
+    shell: /bin/bash
 ```
 
-`init[].run` has the same semantics as the top-level `run`: a command string executed via shell. Each init container can independently specify its own `shell` interpreter (defaults to inheriting the top-level `shell` value; falls back to `/bin/sh` if unset).
+`init[].run` has the same semantics as the top-level `run`: a command string executed via shell.
+`init[].shell` specifies the interpreter path for init containers. If omitted, it inherits the top-level `shell` value (which itself defaults to `/bin/sh`).
 
 Init containers generated by `sync` use exec form (CLI auto-generates the command without shell wrapping) — no `run`/`shell` fields needed.
-
-Init containers do not support `envs`, `secrets`, or `resources` configuration.
 
 `sync` and `init` can coexist. `sync` entries are processed before `init` entries.
 
@@ -461,148 +518,18 @@ Init containers do not support `envs`, `secrets`, or `resources` configuration.
 
 ```
 User writes: worker.replicas: 4
-  pytorch    → PyTorchJob  { Master(1) + Worker(3) }   = 4 pods
-  tensorflow → TFJob       { Chief(1)  + Worker(4) }   = 5 pods
+  pytorch    → PyTorchJob  { Master(1) + Worker(4) }   = 5 pods
   mpi        → MPIJob      { Launcher(1) + Worker(4) }  = 5 pods
+  tensorflow → TFJob       { Worker(4) }   = 4 pods
 
 User writes: worker.replicas: 1
-  pytorch    → PyTorchJob  { Master(1) }   = 1 pods
-  tensorflow → TFJob       { Chief(1)  + Worker(1) }   = 2 pods
+  pytorch    → PyTorchJob  { Master(1) + Worker(1) }   = 2 pods
   mpi        → MPIJob      { Launcher(1) + Worker(1) }  = 2 pods
+  tensorflow → TFJob       { Worker(1) }   = 1 pods
 
-User writes: worker.replicas: 0 (or omitted), invalid value
+User writes: worker.replicas: 0. Validation fails.
+User omits: worker. Validation passes only if the framework is PyTorch and the master block is specified.
 ```
-
-### CLI Override Mapping
-
-All YAML schema fields that are expressible as CLI flags are listed below. Flag names strictly follow schema field names. Complex nested types (`sync`, `init`, `storages`, `scheduling.affinity`) are YAML-only.
-
-The `arena job run` command supports three input modes:
-1. **Pure YAML**: `arena job run -f train.yaml`
-2. **YAML + overrides**: `arena job run -f train.yaml --gpus 8 --workers 4`
-3. **Pure flags**: `arena submit pytorch --name job --image pytorch:2.1 --gpus 2 "python train.py"`, `arena submit pytorchjob --name job --image pytorch:2.1 --gpus 2 "python train.py"`
-
-#### Identity
-
-| Flag | Type | YAML Field | Notes |
-|------|------|-----------|-------|
-| `--name` | string | `name` | Required |
-| `-n, --namespace` | string | `namespace` | Default: kubeconfig context |
-| `-l, --label` | stringSlice | `labels` | `KEY=VALUE` repeated |
-| `-a, --annotation` | stringSlice | `annotations` | `KEY=VALUE` repeated |
-
-#### Task
-
-| Flag | Type | YAML Field | Notes |
-|------|------|-----------|-------|
-| `--framework` | string | `framework` | Also first positional arg |
-| `--image` | string | `image` | Required |
-| `--working-dir` | string | `working_dir` | Container working directory |
-| `--shell` | string | `shell` | Shell interpreter path (default: /bin/sh, invalid values fall back to default) |
-| (trailing args after `--`) | string | `run` | The command to execute |
-
-#### Scale
-
-| Flag | Type | YAML Field | Notes |
-|------|------|-----------|-------|
-| `--workers` | int | `worker.replicas` | Worker replica count |
-
-#### Resources
-
-| Flag | Type | YAML Field | Notes |
-|------|------|-----------|-------|
-| `--gpus` | int | `worker.resources.nvidia.com/gpu` | GPU count |
-| `--gpu-type` | string | (node selector hint) | Maps to `nvidia.com/gpu.product` label |
-| `--cpus` | string | `worker.resources.cpus` | e.g. `"4"` |
-| `--mem` | string | `worker.resources.memory` | e.g. `"16Gi"` |
-| `--shm` | string | `storages` (shm type) | e.g. `"8Gi"`, creates emptyDir at /dev/shm |
-| `--device` | stringSlice | `worker.resources.<name>=<count>` | Extended resources, e.g. `--device hugepages-2Mi=32Gi` |
-
-#### Environment
-
-| Flag | Type | YAML Field | Notes |
-|------|------|-----------|-------|
-| `-e, --env` | stringSlice | `envs` | `KEY=VALUE` repeated |
-
-#### Data (storages)
-
-| Flag | Type | YAML Field | Notes |
-|------|------|-----------|-------|
-| `-d, --data` | stringSlice | `storages` | `name:path:pvc` repeated |
-
-#### Scheduling
-
-| Flag | Type | YAML Field | Notes |
-|------|------|-----------|-------|
-| `--priority` | int | `scheduling.priority` | Pod spec priority field |
-| `--priority-class-name` | string | `scheduling.priority_class_name` | Pod spec priorityClassName field |
-| `--gang` | bool | `scheduling.gang` | Gang scheduling |
-| `--scheduler-name` | string | `scheduling.scheduler_name` | Custom scheduler |
-| `--affinity-policy` | string | `scheduling.affinity.policy` | `none` / `spread` / `binpack` |
-| `--affinity-constraint` | string | `scheduling.affinity.constraint` | `preferred` / `required` |
-| `--selector` | stringSlice | `scheduling.node_selector` | `key=value` repeated |
-| `--toleration` | stringSlice | `scheduling.tolerations` | `key:operator:effect` repeated |
-
-#### Lifecycle
-
-| Flag | Type | YAML Field | Notes |
-|------|------|-----------|-------|
-| `--clean-pod-policy` | string | `lifecycle.clean_pod_policy` | `None` / `Running` / `All` |
-| `--active-deadline` | string | `lifecycle.active_deadline` | Duration, e.g. `"2h"` |
-| `--ttl-after-finished` | string | `lifecycle.ttl_after_finished` | Duration, e.g. `"7d"` |
-| `--backoff-limit` | int | `lifecycle.backoff_limit` | Max restart count |
-| `--success-policy` | string | `lifecycle.success_policy` | `ChiefWorker` / `AllWorkers` (TFJob only) |
-
-#### Runtime
-
-| Flag | Type | YAML Field | Notes |
-|------|------|-----------|-------|
-| `--image-pull-policy` | string | `image_pull_policy` | `Always` / `IfNotPresent` / `Never` |
-| `--image-pull-secret` | stringSlice | `image_pull_secrets` | Image pull secret names |
-| `--service-account` | string | `service_account` | ServiceAccount name |
-| `--restart` | string | `restart` | `Always` / `OnFailure` / `Never` |
-| `--host-network` | bool | `host_network` | |
-| `--host-ipc` | bool | `host_ipc` | |
-| `--host-pid` | bool | `host_pid` | |
-
-#### Logging
-
-| Flag | Type | YAML Field | Notes |
-|------|------|-----------|-------|
-| `--tensorboard` | bool | `logging.tensorboard.enabled` | Enable TensorBoard sidecar |
-| `--tensorboard-logdir` | string | `logging.tensorboard.logdir` | `--logdir` argument |
-| `--tensorboard-image` | string | `logging.tensorboard.image` | Override TB container image |
-
-#### Framework Config
-
-Framework-specific flags are validated at runtime — only valid for the matching `--framework`.
-
-| Flag | Type | YAML Field | Framework |
-|------|------|-----------|-----------|
-| `--nproc-per-node` | string | `framework.options.nproc_per_node` | pytorch |
-| `--ps-count` | int | `framework.options.ps_count` | tensorflow |
-| `--chief` | bool | `framework.options.chief` | tensorflow |
-| `--evaluator` | bool | `framework.options.evaluator` | tensorflow |
-| `--slots-per-worker` | int | `framework.options.slots_per_worker` | mpi |
-| `--gpu-topology` | bool | `framework.options.gpu_topology` | mpi |
-| `--mounts-on-launcher` | bool | `framework.options.mounts_on_launcher` | mpi |
-
-#### Meta
-
-| Flag | Type | Notes |
-|------|------|-------|
-| `-f, --file` | string | Path to task YAML file |
-| `--dry-run` | bool | Print generated CRD without submitting |
-
-#### YAML-Only Fields (not expressible as CLI flags)
-
-These schema sections require YAML input due to nested complexity:
-
-- `sync` — git/rsync/hdfs code injection
-- `init` — generic initContainer injection
-- `storages` — PVC/shm/tmp/hostpath storage declarations
-- `scheduling.affinity` — full affinity rules with policy/constraint/target
-- `framework.options` — when multiple provider config fields are needed simultaneously
 
 ### Affinity Design Principles
 
@@ -612,9 +539,10 @@ These schema sections require YAML input due to nested complexity:
 - **constraint**: `preferred` | `required` — maps to K8s preferredDuringScheduling / requiredDuringScheduling
 - **target**: `pod` | `node` — determines whether to generate podAffinity or nodeAffinity
 
-`rules[]` supports full K8s fields: `topology_key`, `match_labels`, `match_expressions`, `match_fields` (node only), `namespaces`, `namespace_selector` (pod only), `weight`.
+`rules[]` is required when `policy` is not none. It supports full K8s `affinity` semantics.
 
 **Design principles:**
+
 - No additional fields introduced (e.g. `direction`, `match`, `scope`) — `policy`/`constraint`/`target` already orthogonally cover all semantics
 - Users only need to understand three dimensions: policy (intent) + constraint (strength) + target (object)
 - `rules[]` is a direct mapping of K8s native fields with no extra abstraction


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Arena, check the developer guide:
    https://arena-docs.readthedocs.io/en/latest/
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

## Purpose of this PR

Follow-up to #1441. Revises the Arena v2 KEP documents based on review feedback — sharpens the CLI flag mapping, simplifies the YAML schema, and tightens the proposal README so the motivation and scope are clearer before implementation starts.

**Proposed changes:**

- Refine `cli-flag-mapping.md`: reorganize flag categories and clarify the mapping between legacy v1 flags and their v2 equivalents.
- Simplify `yaml-schema.md`: drop redundant fields, consolidate schema sections, and align the spec with the current proposal direction.
- Revise `README.md`: clarify motivation, scope, and design rationale for Arena v2.

## Change Category

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [x] Documentation update

### Rationale

The initial Arena v2 proposal (#1441) landed as a first draft. This PR incorporates follow-up revisions to the proposal artifacts before any implementation work begins, so reviewers and contributors have an up-to-date design reference.

Refs: #1441