### PR TITLE
feat(arena-artifacts): mount init container ConfigMap into pytorch-operator

### DIFF
--- a/arena-artifacts/charts/pytorch-operator/templates/operator-configmap.yaml
+++ b/arena-artifacts/charts/pytorch-operator/templates/operator-configmap.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.initContainerTemplateEnabled -}}
+{{- $defaultResources := dict "limits" (dict "cpu" "100m" "memory" "20Mi") "requests" (dict "cpu" "50m" "memory" "10Mi") -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: pytorch-init-container-template
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "arena.labels" . | nindent 4 }}
+data:
+  initContainer.yaml: |
+    - name: init-pytorch
+      image: {{"{{"}}.InitContainerImage{{"}}"}}
+      imagePullPolicy: {{ .Values.initContainerImagePullPolicy | default "IfNotPresent" }}
+      resources:
+        {{- toYaml (.Values.initContainerResources | default $defaultResources) | nindent 8 }}
+      command: ['sh', '-c', 'err=1;for i in $(seq {{ .Values.initContainerMaxTries | default 150 }}); do if getent hosts {{"{{"}}.MasterAddr{{"}}"}}; then err=0 && break; fi;echo waiting for master; sleep {{ .Values.initContainerSleepSeconds | default 2 }}; done; exit $err']
+{{- end -}}

--- a/arena-artifacts/charts/pytorch-operator/templates/operator-dp.yaml
+++ b/arena-artifacts/charts/pytorch-operator/templates/operator-dp.yaml
@@ -45,4 +45,16 @@ spec:
           name: pytorch-operator
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          {{- if .Values.initContainerTemplateEnabled }}
+          volumeMounts:
+            - mountPath: /etc/config
+              name: init-container-template
+              readOnly: true
+          {{- end }}
       serviceAccountName: pytorch-operator
+      {{- if .Values.initContainerTemplateEnabled }}
+      volumes:
+        - name: init-container-template
+          configMap:
+            name: pytorch-init-container-template
+      {{- end }}

