### PR TITLE
fix(pytorch-operator): update pytorch-operator image tag to 2845db5-aliyun

### DIFF
--- a/arena-artifacts/values.yaml
+++ b/arena-artifacts/values.yaml
@@ -90,7 +90,7 @@ mpi:
 pytorch:
   enabled: true
   image: acs/pytorch-operator
-  tag: 4598b3e-aliyun
+  tag: 2845db5-aliyun
   imagePullPolicy: IfNotPresent
   resources:
     limits:


### PR DESCRIPTION
## Purpose of this PR

**Proposed changes:**

- Update pytorch-operator image tag to `2845db5-aliyun`, which includes the fix for nil CleanPodPolicy dereference panic (AliyunContainerService/pytorch-operator#16).

## Change Category

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

The new image includes a fix for a nil pointer panic in the PyTorch controller when `CleanPodPolicy` is not set on a PyTorchJob.