### PR TITLE
fix: return distributed serving update errors

### DIFF
--- a/pkg/serving/update.go
+++ b/pkg/serving/update.go
@@ -332,7 +332,7 @@ func UpdateKServe(args *types.UpdateKServeArgs) error {
 func UpdateDistributedServing(args *types.UpdateDistributedServingArgs) error {
 	lwsJob, err := findAndBuildLWSJob(args)
 	if err != nil {
-		return nil
+		return err
 	}
 
 	if len(args.Annotations) > 0 {

--- a/pkg/serving/update_test.go
+++ b/pkg/serving/update_test.go
@@ -1,0 +1,39 @@
+// Copyright 2024 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package serving
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/kubeflow/arena/pkg/apis/types"
+)
+
+func TestUpdateDistributedServingReturnsFindAndBuildLWSJobErrors(t *testing.T) {
+	args := &types.UpdateDistributedServingArgs{
+		CommonUpdateServingArgs: types.CommonUpdateServingArgs{
+			Name: "demo",
+			Type: types.UnknownServingJob,
+		},
+	}
+
+	err := UpdateDistributedServing(args)
+	if err == nil {
+		t.Fatal("expected UpdateDistributedServing to return an error")
+	}
+	if !strings.Contains(err.Error(), "unknown serving job type") {
+		t.Fatalf("expected unknown serving job type error, got %q", err)
+	}
+}


### PR DESCRIPTION
## Purpose of this PR

Small follow-up to #1187.
`UpdateDistributedServing` returned `nil` when `findAndBuildLWSJob` failed. That means `arena serve update distributed` could look successful even when job lookup failed. Kinda confusing.

Proposed changes:
- return the original error instead of swallowing it
- add a regression test for this path

## Change Category

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

Repro on current `master`:
1. Point Arena at a cluster with the distributed serving feature enabled.
2. Run `arena serve update distributed --name does-not-exist -n default`.
3. The serving lookup can fail, but `UpdateDistributedServing` returned `nil`, so the error got dropped.

This patch returns that error and adds a focused test. Pretty small fix, but it saves a weird silent success.