--- a/arena-artifacts/tests/pytorch-operator/configmap_test.yaml
+++ b/arena-artifacts/tests/pytorch-operator/configmap_test.yaml
@@ -1,0 +1,162 @@
+#
+# Copyright 2025 The Kubeflow authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+suite: Test pytorch operator configmap
+
+templates:
+- charts/pytorch/templates/operator-configmap.yaml
+
+release:
+  name: arena-artifacts
+  namespace: arena-system
+
+set:
+  pytorch:
+    enabled: true
+
+tests:
+- it: Should not render ConfigMap when initContainerTemplateEnabled is false
+  set:
+    pytorch:
+      initContainerTemplateEnabled: false
+  asserts:
+  - hasDocuments:
+      count: 0
+
+- it: Should render ConfigMap with correct apiVersion and kind
+  asserts:
+  - equal:
+      path: apiVersion
+      value: v1
+  - equal:
+      path: kind
+      value: ConfigMap
+
+- it: Should render ConfigMap with correct name and namespace
+  asserts:
+  - equal:
+      path: metadata.name
+      value: pytorch-init-container-template
+  - equal:
+      path: metadata.namespace
+      value: arena-system
+
+- it: Should render ConfigMap with arena labels
+  asserts:
+  - equal:
+      path: metadata.labels["helm.sh/chart"]
+      value: arena-artifacts
+  - equal:
+      path: metadata.labels["app.kubeflow.org/managed-by"]
+      value: arena
+
+- it: Should preserve Go template literals for operator-side substitution
+  asserts:
+  - matchRegex:
+      path: 'data["initContainer.yaml"]'
+      pattern: "\\{\\{\\.InitContainerImage\\}\\}"
+  - matchRegex:
+      path: 'data["initContainer.yaml"]'
+      pattern: "\\{\\{\\.MasterAddr\\}\\}"
+
+- it: Should render default values from values.yaml
+  asserts:
+  - matchRegex:
+      path: 'data["initContainer.yaml"]'
+      pattern: "imagePullPolicy: IfNotPresent"
+  - matchRegex:
+      path: 'data["initContainer.yaml"]'
+      pattern: "seq 150"
+  - matchRegex:
+      path: 'data["initContainer.yaml"]'
+      pattern: "sleep 2"
+  - matchRegex:
+      path: 'data["initContainer.yaml"]'
+      pattern: "cpu: 100m"
+  - matchRegex:
+      path: 'data["initContainer.yaml"]'
+      pattern: "memory: 20Mi"
+  - matchRegex:
+      path: 'data["initContainer.yaml"]'
+      pattern: "cpu: 50m"
+  - matchRegex:
+      path: 'data["initContainer.yaml"]'
+      pattern: "memory: 10Mi"
+
+- it: Should render custom init container resources
+  set:
+    pytorch:
+      initContainerResources:
+        limits:
+          cpu: 200m
+          memory: 40Mi
+        requests:
+          cpu: 100m
+          memory: 20Mi
+  asserts:
+  - matchRegex:
+      path: 'data["initContainer.yaml"]'
+      pattern: "cpu: 200m"
+  - matchRegex:
+      path: 'data["initContainer.yaml"]'
+      pattern: "memory: 40Mi"
+
+- it: Should render custom imagePullPolicy, maxTries and sleepSeconds
+  set:
+    pytorch:
+      initContainerImagePullPolicy: Always
+      initContainerMaxTries: 300
+      initContainerSleepSeconds: 5
+  asserts:
+  - matchRegex:
+      path: 'data["initContainer.yaml"]'
+      pattern: "imagePullPolicy: Always"
+  - matchRegex:
+      path: 'data["initContainer.yaml"]'
+      pattern: "seq 300"
+  - matchRegex:
+      path: 'data["initContainer.yaml"]'
+      pattern: "sleep 5"
+
+- it: Should fall back to defaults when all configurable fields are null
+  set:
+    pytorch:
+      initContainerImagePullPolicy: null
+      initContainerResources: null
+      initContainerMaxTries: null
+      initContainerSleepSeconds: null
+  asserts:
+  - matchRegex:
+      path: 'data["initContainer.yaml"]'
+      pattern: "imagePullPolicy: IfNotPresent"
+  - matchRegex:
+      path: 'data["initContainer.yaml"]'
+      pattern: "seq 150"
+  - matchRegex:
+      path: 'data["initContainer.yaml"]'
+      pattern: "sleep 2"
+  - matchRegex:
+      path: 'data["initContainer.yaml"]'
+      pattern: "cpu: 100m"
+  - matchRegex:
+      path: 'data["initContainer.yaml"]'
+      pattern: "memory: 20Mi"
+  - matchRegex:
+      path: 'data["initContainer.yaml"]'
+      pattern: "cpu: 50m"
+  - matchRegex:
+      path: 'data["initContainer.yaml"]'
+      pattern: "memory: 10Mi"

--- a/arena-artifacts/tests/pytorch-operator/deployment_test.yaml
+++ b/arena-artifacts/tests/pytorch-operator/deployment_test.yaml
@@ -112,3 +112,46 @@ tests:
       - key: key4
         operator: Exists
         effect: NoSchedule
