### PR TITLE
fix: resolve real username for client-certificate kubeconfigs

### DIFF
--- a/pkg/apis/config/user.go
+++ b/pkg/apis/config/user.go
@@ -16,10 +16,12 @@ package config
 
 import (
 	"context"
-	"errors"
+	"crypto/x509"
+	"encoding/pem"
 	"fmt"
 	"os"
 
+	log "github.com/sirupsen/logrus"
 	authenticationapi "k8s.io/api/authentication/v1"
 	authorizationv1 "k8s.io/api/authorization/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -38,6 +40,21 @@ func getUserName(namespace string, clientConfig clientcmd.ClientConfig, restConf
 		return &userName, nil
 	}
 	if tc.HasCertAuth() {
+		// Prefer asking the API server who we are (same as `kubectl auth whoami`).
+		// Historically this branch hard-coded "kubecfg:certauth:admin", which is wrong for
+		// per-user client certificates (e.g. ACK RAM X509 kubeconfigs whose CN is the RAM UID).
+		if userName, err := getUserNameBySelfSubjectReview(clientSet); err == nil {
+			return userName, nil
+		} else {
+			log.Debugf("SelfSubjectReview failed for cert auth, falling back to certificate CN: %v", err)
+		}
+		// Offline fallback: Kubernetes maps the certificate CommonName to the username.
+		if userName, err := getUserNameFromClientCertificate(restConfig); err == nil {
+			return userName, nil
+		} else {
+			log.Debugf("failed to parse client certificate CN, falling back to legacy username: %v", err)
+		}
+		// Preserve legacy behavior for unusual certificate setups.
 		userName := "kubecfg:certauth:admin"
 		return &userName, nil
 	}
@@ -82,10 +99,55 @@ func getUserNameByToken(kubeclient kubernetes.Interface, token string) (*string,
 	}
 
 	if result.Status.Error != "" {
-		return nil, errors.New(result.Status.Error)
+		return nil, fmt.Errorf("%s", result.Status.Error)
 	}
 
 	return &result.Status.User.Username, nil
+}
+
+func getUserNameBySelfSubjectReview(kubeclient kubernetes.Interface) (*string, error) {
+	result, err := kubeclient.AuthenticationV1().SelfSubjectReviews().Create(
+		context.TODO(),
+		&authenticationapi.SelfSubjectReview{},
+		metav1.CreateOptions{},
+	)
+	if err != nil {
+		return nil, err
+	}
+	if result.Status.UserInfo.Username == "" {
+		return nil, fmt.Errorf("SelfSubjectReview returned empty username")
+	}
+	return &result.Status.UserInfo.Username, nil
+}
+
+func getUserNameFromClientCertificate(restConfig *rest.Config) (*string, error) {
+	var certPEM []byte
+	switch {
+	case len(restConfig.CertData) > 0:
+		certPEM = restConfig.CertData
+	case restConfig.CertFile != "":
+		var err error
+		certPEM, err = os.ReadFile(restConfig.CertFile)
+		if err != nil {
+			return nil, err
+		}
+	default:
+		return nil, fmt.Errorf("no client certificate data or file configured")
+	}
+
+	block, _ := pem.Decode(certPEM)
+	if block == nil {
+		return nil, fmt.Errorf("failed to decode client certificate PEM")
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return nil, err
+	}
+	if cert.Subject.CommonName == "" {
+		return nil, fmt.Errorf("client certificate has empty CommonName")
+	}
+	userName := cert.Subject.CommonName
+	return &userName, nil
 }
 
 func createSubjectRulesReviews(namespace string, kubeclient kubernetes.Interface) error {

--- a/pkg/apis/config/user_test.go
+++ b/pkg/apis/config/user_test.go
@@ -1,0 +1,109 @@
+// Copyright 2024 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"k8s.io/client-go/rest"
+)
+
+func mustGenerateClientCertPEM(t *testing.T, commonName string) []byte {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			CommonName: commonName,
+		},
+		NotBefore: time.Now().Add(-time.Hour),
+		NotAfter:  time.Now().Add(time.Hour),
+		KeyUsage:  x509.KeyUsageDigitalSignature,
+		ExtKeyUsage: []x509.ExtKeyUsage{
+			x509.ExtKeyUsageClientAuth,
+		},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create certificate: %v", err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+}
+
+func TestGetUserNameFromClientCertificateCertData(t *testing.T) {
+	const want = "204360775885168282"
+	cfg := &rest.Config{
+		TLSClientConfig: rest.TLSClientConfig{
+			CertData: mustGenerateClientCertPEM(t, want),
+		},
+	}
+	got, err := getUserNameFromClientCertificate(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got == nil || *got != want {
+		t.Fatalf("got %v, want %q", got, want)
+	}
+}
+
+func TestGetUserNameFromClientCertificateCertFile(t *testing.T) {
+	const want = "ram-user-from-file"
+	dir := t.TempDir()
+	path := filepath.Join(dir, "client.crt")
+	if err := os.WriteFile(path, mustGenerateClientCertPEM(t, want), 0o600); err != nil {
+		t.Fatalf("write cert: %v", err)
+	}
+	cfg := &rest.Config{
+		TLSClientConfig: rest.TLSClientConfig{
+			CertFile: path,
+		},
+	}
+	got, err := getUserNameFromClientCertificate(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got == nil || *got != want {
+		t.Fatalf("got %v, want %q", got, want)
+	}
+}
+
+func TestGetUserNameFromClientCertificateMissing(t *testing.T) {
+	if _, err := getUserNameFromClientCertificate(&rest.Config{}); err == nil {
+		t.Fatal("expected error for missing certificate")
+	}
+}
+
+func TestGetUserNameFromClientCertificateEmptyCN(t *testing.T) {
+	cfg := &rest.Config{
+		TLSClientConfig: rest.TLSClientConfig{
+			CertData: mustGenerateClientCertPEM(t, ""),
+		},
+	}
+	if _, err := getUserNameFromClientCertificate(cfg); err == nil {
+		t.Fatal("expected error for empty CommonName")
+	}
+}


### PR DESCRIPTION
Arena previously hard-coded arena.kubeflow.org/username to kubecfg:certauth:admin whenever kubeconfig used client certs. That breaks multi-user ACK/RAM X509 setups where the certificate CN is the real principal.

Prefer SelfSubjectReview (same as kubectl auth whoami), then fall back to parsing the client certificate CommonName, and only then keep the legacy admin placeholder.

<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Arena, check the developer guide:
    https://arena-docs.readthedocs.io/en/latest/
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

## Purpose of this PR

<!-- Provide a clear and concise description of the changes. Explain the motivation behind these changes and link to relevant issues or discussions. -->

**Proposed changes:**

- <Change 1>
- <Change 2>
- <Change 3>

## Change Category

<!-- Indicate the type of change by marking the applicable boxes. -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

<!-- Provide reasoning for the changes if not already covered in the description above. -->