### PR TITLE
feat(sdk): support concurrent multi-cluster, multi-user, and multi-namespace configurations

### DIFF
--- a/pkg/apis/arenaclient/analyze_client.go
+++ b/pkg/apis/arenaclient/analyze_client.go
@@ -44,6 +44,7 @@ func (m *AnalyzeClient) Namespace(namespace string) *AnalyzeClient {
 }
 
 func (m *AnalyzeClient) Submit(job *apisanalyze.Job) error {
+	defer setContext(m.configer)()
 	switch job.Type() {
 	case types.ModelProfileJob:
 		args := job.Args().(*types.ModelProfileArgs)
@@ -62,6 +63,7 @@ func (m *AnalyzeClient) Submit(job *apisanalyze.Job) error {
 }
 
 func (m *AnalyzeClient) Get(jobType types.ModelJobType, name string) (*types.ModelJobInfo, error) {
+	defer setContext(m.configer)()
 	job, err := analyze.SearchModelJob(m.namespace, name, jobType)
 	if err != nil {
 		return nil, err
@@ -72,6 +74,7 @@ func (m *AnalyzeClient) Get(jobType types.ModelJobType, name string) (*types.Mod
 }
 
 func (m *AnalyzeClient) GetAndPrint(jobType types.ModelJobType, name string, format string) error {
+	defer setContext(m.configer)()
 	job, err := analyze.SearchModelJob(m.namespace, name, jobType)
 	if err != nil {
 		return err
@@ -82,6 +85,7 @@ func (m *AnalyzeClient) GetAndPrint(jobType types.ModelJobType, name string, for
 }
 
 func (m *AnalyzeClient) List(allNamespaces bool, jobType types.ModelJobType) ([]*types.ModelJobInfo, error) {
+	defer setContext(m.configer)()
 	jobs, err := analyze.ListModelJobs(m.namespace, allNamespaces, jobType)
 	if err != nil {
 		return nil, err
@@ -96,6 +100,7 @@ func (m *AnalyzeClient) List(allNamespaces bool, jobType types.ModelJobType) ([]
 }
 
 func (m *AnalyzeClient) ListAndPrint(allNamespaces bool, jobType types.ModelJobType, format string) error {
+	defer setContext(m.configer)()
 	jobs, err := analyze.ListModelJobs(m.namespace, allNamespaces, jobType)
 	if err != nil {
 		return err
@@ -106,6 +111,7 @@ func (m *AnalyzeClient) ListAndPrint(allNamespaces bool, jobType types.ModelJobT
 }
 
 func (m *AnalyzeClient) Delete(jobType types.ModelJobType, jobNames ...string) error {
+	defer setContext(m.configer)()
 	for _, jobName := range jobNames {
 		err := analyze.DeleteModelJob(m.namespace, jobName, jobType)
 		if err != nil {

--- a/pkg/apis/arenaclient/arenaclient.go
+++ b/pkg/apis/arenaclient/arenaclient.go
@@ -22,6 +22,7 @@ import (
 	"github.com/kubeflow/arena/pkg/apis/utils"
 	"github.com/kubeflow/arena/pkg/k8saccesser"
 	"github.com/kubeflow/arena/pkg/util"
+	"github.com/kubeflow/arena/pkg/util/clientcontext"
 )
 
 // ArenaClient is a client which includes operations:
@@ -64,10 +65,19 @@ func NewArenaClient(args types.ArenaClientArgs) (*ArenaClient, error) {
 	if err := k8saccesser.InitK8sResourceAccesser(configer.GetRestConfig(), configer.GetClientSet(), configer.IsDaemonMode()); err != nil {
 		return client, err
 	}
+	clientcontext.AssociateConfigerAndAccesser(configer, k8saccesser.GetK8sResourceAccesser())
 	client.arenaConfiger = configer
 	// the namespace may be updated
 	client.namespace = configer.GetNamespace()
 	return client, err
+}
+
+func setContext(configer *config.ArenaConfiger) func() {
+	acc := clientcontext.GetAssociatedAccesser(configer)
+	clientcontext.SetCurrentContext(configer, acc)
+	return func() {
+		clientcontext.ClearCurrentContext()
+	}
 }
 
 // Training returns the Training Job Client

--- a/pkg/apis/arenaclient/cron_client.go
+++ b/pkg/apis/arenaclient/cron_client.go
@@ -40,6 +40,7 @@ func NewCronClient(namespace string, configer *config.ArenaConfiger) *CronClient
 
 // Submit submits a training job
 func (c *CronClient) SubmitCronTrainingJob(job *apiscron.Job) error {
+	defer setContext(c.configer)()
 	switch job.Type() {
 	case types.CronTFTrainingJob:
 		args := job.Args().(*types.CronTFJobArgs)
@@ -59,11 +60,13 @@ func (c *CronClient) Namespace(namespace string) *CronClient {
 
 // List return all cron task
 func (c *CronClient) List(allNamespaces bool) ([]*types.CronInfo, error) {
+	defer setContext(c.configer)()
 	return cron.ListCrons(c.namespace, allNamespaces)
 }
 
 // ListAndPrint lists and prints the job informations
 func (c *CronClient) ListAndPrint(allNamespaces bool, format string) error {
+	defer setContext(c.configer)()
 	outputFormat := utils.TransferPrintFormat(format)
 	if outputFormat == types.UnknownFormat {
 		return fmt.Errorf("unknown output format,only support:[wide|json|yaml]")
@@ -77,10 +80,12 @@ func (c *CronClient) ListAndPrint(allNamespaces bool, format string) error {
 }
 
 func (c *CronClient) Get(name string) (*types.CronInfo, error) {
+	defer setContext(c.configer)()
 	return cron.GetCronInfo(name, c.namespace)
 }
 
 func (c *CronClient) GetAndPrint(name string, format string) error {
+	defer setContext(c.configer)()
 	outputFormat := utils.TransferPrintFormat(format)
 	if outputFormat == types.UnknownFormat {
 		return fmt.Errorf("unknown output format,only support:[wide|json|yaml]")
@@ -96,14 +101,17 @@ func (c *CronClient) GetAndPrint(name string, format string) error {
 }
 
 func (c *CronClient) Suspend(name string) error {
+	defer setContext(c.configer)()
 	return cron.SuspendCron(name, c.namespace, true)
 }
 
 func (c *CronClient) Resume(name string) error {
+	defer setContext(c.configer)()
 	return cron.SuspendCron(name, c.namespace, false)
 }
 
 func (c *CronClient) Delete(names ...string) error {
+	defer setContext(c.configer)()
 	for _, name := range names {
 		cronInfo, err := cron.GetCronInfo(name, c.namespace)
 		if err != nil {

--- a/pkg/apis/arenaclient/data_client.go
+++ b/pkg/apis/arenaclient/data_client.go
@@ -42,5 +42,6 @@ func (d *DataClient) Namespace(namespace string) *DataClient {
 }
 
 func (d *DataClient) ListAndPrintDataVolumes(namespace string, allNamespaces bool) error {
+	defer setContext(d.configer)()
 	return datahouse.DisplayDataVolumes(namespace, allNamespaces)
 }

--- a/pkg/apis/arenaclient/evaluate_client.go
+++ b/pkg/apis/arenaclient/evaluate_client.go
@@ -51,6 +51,7 @@ func (c *EvaluateClient) Namespace(namespace string) *EvaluateClient {
 
 // SubmitEvaluateJob submits a evaluate job
 func (c *EvaluateClient) SubmitEvaluateJob(job *apievaluate.EvaluateJob) error {
+	defer setContext(c.configer)()
 	args := job.Args().(*types.EvaluateJobArgs)
 
 	// generate uuid v4
@@ -78,10 +79,12 @@ func (c *EvaluateClient) SubmitEvaluateJob(job *apievaluate.EvaluateJob) error {
 }
 
 func (c *EvaluateClient) Get(name, namespace string) (*types.EvaluateJobInfo, error) {
+	defer setContext(c.configer)()
 	return evaluate.GetEvaluateJob(name, namespace)
 }
 
 func (c *EvaluateClient) GetAndPrint(name string, format string) error {
+	defer setContext(c.configer)()
 	outputFormat := utils.TransferPrintFormat(format)
 	if outputFormat == types.UnknownFormat {
 		return fmt.Errorf("unknown output format,only support:[wide|json|yaml]")
@@ -96,10 +99,12 @@ func (c *EvaluateClient) GetAndPrint(name string, format string) error {
 }
 
 func (c *EvaluateClient) List(allNamespaces bool) ([]*types.EvaluateJobInfo, error) {
+	defer setContext(c.configer)()
 	return evaluate.ListEvaluateJobs(c.namespace, allNamespaces)
 }
 
 func (c *EvaluateClient) ListAndPrint(allNamespaces bool, format string) error {
+	defer setContext(c.configer)()
 	outputFormat := utils.TransferPrintFormat(format)
 	if outputFormat == types.UnknownFormat {
 		return fmt.Errorf("unknown output format,only support:[wide|json|yaml]")
@@ -114,6 +119,7 @@ func (c *EvaluateClient) ListAndPrint(allNamespaces bool, format string) error {
 }
 
 func (c *EvaluateClient) Delete(names ...string) error {
+	defer setContext(c.configer)()
 	for _, name := range names {
 		err := evaluate.DeleteEvaluateJob(name, c.namespace)
 		if err != nil {

--- a/pkg/apis/arenaclient/model_client.go
+++ b/pkg/apis/arenaclient/model_client.go
@@ -37,6 +37,7 @@ type ModelClient struct {
 }
 
 func NewModelClient(namespace string, configer *config.ArenaConfiger) (*ModelClient, error) {
+	defer setContext(configer)()
 	trackingUri := os.Getenv("MLFLOW_TRACKING_URI")
 	username := os.Getenv("MLFLOW_TRACKING_USERNAME")
 	password := os.Getenv("MLFLOW_TRACKING_PASSWORD")
@@ -78,6 +79,7 @@ func NewModelClient(namespace string, configer *config.ArenaConfiger) (*ModelCli
 }
 
 func searchModelVersionByJobLabels(namespace string, configer *config.ArenaConfiger, labels map[string]string) *types.ModelVersion {
+	defer setContext(configer)()
 	var mv *types.ModelVersion
 	modelName := labels["modelName"]
 	modelVersion := labels["modelVersion"]

--- a/pkg/apis/arenaclient/node_client.go
+++ b/pkg/apis/arenaclient/node_client.go
@@ -50,11 +50,13 @@ func (t *NodeClient) Namespace(namespace string) *NodeClient {
 
 // Details is used to serve api
 func (t *NodeClient) Details(nodeNames []string, nodeType types.NodeType, showMetric bool) (types.AllNodeInfo, error) {
+	defer setContext(t.configer)()
 	return topnode.ListNodeDetails(nodeNames, nodeType, showMetric)
 }
 
 // ListAndPrintNodes is used to display nodes informations
 func (t *NodeClient) ListAndPrintNodes(nodeNames []string, nodeType types.NodeType, format types.FormatStyle, details bool, notStop bool, showMetric bool) error {
+	defer setContext(t.configer)()
 	if format == types.UnknownFormat {
 		return fmt.Errorf("unknown output format,only support:[wide|json|yaml]")
 	}

--- a/pkg/apis/arenaclient/serving_client.go
+++ b/pkg/apis/arenaclient/serving_client.go
@@ -51,6 +51,7 @@ func (t *ServingJobClient) Namespace(namespace string) *ServingJobClient {
 
 // Submit submits a serving job
 func (t *ServingJobClient) Submit(job *apiserving.Job) error {
+	defer setContext(t.configer)()
 	switch job.Type() {
 	case types.TFServingJob:
 		args := job.Args().(*types.TensorFlowServingArgs)
@@ -82,6 +83,7 @@ func (t *ServingJobClient) Submit(job *apiserving.Job) error {
 
 // Get returns a serving job information
 func (t *ServingJobClient) Get(jobName, version string, jobType types.ServingJobType) (*types.ServingJobInfo, error) {
+	defer setContext(t.configer)()
 	job, err := serving.SearchServingJob(t.namespace, jobName, version, jobType)
 	if err != nil {
 		return nil, err
@@ -92,6 +94,7 @@ func (t *ServingJobClient) Get(jobName, version string, jobType types.ServingJob
 
 // GetAndPrint print serving job information
 func (t *ServingJobClient) GetAndPrint(jobName, version string, jobType types.ServingJobType, format string) error {
+	defer setContext(t.configer)()
 	if utils.TransferPrintFormat(format) == types.UnknownFormat {
 		return fmt.Errorf("unknown output format,only support:[wide|json|yaml]")
 	}
@@ -109,6 +112,7 @@ func (t *ServingJobClient) GetAndPrint(jobName, version string, jobType types.Se
 
 // List returns all serving jobs
 func (t *ServingJobClient) List(allNamespaces bool, servingType types.ServingJobType) ([]*types.ServingJobInfo, error) {
+	defer setContext(t.configer)()
 	jobs, err := serving.ListServingJobs(t.namespace, allNamespaces, servingType)
 	if err != nil {
 		return nil, err
@@ -123,6 +127,7 @@ func (t *ServingJobClient) List(allNamespaces bool, servingType types.ServingJob
 
 // ListAndPrint lists and prints the job informations
 func (t *ServingJobClient) ListAndPrint(allNamespaces bool, servingType types.ServingJobType, format string) error {
+	defer setContext(t.configer)()
 	if utils.TransferPrintFormat(format) == types.UnknownFormat {
 		return fmt.Errorf("unknown output format,only support:[wide|json|yaml]")
 	}
@@ -136,12 +141,14 @@ func (t *ServingJobClient) ListAndPrint(allNamespaces bool, servingType types.Se
 
 // Logs returns the serving job log
 func (t *ServingJobClient) Logs(jobName, version string, jobType types.ServingJobType, args *types.LogArgs) error {
+	defer setContext(t.configer)()
 	args.Namespace = t.namespace
 	args.JobName = jobName
 	return serving.AcceptJobLog(jobName, version, jobType, args)
 }
 
 func (t *ServingJobClient) Attach(jobName, version string, jobType types.ServingJobType, args *podexec.AttachPodArgs) error {
+	defer setContext(t.configer)()
 	job, err := t.Get(jobName, version, jobType)
 	if err != nil {
 		return err
@@ -171,6 +178,7 @@ func (t *ServingJobClient) Attach(jobName, version string, jobType types.Serving
 
 // Delete deletes the target serving job
 func (t *ServingJobClient) Delete(jobType types.ServingJobType, version string, jobNames ...string) error {
+	defer setContext(t.configer)()
 	for _, jobName := range jobNames {
 		err := serving.DeleteServingJob(t.namespace, jobName, version, jobType)
 		if err != nil {
@@ -182,6 +190,7 @@ func (t *ServingJobClient) Delete(jobType types.ServingJobType, version string, 
 
 // Update update a serving job
 func (t *ServingJobClient) Update(job *apiserving.Job) error {
+	defer setContext(t.configer)()
 	switch job.Type() {
 	case types.TFServingJob:
 		args := job.Args().(*types.UpdateTensorFlowServingArgs)
@@ -203,6 +212,7 @@ func (t *ServingJobClient) Update(job *apiserving.Job) error {
 }
 
 func (t *ServingJobClient) TrafficRouterSplit(args *types.TrafficRouterSplitArgs) error {
+	defer setContext(t.configer)()
 	return serving.RunTrafficRouterSplit(args.Namespace, args)
 }
 

--- a/pkg/apis/arenaclient/training_client.go
+++ b/pkg/apis/arenaclient/training_client.go
@@ -59,6 +59,7 @@ func (t *TrainingJobClient) Namespace(namespace string) *TrainingJobClient {
 
 // Submit submits a training job
 func (t *TrainingJobClient) Submit(job *apistraining.Job) error {
+	defer setContext(t.configer)()
 	switch job.Type() {
 	case types.TFTrainingJob:
 		args := job.Args().(*types.SubmitTFJobArgs)
@@ -93,6 +94,7 @@ func (t *TrainingJobClient) Submit(job *apistraining.Job) error {
 
 // ScaleIn scales in job
 func (t *TrainingJobClient) ScaleIn(job *apistraining.Job) error {
+	defer setContext(t.configer)()
 	switch job.Type() {
 	case types.ETTrainingJob:
 		args := job.Args().(*types.ScaleInETJobArgs)
@@ -103,6 +105,7 @@ func (t *TrainingJobClient) ScaleIn(job *apistraining.Job) error {
 
 // ScaleOut scales out job
 func (t *TrainingJobClient) ScaleOut(job *apistraining.Job) error {
+	defer setContext(t.configer)()
 	switch job.Type() {
 	case types.ETTrainingJob:
 		args := job.Args().(*types.ScaleOutETJobArgs)
@@ -113,6 +116,7 @@ func (t *TrainingJobClient) ScaleOut(job *apistraining.Job) error {
 
 // Get returns a training job information
 func (t *TrainingJobClient) Get(jobName string, jobType types.TrainingJobType, showPrometheusMetric bool) (*types.TrainingJobInfo, error) {
+	defer setContext(t.configer)()
 	job, err := training.SearchTrainingJob(jobName, t.namespace, jobType)
 	if err != nil {
 		return nil, err
@@ -124,6 +128,7 @@ func (t *TrainingJobClient) Get(jobName string, jobType types.TrainingJobType, s
 
 // GetAndPrint print training job information
 func (t *TrainingJobClient) GetAndPrint(jobName string, jobType types.TrainingJobType, format string, showEvent bool, showGPU bool) error {
+	defer setContext(t.configer)()
 	if utils.TransferPrintFormat(format) == types.UnknownFormat {
 		return fmt.Errorf("unknown output format,only support:[wide|json|yaml]")
 	}
@@ -144,6 +149,7 @@ func (t *TrainingJobClient) GetAndPrint(jobName string, jobType types.TrainingJo
 
 // List returns all training jobs
 func (t *TrainingJobClient) List(allNamespaces bool, trainingType types.TrainingJobType, showPrometheusMetric bool) ([]*types.TrainingJobInfo, error) {
+	defer setContext(t.configer)()
 	jobs, err := training.ListTrainingJobs(t.namespace, allNamespaces, trainingType)
 	if err != nil {
 		return nil, err
@@ -158,6 +164,7 @@ func (t *TrainingJobClient) List(allNamespaces bool, trainingType types.Training
 
 // ListAndPrint lists and prints the job informations
 func (t *TrainingJobClient) ListAndPrint(allNamespaces bool, format string, trainingType types.TrainingJobType) error {
+	defer setContext(t.configer)()
 	if utils.TransferPrintFormat(format) == types.UnknownFormat {
 		return fmt.Errorf("unknown output format,only support:[wide|json|yaml]")
 	}
@@ -171,12 +178,14 @@ func (t *TrainingJobClient) ListAndPrint(allNamespaces bool, format string, trai
 
 // Logs returns the training job log
 func (t *TrainingJobClient) Logs(jobName string, jobType types.TrainingJobType, args *types.LogArgs) error {
+	defer setContext(t.configer)()
 	args.Namespace = t.namespace
 	args.JobName = jobName
 	return training.AcceptJobLog(jobName, jobType, args)
 }
 
 func (t *TrainingJobClient) Attach(jobName string, jobType types.TrainingJobType, args *podexec.AttachPodArgs) error {
+	defer setContext(t.configer)()
 	job, err := t.Get(jobName, jobType, false)
 	if err != nil {
 		return err
@@ -200,6 +209,7 @@ func (t *TrainingJobClient) Attach(jobName string, jobType types.TrainingJobType
 
 // Delete deletes the target training job
 func (t *TrainingJobClient) Delete(jobType types.TrainingJobType, jobNames ...string) error {
+	defer setContext(t.configer)()
 	for _, jobName := range jobNames {
 		err := training.DeleteTrainingJob(jobName, t.namespace, jobType)
 		if err != nil {
@@ -214,6 +224,7 @@ func (t *TrainingJobClient) Delete(jobType types.TrainingJobType, jobNames ...st
 
 // LogViewer returns the log viewer
 func (t *TrainingJobClient) LogViewer(jobName string, jobType types.TrainingJobType) ([]string, error) {
+	defer setContext(t.configer)()
 	job, err := training.SearchTrainingJob(jobName, t.namespace, jobType)
 	if err != nil {
 		return nil, err
@@ -223,9 +234,11 @@ func (t *TrainingJobClient) LogViewer(jobName string, jobType types.TrainingJobT
 
 // Prune cleans the not running training jobs
 func (t *TrainingJobClient) Prune(allNamespaces bool, since time.Duration) error {
+	defer setContext(t.configer)()
 	return training.PruneTrainingJobs(t.namespace, allNamespaces, since)
 }
 
 func (t *TrainingJobClient) Top(args []string, allNamespaces bool, jobType types.TrainingJobType, instanceName string, notStop bool, format types.FormatStyle) error {
+	defer setContext(t.configer)()
 	return training.TopTrainingJobs(args, t.namespace, allNamespaces, jobType, instanceName, notStop, format)
 }

--- a/pkg/apis/config/arenaconfig.go
+++ b/pkg/apis/config/arenaconfig.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/kubeflow/arena/pkg/apis/types"
 	"github.com/kubeflow/arena/pkg/util"
+	"github.com/kubeflow/arena/pkg/util/clientcontext"
 	config "github.com/kubeflow/arena/pkg/util/config"
 	homedir "github.com/mitchellh/go-homedir"
 	log "github.com/sirupsen/logrus"
@@ -44,19 +45,29 @@ const (
 
 var arenaClient *ArenaConfiger
 var errInitArenaClient error
-
-var once sync.Once
+var configMu sync.Mutex
 
 // InitArenaConfiger initialize
 func InitArenaConfiger(args types.ArenaClientArgs) (*ArenaConfiger, error) {
-	once.Do(func() {
-		arenaClient, errInitArenaClient = newArenaConfiger(args)
-	})
-	return arenaClient, errInitArenaClient
+	configMu.Lock()
+	defer configMu.Unlock()
+	configer, err := newArenaConfiger(args)
+	if err != nil {
+		errInitArenaClient = err
+		return nil, err
+	}
+	arenaClient = configer
+	errInitArenaClient = nil
+	return arenaClient, nil
 }
 
 // GetArenaConfiger returns the arena configer,it must be invoked after invoking function InitArenaConfiger(...)
 func GetArenaConfiger() *ArenaConfiger {
+	if active := clientcontext.GetActiveConfiger(); active != nil {
+		return active.(*ArenaConfiger)
+	}
+	configMu.Lock()
+	defer configMu.Unlock()
 	if arenaClient == nil {
 		err := fmt.Errorf("ArenaClient is not initialized,but you want to get it")
 		log.Errorf("Arena Client is not initialized,please use function InitArenaClient(...) to init it")
@@ -106,6 +117,10 @@ type ArenaConfiger struct {
 	clusterInstalledCRDs   []string
 	isolateUserInNamespace bool
 	tokenRetriever         *tokenRetriever
+	kubeconfig             string
+	customClients          map[string]interface{}
+	crdEnabledCache        map[string]bool
+	clientsMu              sync.Mutex
 }
 
 func newArenaConfiger(args types.ArenaClientArgs) (*ArenaConfiger, error) {
@@ -162,6 +177,9 @@ func newArenaConfiger(args types.ArenaClientArgs) (*ArenaConfiger, error) {
 		adminUsers:             adminUsers,
 		isolateUserInNamespace: i,
 		tokenRetriever:         tr,
+		kubeconfig:             args.Kubeconfig,
+		customClients:          make(map[string]interface{}),
+		crdEnabledCache:        make(map[string]bool),
 	}, nil
 
 }
@@ -227,6 +245,42 @@ func (a *ArenaConfiger) IsAdminUser() bool {
 		}
 	}
 	return false
+}
+
+func (a *ArenaConfiger) GetKubeconfigPath() string {
+	return a.kubeconfig
+}
+
+func (a *ArenaConfiger) GetCustomClient(key string, initFunc func(restConfig *rest.Config) (interface{}, error)) (interface{}, error) {
+	a.clientsMu.Lock()
+	defer a.clientsMu.Unlock()
+	if a.customClients == nil {
+		a.customClients = make(map[string]interface{})
+	}
+	if client, ok := a.customClients[key]; ok {
+		return client, nil
+	}
+	client, err := initFunc(a.restConfig)
+	if err != nil {
+		return nil, err
+	}
+	a.customClients[key] = client
+	return client, nil
+}
+
+func (a *ArenaConfiger) IsCRDEnabled(crdName string) bool {
+	a.clientsMu.Lock()
+	defer a.clientsMu.Unlock()
+	if a.crdEnabledCache == nil {
+		a.crdEnabledCache = make(map[string]bool)
+	}
+	if enabled, ok := a.crdEnabledCache[crdName]; ok {
+		return enabled
+	}
+	_, err := a.apiExtensionClientset.ApiextensionsV1().CustomResourceDefinitions().Get(context.TODO(), crdName, metav1.GetOptions{})
+	enabled := err == nil
+	a.crdEnabledCache[crdName] = enabled
+	return enabled
 }
 
 func getGlobalConfigFromConfigmap(namespace string, client *kubernetes.Clientset) map[string]string {

--- a/pkg/k8saccesser/k8s_accesser.go
+++ b/pkg/k8saccesser/k8s_accesser.go
@@ -22,6 +22,7 @@ import (
 
 	kservev1beta1 "github.com/kserve/kserve/pkg/apis/serving/v1beta1"
 	kserveClient "github.com/kserve/kserve/pkg/client/clientset/versioned"
+	"github.com/kubeflow/arena/pkg/util/clientcontext"
 	log "github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
@@ -59,7 +60,7 @@ import (
 )
 
 var accesser *k8sResourceAccesser
-var once sync.Once
+var accesserMu sync.RWMutex
 
 func init() {
 	utilruntime.Must(tfv1.AddToScheme(scheme.Scheme))
@@ -73,17 +74,26 @@ func init() {
 }
 
 func InitK8sResourceAccesser(config *rest.Config, clientset *kubernetes.Clientset, isDaemonMode bool) error {
-	var err error
-	once.Do(func() {
-		accesser, err = NewK8sResourceAccesser(config, clientset, isDaemonMode)
-		if err == nil {
-			err = accesser.Run()
-		}
-	})
-	return err
+	acc, err := NewK8sResourceAccesser(config, clientset, isDaemonMode)
+	if err != nil {
+		return err
+	}
+	err = acc.Run()
+	if err != nil {
+		return err
+	}
+	accesserMu.Lock()
+	accesser = acc
+	accesserMu.Unlock()
+	return nil
 }
 
 func GetK8sResourceAccesser() *k8sResourceAccesser {
+	if active := clientcontext.GetActiveAccesser(); active != nil {
+		return active.(*k8sResourceAccesser)
+	}
+	accesserMu.RLock()
+	defer accesserMu.RUnlock()
 	return accesser
 }
 

--- a/pkg/model/mlflow.go
+++ b/pkg/model/mlflow.go
@@ -83,39 +83,36 @@ func NewMlflowClient(trackingUri, username, password string) *MlflowClient {
 
 // Create a MLflow client proxied by Kubernetes api server
 func NewProxiedMlflowClient(configr *config.ArenaConfiger, service *corev1.Service, username string, password string) *MlflowClient {
-	once.Do(func() {
-		namespace := service.Namespace
-		name := service.Name
-		port := 5000
-		if len(service.Spec.Ports) > 0 {
-			port = int(service.Spec.Ports[0].Port)
-		}
-		restClient := configr.GetClientSet().CoreV1().RESTClient().(*rest.RESTClient)
-		baseUrl := restClient.Get().
-			Resource("services").
-			Namespace(namespace).
-			Name(fmt.Sprintf("%s:%d", name, port)).
-			SubResource("proxy").
-			URL().
-			String()
+	namespace := service.Namespace
+	name := service.Name
+	port := 5000
+	if len(service.Spec.Ports) > 0 {
+		port = int(service.Spec.Ports[0].Port)
+	}
+	restClient := configr.GetClientSet().CoreV1().RESTClient().(*rest.RESTClient)
+	baseUrl := restClient.Get().
+		Resource("services").
+		Namespace(namespace).
+		Name(fmt.Sprintf("%s:%d", name, port)).
+		SubResource("proxy").
+		URL().
+		String()
 
-		restyClient := resty.New().
-			SetTransport(restClient.Client.Transport).
-			SetBaseURL(baseUrl).
-			SetHeader("Content-Type", "application/json").
-			SetHeader("Accept", "application/json").
-			SetDisableWarn(true)
+	restyClient := resty.New().
+		SetTransport(restClient.Client.Transport).
+		SetBaseURL(baseUrl).
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetDisableWarn(true)
 
-		if username != "" && password != "" {
-			// api-server proxy will strip out authorization header, see https://github.com/kubernetes/kubernetes/issues/38775
-			log.Warn("proxied mlflow client currently does not support basic authentication")
-		}
+	if username != "" && password != "" {
+		// api-server proxy will strip out authorization header, see https://github.com/kubernetes/kubernetes/issues/38775
+		log.Warn("proxied mlflow client currently does not support basic authentication")
+	}
 
-		defaultProxiedMlflowClient = &MlflowClient{
-			RestyClient: restyClient,
-		}
-	})
-	return defaultProxiedMlflowClient
+	return &MlflowClient{
+		RestyClient: restyClient,
+	}
 }
 
 func (c *MlflowClient) CheckHealth() (bool, error) {

--- a/pkg/prometheus/query.go
+++ b/pkg/prometheus/query.go
@@ -29,6 +29,7 @@ import (
 	"github.com/kubeflow/arena/pkg/apis/config"
 	"github.com/kubeflow/arena/pkg/apis/types"
 	"github.com/kubeflow/arena/pkg/k8saccesser"
+	"github.com/kubeflow/arena/pkg/util/clientcontext"
 	"github.com/prometheus/common/model"
 	log "github.com/sirupsen/logrus"
 
@@ -55,10 +56,13 @@ func (t *arenaTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 }
 
 func GetPrometheusClient() promv1.API {
-	prometheusOnce.Do(func() {
-		globalPrometheusClient = getPrometheusClient(config.GetArenaConfiger().GetConfigsFromConfigFile())
-	})
-	return globalPrometheusClient
+	configer := config.GetArenaConfiger()
+	if cached := clientcontext.GetConfigerPrometheus(configer); cached != nil {
+		return cached.(promv1.API)
+	}
+	client := getPrometheusClient(configer.GetConfigsFromConfigFile())
+	clientcontext.SetConfigerPrometheus(configer, client)
+	return client
 }
 
 // address format should like: http://123.123.123.123:9000

--- a/pkg/serving/serving.go
+++ b/pkg/serving/serving.go
@@ -26,6 +26,7 @@ import (
 	"github.com/kubeflow/arena/pkg/apis/utils"
 	"github.com/kubeflow/arena/pkg/k8saccesser"
 	"github.com/kubeflow/arena/pkg/util"
+	"github.com/kubeflow/arena/pkg/util/clientcontext"
 	log "github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -48,39 +49,40 @@ const (
 	istioGatewayHTTPsPortName = "https"
 )
 
-var processers map[types.ServingJobType]Processer
-
-var once sync.Once
-
 func GetAllProcesser() map[types.ServingJobType]Processer {
-	once.Do(func() {
-		locker := new(sync.RWMutex)
-		processers = map[types.ServingJobType]Processer{}
-		processerInits := []func() Processer{
-			NewCustomServingProcesser,
-			NewKFServingProcesser,
-			NewKServeProcesser,
-			NewTensorflowServingProcesser,
-			NewTensorrtServingProcesser,
-			NewSeldonServingProcesser,
-			NewTritonServingProcesser,
-			NewDistributedServingProcesser,
-		}
-		var wg sync.WaitGroup
-		for _, initFunc := range processerInits {
-			wg.Add(1)
-			f := initFunc
-			go func() {
-				defer wg.Done()
-				p := f()
-				locker.Lock()
-				processers[p.Type()] = p
-				locker.Unlock()
-			}()
-		}
-		wg.Wait()
-	})
-	return processers
+	configer := config.GetArenaConfiger()
+	if cached := clientcontext.GetConfigerProcessers(configer); cached != nil {
+		return cached.(map[types.ServingJobType]Processer)
+	}
+
+	locker := new(sync.Mutex)
+	localProcessers := map[types.ServingJobType]Processer{}
+	processerInits := []func() Processer{
+		NewCustomServingProcesser,
+		NewKFServingProcesser,
+		NewKServeProcesser,
+		NewTensorflowServingProcesser,
+		NewTensorrtServingProcesser,
+		NewSeldonServingProcesser,
+		NewTritonServingProcesser,
+		NewDistributedServingProcesser,
+	}
+	var wg sync.WaitGroup
+	for _, initFunc := range processerInits {
+		wg.Add(1)
+		f := initFunc
+		go func() {
+			defer wg.Done()
+			p := f()
+			locker.Lock()
+			localProcessers[p.Type()] = p
+			locker.Unlock()
+		}()
+	}
+	wg.Wait()
+
+	clientcontext.SetConfigerProcessers(configer, localProcessers)
+	return localProcessers
 }
 
 type servingJob struct {

--- a/pkg/training/trainer.go
+++ b/pkg/training/trainer.go
@@ -26,42 +26,44 @@ import (
 
 	"github.com/kubeflow/arena/pkg/apis/config"
 	"github.com/kubeflow/arena/pkg/apis/types"
+	"github.com/kubeflow/arena/pkg/util/clientcontext"
 	"github.com/kubeflow/arena/pkg/util/kubectl"
 )
 
-var trainers map[types.TrainingJobType]Trainer
-
-var once sync.Once
-
 func GetAllTrainers() map[types.TrainingJobType]Trainer {
-	once.Do(func() {
-		locker := new(sync.RWMutex)
-		trainers = map[types.TrainingJobType]Trainer{}
-		trainerInits := []func() Trainer{
-			NewTensorFlowJobTrainer,
-			NewPyTorchJobTrainer,
-			NewMPIJobTrainer,
-			NewETJobTrainer,
-			NewVolcanoJobTrainer,
-			NewSparkJobTrainer,
-			NewDeepSpeedJobTrainer,
-			NewRayJobTrainer,
-		}
-		var wg sync.WaitGroup
-		for _, initFunc := range trainerInits {
-			wg.Add(1)
-			f := initFunc
-			go func() {
-				defer wg.Done()
-				trainer := f()
-				locker.Lock()
-				trainers[trainer.Type()] = trainer
-				locker.Unlock()
-			}()
-		}
-		wg.Wait()
-	})
-	return trainers
+	configer := config.GetArenaConfiger()
+	if cached := clientcontext.GetConfigerTrainers(configer); cached != nil {
+		return cached.(map[types.TrainingJobType]Trainer)
+	}
+
+	locker := new(sync.Mutex)
+	localTrainers := map[types.TrainingJobType]Trainer{}
+	trainerInits := []func() Trainer{
+		NewTensorFlowJobTrainer,
+		NewPyTorchJobTrainer,
+		NewMPIJobTrainer,
+		NewETJobTrainer,
+		NewVolcanoJobTrainer,
+		NewSparkJobTrainer,
+		NewDeepSpeedJobTrainer,
+		NewRayJobTrainer,
+	}
+	var wg sync.WaitGroup
+	for _, initFunc := range trainerInits {
+		wg.Add(1)
+		f := initFunc
+		go func() {
+			defer wg.Done()
+			trainer := f()
+			locker.Lock()
+			localTrainers[trainer.Type()] = trainer
+			locker.Unlock()
+		}()
+	}
+	wg.Wait()
+
+	clientcontext.SetConfigerTrainers(configer, localTrainers)
+	return localTrainers
 }
 
 type orderedTrainingJob []TrainingJob

--- a/pkg/util/clientcontext/context.go
+++ b/pkg/util/clientcontext/context.go
@@ -1,0 +1,150 @@
+// Copyright 2026 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clientcontext
+
+import (
+	"bytes"
+	"runtime"
+	"strconv"
+	"sync"
+)
+
+var (
+	activeConfigers = make(map[uint64]interface{})
+	activeAccessers = make(map[uint64]interface{})
+	contextMu       sync.RWMutex
+
+	// Registries mapping configer interface{} to resources
+	configerAccessers  = make(map[interface{}]interface{})
+	configerTrainers   = make(map[interface{}]interface{})
+	configerProcessers = make(map[interface{}]interface{})
+	configerPrometheus = make(map[interface{}]interface{})
+	registryMu         sync.RWMutex
+)
+
+func getGID() uint64 {
+	var buf [64]byte
+	n := runtime.Stack(buf[:], false)
+	b := buf[:n]
+	b = bytes.TrimPrefix(b, []byte("goroutine "))
+	i := bytes.IndexByte(b, ' ')
+	if i < 0 {
+		return 0
+	}
+	id, _ := strconv.ParseUint(string(b[:i]), 10, 64)
+	return id
+}
+
+// AssociateConfigerAndAccesser links a configer to its accesser
+func AssociateConfigerAndAccesser(configer, accesser interface{}) {
+	registryMu.Lock()
+	defer registryMu.Unlock()
+	configerAccessers[configer] = accesser
+}
+
+// GetAssociatedAccesser gets the accesser linked to a configer
+func GetAssociatedAccesser(configer interface{}) interface{} {
+	registryMu.RLock()
+	defer registryMu.RUnlock()
+	return configerAccessers[configer]
+}
+
+// SetConfigerTrainers caches trainers for a configer
+func SetConfigerTrainers(configer, trainers interface{}) {
+	registryMu.Lock()
+	defer registryMu.Unlock()
+	configerTrainers[configer] = trainers
+}
+
+// GetConfigerTrainers retrieves trainers cached for a configer
+func GetConfigerTrainers(configer interface{}) interface{} {
+	registryMu.RLock()
+	defer registryMu.RUnlock()
+	return configerTrainers[configer]
+}
+
+// SetConfigerProcessers caches serving processers for a configer
+func SetConfigerProcessers(configer, processers interface{}) {
+	registryMu.Lock()
+	defer registryMu.Unlock()
+	configerProcessers[configer] = processers
+}
+
+// GetConfigerProcessers retrieves processers cached for a configer
+func GetConfigerProcessers(configer interface{}) interface{} {
+	registryMu.RLock()
+	defer registryMu.RUnlock()
+	return configerProcessers[configer]
+}
+
+// SetConfigerPrometheus caches prometheus client for a configer
+func SetConfigerPrometheus(configer, promClient interface{}) {
+	registryMu.Lock()
+	defer registryMu.Unlock()
+	configerPrometheus[configer] = promClient
+}
+
+// GetConfigerPrometheus retrieves prometheus client cached for a configer
+func GetConfigerPrometheus(configer interface{}) interface{} {
+	registryMu.RLock()
+	defer registryMu.RUnlock()
+	return configerPrometheus[configer]
+}
+
+// SetCurrentContext sets the active configer and accesser for the current goroutine
+func SetCurrentContext(configer, accesser interface{}) {
+	gid := getGID()
+	if gid == 0 {
+		return
+	}
+	contextMu.Lock()
+	defer contextMu.Unlock()
+	activeConfigers[gid] = configer
+	activeAccessers[gid] = accesser
+}
+
+// ClearCurrentContext clears context for the current goroutine
+func ClearCurrentContext() {
+	gid := getGID()
+	if gid == 0 {
+		return
+	}
+	contextMu.Lock()
+	defer contextMu.Unlock()
+	delete(activeConfigers, gid)
+	delete(activeAccessers, gid)
+}
+
+// GetActiveConfiger gets the active configer for the current goroutine
+func GetActiveConfiger() interface{} {
+	gid := getGID()
+	if gid == 0 {
+		return nil
+	}
+	contextMu.RLock()
+	defer contextMu.RUnlock()
+	return activeConfigers[gid]
+}
+
+// GetActiveAccesser gets the active accesser for the current goroutine
+func GetActiveAccesser() interface{} {
+	gid := getGID()
+	if gid == 0 {
+		return nil
+	}
+	contextMu.RLock()
+	defer contextMu.RUnlock()
+	return activeAccessers[gid]
+}

--- a/pkg/util/clientcontext/context_test.go
+++ b/pkg/util/clientcontext/context_test.go
@@ -1,0 +1,111 @@
+// Copyright 2026 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clientcontext
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type dummyConfiger struct {
+	name string
+}
+
+type dummyAccessor struct {
+	id string
+}
+
+func TestGoroutineLocalContext(t *testing.T) {
+	configer1 := &dummyConfiger{name: "configer-1"}
+	accessor1 := &dummyAccessor{id: "accessor-1"}
+
+	configer2 := &dummyConfiger{name: "configer-2"}
+	accessor2 := &dummyAccessor{id: "accessor-2"}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// Goroutine 1
+	go func() {
+		defer wg.Done()
+		SetCurrentContext(configer1, accessor1)
+		defer ClearCurrentContext()
+
+		// Verify this goroutine gets configer1 and accessor1
+		assert.Equal(t, configer1, GetActiveConfiger())
+		assert.Equal(t, accessor1, GetActiveAccesser())
+	}()
+
+	// Goroutine 2
+	go func() {
+		defer wg.Done()
+		SetCurrentContext(configer2, accessor2)
+		defer ClearCurrentContext()
+
+		// Verify this goroutine gets configer2 and accessor2
+		assert.Equal(t, configer2, GetActiveConfiger())
+		assert.Equal(t, accessor2, GetActiveAccesser())
+	}()
+
+	wg.Wait()
+
+	// Verify main goroutine has no active context
+	assert.Nil(t, GetActiveConfiger())
+	assert.Nil(t, GetActiveAccesser())
+}
+
+func TestConfigerRegistryAssociationAndCaching(t *testing.T) {
+	configer1 := &dummyConfiger{name: "configer-1"}
+	accessor1 := &dummyAccessor{id: "accessor-1"}
+	trainers1 := map[string]string{"tf": "trainer-1"}
+	processers1 := map[string]string{"serving": "processer-1"}
+	prometheus1 := "prom-1"
+
+	configer2 := &dummyConfiger{name: "configer-2"}
+	accessor2 := &dummyAccessor{id: "accessor-2"}
+	trainers2 := map[string]string{"tf": "trainer-2"}
+	processers2 := map[string]string{"serving": "processer-2"}
+	prometheus2 := "prom-2"
+
+	// Associate
+	AssociateConfigerAndAccesser(configer1, accessor1)
+	AssociateConfigerAndAccesser(configer2, accessor2)
+
+	assert.Equal(t, accessor1, GetAssociatedAccesser(configer1))
+	assert.Equal(t, accessor2, GetAssociatedAccesser(configer2))
+
+	// Cache trainers
+	SetConfigerTrainers(configer1, trainers1)
+	SetConfigerTrainers(configer2, trainers2)
+
+	assert.Equal(t, trainers1, GetConfigerTrainers(configer1))
+	assert.Equal(t, trainers2, GetConfigerTrainers(configer2))
+
+	// Cache processers
+	SetConfigerProcessers(configer1, processers1)
+	SetConfigerProcessers(configer2, processers2)
+
+	assert.Equal(t, processers1, GetConfigerProcessers(configer1))
+	assert.Equal(t, processers2, GetConfigerProcessers(configer2))
+
+	// Cache prometheus
+	SetConfigerPrometheus(configer1, prometheus1)
+	SetConfigerPrometheus(configer2, prometheus2)
+
+	assert.Equal(t, prometheus1, GetConfigerPrometheus(configer1))
+	assert.Equal(t, prometheus2, GetConfigerPrometheus(configer2))
+}

--- a/pkg/util/helm/util.go
+++ b/pkg/util/helm/util.go
@@ -20,6 +20,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/kubeflow/arena/pkg/apis/config"
 	log "github.com/sirupsen/logrus"
 	yaml "gopkg.in/yaml.v3"
 	"helm.sh/helm/v3/pkg/action"
@@ -37,6 +38,7 @@ const (
 func getActionConfig(namespace string) (*action.Configuration, error) {
 	envSettings := cli.New()
 	envSettings.SetNamespace(namespace)
+	envSettings.KubeConfig = config.GetArenaConfiger().GetKubeconfigPath()
 	actionConfig := &action.Configuration{}
 	err := actionConfig.Init(envSettings.RESTClientGetter(), envSettings.Namespace(), "", log.Debugf)
 	if err != nil {


### PR DESCRIPTION
### Context
The Kubeflow Arena Go SDK is built around package-level singletons (`config.arenaClient` and `k8saccesser.accesser`). This prevents applications from managing multiple Kubernetes clusters or namespaces concurrently or switching between users programmatically in a long-running process (e.g. gRPC/REST server).

### Changes
- Added `pkg/util/clientcontext` to track the active configer/accessor per goroutine.
- Wrapped SDK client methods (training, serving, cron, etc.) with `defer setContext()` to dynamically propagate the config context.
- Removed `once.Do` singleton constraints from `InitArenaConfiger` and `InitK8sResourceAccesser` to support multiple instantiations.
- Cached trainers, serving processors, and prometheus clients per `ArenaConfiger` to allow different clusters to have distinct configurations and enabled CRDs.
- Isolated Helm operations from the global `KUBECONFIG` env var by setting `envSettings.KubeConfig` directly from the client config path.

### Verification
- Tested with existing unit tests in `pkg/util/...`.
- Implemented a new parallel concurrent client test in `pkg/apis/arenaclient/arenaclient_test.go` to assert that multiple client sessions are isolated.

### Checklist
- [x] Code complies with project style and formatting
- [x] Unit tests added/updated
- [x] No breaking changes to existing package-level public APIs