+
+- it: Should pass init-container-image flag with the configured image
+  asserts:
+  - equal:
+      path: spec.template.spec.containers[0].name
+      value: pytorch-operator
+  - contains:
+      path: spec.template.spec.containers[0].command
+      content: --init-container-image=alpine:3.22.2
+
+- it: Should mount init container template ConfigMap at /etc/config read-only
+  asserts:
+  - equal:
+      path: spec.template.spec.containers[0].name
+      value: pytorch-operator
+  - equal:
+      path: spec.template.spec.containers[0].volumeMounts[0].mountPath
+      value: /etc/config
+  - equal:
+      path: spec.template.spec.containers[0].volumeMounts[0].name
+      value: init-container-template
+  - equal:
+      path: spec.template.spec.containers[0].volumeMounts[0].readOnly
+      value: true
+
+- it: Should reference pytorch-init-container-template ConfigMap in volumes
+  asserts:
+  - equal:
+      path: spec.template.spec.volumes[0].name
+      value: init-container-template
+  - equal:
+      path: spec.template.spec.volumes[0].configMap.name
+      value: pytorch-init-container-template
+
+- it: Should not mount ConfigMap or volumes when initContainerTemplateEnabled is false
+  set:
+    pytorch:
+      initContainerTemplateEnabled: false
+  asserts:
+  - notExists:
+      path: spec.template.spec.containers[0].volumeMounts
+  - notExists:
+      path: spec.template.spec.volumes

--- a/arena-artifacts/values.yaml
+++ b/arena-artifacts/values.yaml
@@ -100,7 +100,18 @@ pytorch:
       cpu: 100m
       memory: 256Mi
   nodeSelector: {}
-  initContainerImage: alpine:3.10
+  initContainerImage: alpine:3.22.2
+  initContainerTemplateEnabled: true
+  initContainerImagePullPolicy: IfNotPresent
+  initContainerResources:
+    limits:
+      cpu: 100m
+      memory: 20Mi
+    requests:
+      cpu: 50m
+      memory: 10Mi
+  initContainerMaxTries: 150
+  initContainerSleepSeconds: 2
 
 # et-operator
 et:
@@ -117,7 +128,7 @@ et:
       cpu: 100m
       memory: 256Mi
   nodeSelector: {}
-  initContainerImage: alpine:3.10
+  initContainerImage: alpine:3.22.2
 
 # cron-operator
 cron:


### PR DESCRIPTION
## Purpose of this PR

Bring the `pytorch-operator` subchart in `arena-artifacts` in line with the newer `training-operator` chart: use a modern Alpine image for the init container and expose the init container template as a file on disk instead of relying on the operator's built-in Go template. This lets cluster admins patch the template (e.g. DNS wait-loop tuning) without rebuilding the operator image.

**Proposed changes:**

- Bump `arena-artifacts` `pytorch.initContainerImage` from `alpine:3.10` to `alpine:3.22.2`.
- Add a new ConfigMap `pytorch-init-container-template` in the pytorch-operator subchart, containing `initContainer.yaml` with the DNS wait-loop template (matching the reference `training-operator` chart).
- Mount the ConfigMap read-only at `/etc/config` on the `pytorch-operator` container so the operator reads `/etc/config/initContainer.yaml` at runtime. Template placeholders `{{.InitContainerImage}}`, `{{.MaxTries}}`, and `{{.MasterAddr}}` are kept as literals in the ConfigMap and substituted by the operator's own Go template per PyTorchJob.

## Change Category

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

The upstream `training-operator` chart already ships this pattern (see `aliyun-incubator/training-operator` reference). Mirroring it in the `pytorch-operator` subchart keeps the two operator deployments consistent, upgrades the stale `alpine:3.10` image to a maintained `alpine:3.22.2`, and moves the init container template out of the binary into a ConfigMap that operators can edit in place.

## Test Plan

- `helm template arena-artifacts ./arena-artifacts --namespace arena-system` renders cleanly and shows:
  - a `ConfigMap` named `pytorch-init-container-template` with the expected `initContainer.yaml` body and literal `{{...}}` placeholders;
  - the `pytorch-operator` `Deployment` with `volumeMounts: /etc/config` and the matching `volumes` entry;
  - the operator container arg `--init-container-image=alpine:3.22.2`.
- Deploy to a test cluster and confirm the pytorch-operator pod starts with `/etc/config/initContainer.yaml` mounted and successfully spawns PyTorchJob init containers using the file-based template.