### PR TITLE
fix: prevent nil pointer dereference in servingJob and lwsJob methods

### DIFF
--- a/pkg/serving/serving.go
+++ b/pkg/serving/serving.go
@@ -95,6 +95,9 @@ type servingJob struct {
 }
 
 func (s *servingJob) Uid() string {
+	if s.deployment == nil {
+		return ""
+	}
 	return string(s.deployment.UID)
 }
 
@@ -163,10 +166,16 @@ func (s *servingJob) IPAddress() string {
 }
 
 func (s *servingJob) Age() time.Duration {
+	if s.deployment == nil {
+		return 0
+	}
 	return time.Since(s.deployment.CreationTimestamp.Time)
 }
 
 func (s *servingJob) StartTime() *metav1.Time {
+	if s.deployment == nil {
+		return &metav1.Time{}
+	}
 	return &s.deployment.CreationTimestamp
 }
 
@@ -226,7 +235,10 @@ func (s *servingJob) RequestCPUs() float64 {
 	//}
 	//return cpus
 
-	replicas := *s.deployment.Spec.Replicas
+	if s.deployment == nil {
+		return 0
+	}
+	replicas := int32PtrVal(s.deployment.Spec.Replicas, 1)
 	podCPUs := 0.0
 
 	for _, c := range s.deployment.Spec.Template.Spec.Containers {
@@ -238,7 +250,10 @@ func (s *servingJob) RequestCPUs() float64 {
 }
 
 func (s *servingJob) RequestGPUs() float64 {
-	replicas := *s.deployment.Spec.Replicas
+	if s.deployment == nil {
+		return 0
+	}
+	replicas := int32PtrVal(s.deployment.Spec.Replicas, 1)
 	podGPUs := 0
 	for _, c := range s.deployment.Spec.Template.Spec.Containers {
 		if val, ok := c.Resources.Limits[corev1.ResourceName(types.NvidiaGPUResourceName)]; ok {
@@ -252,7 +267,10 @@ func (s *servingJob) RequestGPUs() float64 {
 }
 
 func (s *servingJob) RequestGPUMemory() int {
-	replicas := *s.deployment.Spec.Replicas
+	if s.deployment == nil {
+		return 0
+	}
+	replicas := int32PtrVal(s.deployment.Spec.Replicas, 1)
 	podGPUMemory := 0
 	for _, c := range s.deployment.Spec.Template.Spec.Containers {
 		if val, ok := c.Resources.Limits[corev1.ResourceName(types.GPUShareResourceName)]; ok {
@@ -263,7 +281,10 @@ func (s *servingJob) RequestGPUMemory() int {
 }
 
 func (s *servingJob) RequestGPUCore() int {
-	replicas := *s.deployment.Spec.Replicas
+	if s.deployment == nil {
+		return 0
+	}
+	replicas := int32PtrVal(s.deployment.Spec.Replicas, 1)
 	podGPUCore := 0
 	for _, c := range s.deployment.Spec.Template.Spec.Containers {
 		if val, ok := c.Resources.Limits[corev1.ResourceName(types.GPUCoreShareResourceName)]; ok {
@@ -274,10 +295,16 @@ func (s *servingJob) RequestGPUCore() int {
 }
 
 func (s *servingJob) AvailableInstances() int {
+	if s.deployment == nil {
+		return 0
+	}
 	return int(s.deployment.Status.AvailableReplicas)
 }
 
 func (s *servingJob) DesiredInstances() int {
+	if s.deployment == nil {
+		return 0
+	}
 	return int(s.deployment.Status.Replicas)
 }
 
@@ -332,6 +359,9 @@ func (s *servingJob) Convert2JobInfo() types.ServingJobInfo {
 }
 
 func (s *servingJob) GetLabels() map[string]string {
+	if s.deployment == nil {
+		return map[string]string{}
+	}
 	return s.deployment.Labels
 }
 

--- a/pkg/serving/serving_distributed.go
+++ b/pkg/serving/serving_distributed.go
@@ -153,19 +153,31 @@ func (p *DistributedServingProcesser) FilterServingJobs(namespace string, allNam
 }
 
 func (s *lwsJob) Uid() string {
+	if s.lws == nil {
+		return ""
+	}
 	return string(s.lws.UID)
 }
 
 func (s *lwsJob) Age() time.Duration {
+	if s.lws == nil {
+		return 0
+	}
 	return time.Since(s.lws.CreationTimestamp.Time)
 }
 
 func (s *lwsJob) StartTime() *metav1.Time {
+	if s.lws == nil {
+		return &metav1.Time{}
+	}
 	return &s.lws.CreationTimestamp
 }
 
 func (s *lwsJob) RequestCPUs() float64 {
-	replicas := s.lws.Spec.Replicas
+	if s.lws == nil {
+		return 0
+	}
+	replicas := int32PtrVal(s.lws.Spec.Replicas, 1)
 	size := s.lws.Spec.LeaderWorkerTemplate.Size
 	masterCPUs := 0.0
 	for _, c := range s.lws.Spec.LeaderWorkerTemplate.LeaderTemplate.Spec.Containers {
@@ -173,7 +185,7 @@ func (s *lwsJob) RequestCPUs() float64 {
 			masterCPUs += float64(val.Value())
 		}
 	}
-	result := masterCPUs * float64(*replicas)
+	result := masterCPUs * float64(replicas)
 	if size != nil && *size > 1 {
 		workerCPUs := 0.0
 		for _, c := range s.lws.Spec.LeaderWorkerTemplate.WorkerTemplate.Spec.Containers {
@@ -182,13 +194,16 @@ func (s *lwsJob) RequestCPUs() float64 {
 			}
 		}
 		workerCPUs *= float64((*size) - 1)
-		result += float64(*replicas) * workerCPUs
+		result += float64(replicas) * workerCPUs
 	}
 	return result
 }
 
 func (s *lwsJob) RequestGPUs() float64 {
-	replicas := s.lws.Spec.Replicas
+	if s.lws == nil {
+		return 0
+	}
+	replicas := int32PtrVal(s.lws.Spec.Replicas, 1)
 	size := s.lws.Spec.LeaderWorkerTemplate.Size
 	masterGPUs := 0.0
 	for _, c := range s.lws.Spec.LeaderWorkerTemplate.LeaderTemplate.Spec.Containers {
@@ -199,7 +214,7 @@ func (s *lwsJob) RequestGPUs() float64 {
 			masterGPUs += float64(val.Value())
 		}
 	}
-	result := masterGPUs * float64(*replicas)
+	result := masterGPUs * float64(replicas)
 	if size != nil && *size > 1 {
 		workerGPUs := 0.0
 		for _, c := range s.lws.Spec.LeaderWorkerTemplate.WorkerTemplate.Spec.Containers {
@@ -213,13 +228,16 @@ func (s *lwsJob) RequestGPUs() float64 {
 			}
 		}
 		workerGPUs *= float64((*size) - 1)
-		result += float64(*replicas) * workerGPUs
+		result += float64(replicas) * workerGPUs
 	}
 	return result
 }
 
 func (s *lwsJob) RequestGPUMemory() int {
-	replicas := s.lws.Spec.Replicas
+	if s.lws == nil {
+		return 0
+	}
+	replicas := int32PtrVal(s.lws.Spec.Replicas, 1)
 	size := s.lws.Spec.LeaderWorkerTemplate.Size
 
 	masterGpuMemory := 0
@@ -229,7 +247,7 @@ func (s *lwsJob) RequestGPUMemory() int {
 		}
 	}
 
-	result := masterGpuMemory * int(*replicas)
+	result := masterGpuMemory * int(replicas)
 	if size != nil && *size > 1 {
 		workerGpuMemory := 0
 		for _, c := range s.lws.Spec.LeaderWorkerTemplate.WorkerTemplate.Spec.Containers {
@@ -238,14 +256,17 @@ func (s *lwsJob) RequestGPUMemory() int {
 			}
 		}
 		workerGpuMemory *= int((*size) - 1)
-		result += int(*replicas) * workerGpuMemory
+		result += int(replicas) * workerGpuMemory
 	}
 
 	return result
 }
 
 func (s *lwsJob) RequestGPUCore() int {
-	replicas := s.lws.Spec.Replicas
+	if s.lws == nil {
+		return 0
+	}
+	replicas := int32PtrVal(s.lws.Spec.Replicas, 1)
 	size := s.lws.Spec.LeaderWorkerTemplate.Size
 
 	masterGpuCore := 0
@@ -255,7 +276,7 @@ func (s *lwsJob) RequestGPUCore() int {
 		}
 	}
 
-	result := masterGpuCore * int(*replicas)
+	result := masterGpuCore * int(replicas)
 	if size != nil && *size > 1 {
 		workerGpuCore := 0
 		for _, c := range s.lws.Spec.LeaderWorkerTemplate.WorkerTemplate.Spec.Containers {
@@ -264,21 +285,30 @@ func (s *lwsJob) RequestGPUCore() int {
 			}
 		}
 		workerGpuCore *= int((*size) - 1)
-		result += int(*replicas) * workerGpuCore
+		result += int(replicas) * workerGpuCore
 	}
 
 	return result
 }
 
 func (s *lwsJob) DesiredInstances() int {
+	if s.lws == nil {
+		return 0
+	}
 	return int(s.lws.Status.Replicas)
 }
 
 func (s *lwsJob) AvailableInstances() int {
+	if s.lws == nil {
+		return 0
+	}
 	return int(s.lws.Status.ReadyReplicas)
 }
 
 func (s *lwsJob) GetLabels() map[string]string {
+	if s.lws == nil {
+		return map[string]string{}
+	}
 	return s.lws.Labels
 }
 

--- a/pkg/serving/serving_kserve.go
+++ b/pkg/serving/serving_kserve.go
@@ -207,7 +207,7 @@ func (s *kserveJob) IPAddress() string {
 func (s *kserveJob) RequestCPUs() float64 {
 	var result float64
 	for _, dp := range s.inferenceDeployments {
-		replicas := *dp.Spec.Replicas
+		replicas := int32PtrVal(dp.Spec.Replicas, 1)
 		podCPUs := 0.0
 		for _, c := range dp.Spec.Template.Spec.Containers {
 			if val, ok := c.Resources.Limits[corev1.ResourceName(types.CPUResourceName)]; ok {
@@ -222,7 +222,7 @@ func (s *kserveJob) RequestCPUs() float64 {
 func (s *kserveJob) RequestGPUs() float64 {
 	var result float64
 	for _, dp := range s.inferenceDeployments {
-		replicas := *dp.Spec.Replicas
+		replicas := int32PtrVal(dp.Spec.Replicas, 1)
 		podGPUs := 0
 		for _, c := range dp.Spec.Template.Spec.Containers {
 			if val, ok := c.Resources.Limits[corev1.ResourceName(types.NvidiaGPUResourceName)]; ok {
@@ -240,7 +240,7 @@ func (s *kserveJob) RequestGPUs() float64 {
 func (s *kserveJob) RequestGPUMemory() int {
 	var result int
 	for _, dp := range s.inferenceDeployments {
-		replicas := *dp.Spec.Replicas
+		replicas := int32PtrVal(dp.Spec.Replicas, 1)
 		podGPUMemory := 0
 		for _, c := range dp.Spec.Template.Spec.Containers {
 			if val, ok := c.Resources.Limits[corev1.ResourceName(types.GPUShareResourceName)]; ok {
@@ -255,7 +255,7 @@ func (s *kserveJob) RequestGPUMemory() int {
 func (s *kserveJob) RequestGPUCore() int {
 	var result int
 	for _, dp := range s.inferenceDeployments {
-		replicas := *dp.Spec.Replicas
+		replicas := int32PtrVal(dp.Spec.Replicas, 1)
 		podGPUCore := 0
 		for _, c := range dp.Spec.Template.Spec.Containers {
 			if val, ok := c.Resources.Limits[corev1.ResourceName(types.GPUCoreShareResourceName)]; ok {

--- a/pkg/serving/serving_test.go
+++ b/pkg/serving/serving_test.go
@@ -1,0 +1,184 @@
+// Copyright 2026 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package serving
+
+import (
+	"testing"
+
+	"github.com/kubeflow/arena/pkg/apis/types"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	lws_v1 "sigs.k8s.io/lws/api/leaderworkerset/v1"
+)
+
+func TestInt32PtrVal(t *testing.T) {
+	if val := int32PtrVal(nil, 1); val != 1 {
+		t.Errorf("expected 1, got %d", val)
+	}
+	var v int32 = 5
+	if val := int32PtrVal(&v, 1); val != 5 {
+		t.Errorf("expected 5, got %d", val)
+	}
+}
+
+func TestServingJobNilDeployment(t *testing.T) {
+	job := &servingJob{
+		name:        "test-job",
+		namespace:   "default",
+		servingType: types.CustomServingJob,
+		version:     "v1",
+		deployment:  nil,
+	}
+
+	if job.Uid() != "" {
+		t.Errorf("expected empty string for Uid when deployment is nil, got %s", job.Uid())
+	}
+	if job.Age() != 0 {
+		t.Errorf("expected 0 for Age when deployment is nil, got %v", job.Age())
+	}
+	if job.StartTime() == nil {
+		t.Errorf("expected non-nil StartTime when deployment is nil")
+	}
+	if job.RequestCPUs() != 0 {
+		t.Errorf("expected 0 for RequestCPUs when deployment is nil, got %f", job.RequestCPUs())
+	}
+	if job.RequestGPUs() != 0 {
+		t.Errorf("expected 0 for RequestGPUs when deployment is nil, got %f", job.RequestGPUs())
+	}
+	if job.RequestGPUMemory() != 0 {
+		t.Errorf("expected 0 for RequestGPUMemory when deployment is nil, got %d", job.RequestGPUMemory())
+	}
+	if job.RequestGPUCore() != 0 {
+		t.Errorf("expected 0 for RequestGPUCore when deployment is nil, got %d", job.RequestGPUCore())
+	}
+	if job.AvailableInstances() != 0 {
+		t.Errorf("expected 0 for AvailableInstances when deployment is nil, got %d", job.AvailableInstances())
+	}
+	if job.DesiredInstances() != 0 {
+		t.Errorf("expected 0 for DesiredInstances when deployment is nil, got %d", job.DesiredInstances())
+	}
+	labels := job.GetLabels()
+	if labels == nil || len(labels) != 0 {
+		t.Errorf("expected empty map for GetLabels when deployment is nil, got %v", labels)
+	}
+}
+
+func TestServingJobNilReplicas(t *testing.T) {
+	job := &servingJob{
+		name:        "test-job",
+		namespace:   "default",
+		servingType: types.CustomServingJob,
+		version:     "v1",
+		deployment: &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-job-v1",
+				Namespace: "default",
+				Labels: map[string]string{
+					servingNameLabelKey: "test-job",
+				},
+			},
+			Spec: appsv1.DeploymentSpec{
+				Replicas: nil, // nil Replicas pointer
+			},
+		},
+	}
+
+	if job.GetLabels()[servingNameLabelKey] != "test-job" {
+		t.Errorf("expected label servingName to be test-job, got %v", job.GetLabels())
+	}
+	// Verify calculations don't panic and default replicas to 1
+	if job.RequestCPUs() != 0 {
+		t.Errorf("expected 0 CPUs for container without CPU limits, got %f", job.RequestCPUs())
+	}
+}
+
+func TestLwsJobNilLws(t *testing.T) {
+	job := &lwsJob{
+		lws: nil,
+		servingJob: &servingJob{
+			name:        "lws-test",
+			namespace:   "default",
+			servingType: types.DistributedServingJob,
+			version:     "v1",
+			deployment:  nil,
+		},
+	}
+
+	if job.GetLabels() == nil || len(job.GetLabels()) != 0 {
+		t.Errorf("expected empty map for GetLabels when lws is nil, got %v", job.GetLabels())
+	}
+	if job.Uid() != "" {
+		t.Errorf("expected empty string for Uid when lws is nil, got %s", job.Uid())
+	}
+	if job.Age() != 0 {
+		t.Errorf("expected 0 for Age when lws is nil, got %v", job.Age())
+	}
+	if job.RequestCPUs() != 0 {
+		t.Errorf("expected 0 for RequestCPUs when lws is nil, got %f", job.RequestCPUs())
+	}
+	if job.RequestGPUs() != 0 {
+		t.Errorf("expected 0 for RequestGPUs when lws is nil, got %f", job.RequestGPUs())
+	}
+	if job.DesiredInstances() != 0 {
+		t.Errorf("expected 0 for DesiredInstances when lws is nil, got %d", job.DesiredInstances())
+	}
+	if job.AvailableInstances() != 0 {
+		t.Errorf("expected 0 for AvailableInstances when lws is nil, got %d", job.AvailableInstances())
+	}
+}
+
+func TestLwsJobValidLws(t *testing.T) {
+	lws := &lws_v1.LeaderWorkerSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "lws-job",
+			Namespace: "default",
+			UID:       "uid-1234",
+			Labels: map[string]string{
+				servingNameLabelKey: "lws-job",
+			},
+		},
+		Spec: lws_v1.LeaderWorkerSetSpec{
+			Replicas: nil, // nil replicas
+		},
+		Status: lws_v1.LeaderWorkerSetStatus{
+			Replicas:      2,
+			ReadyReplicas: 1,
+		},
+	}
+
+	job := &lwsJob{
+		lws: lws,
+		servingJob: &servingJob{
+			name:        "lws-job",
+			namespace:   "default",
+			servingType: types.DistributedServingJob,
+			version:     "v1",
+			deployment:  nil,
+		},
+	}
+
+	if job.Uid() != "uid-1234" {
+		t.Errorf("expected Uid uid-1234, got %s", job.Uid())
+	}
+	if job.GetLabels()[servingNameLabelKey] != "lws-job" {
+		t.Errorf("expected label servingName to be lws-job, got %v", job.GetLabels())
+	}
+	if job.DesiredInstances() != 2 {
+		t.Errorf("expected DesiredInstances 2, got %d", job.DesiredInstances())
+	}
+	if job.AvailableInstances() != 1 {
+		t.Errorf("expected AvailableInstances 1, got %d", job.AvailableInstances())
+	}
+}

--- a/pkg/serving/util.go
+++ b/pkg/serving/util.go
@@ -97,3 +97,13 @@ func ValidateJobsBeforeSubmiting(jobs []ServingJob, name string) error {
 	}
 	return nil
 }
+
+// int32PtrVal safely dereferences a *int32 pointer, returning defaultVal if p is nil.
+// This is used to guard against nil Spec.Replicas in Deployment and LeaderWorkerSet specs,
+// which can be nil when replicas are managed by an autoscaler (e.g., HPA, KEDA).
+func int32PtrVal(p *int32, defaultVal int32) int32 {
+	if p == nil {
+		return defaultVal
+	}
+	return *p
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Arena, check the developer guide:
    https://arena-docs.readthedocs.io/en/latest/
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

## Purpose of this PR

Fixes #1454

This PR resolves a nil pointer dereference panic occurring when viewing or listing distributed serving jobs (or any serving job where `deployment`, `lws`, or `Spec.Replicas` is `nil`).

**Proposed changes:**

- Added defensive `nil` pointer checks in `servingJob` base methods (`pkg/serving/serving.go`) when `s.deployment` is `nil`.
- Added defensive `nil` pointer checks in `lwsJob` methods (`pkg/serving/serving_distributed.go`) when `s.lws` is `nil`.
- Added `int32PtrVal` helper in `pkg/serving/util.go` to safely dereference `*int32` pointers (`Spec.Replicas`) without panicking when `Replicas` is managed by an autoscaler (e.g. HPA/KEDA).
- Updated `serving.go`, `serving_distributed.go`, and `serving_kserve.go` to use `int32PtrVal`.
- Added unit tests in `pkg/serving/serving_test.go` covering `servingJob` and `lwsJob` under nil pointer scenarios.

### Rationale

When running `arena serving get <job-name> --type distributed-serving`, `ServingJobClient.GetAndPrint()` invokes `job.GetLabels()` and other interface methods. `lwsJob` sets `deployment: nil` in its embedded `servingJob`. Without defensive nil checks, accessing `s.deployment.Labels` or dereferencing `*s.lws.Spec.Replicas` causes a CLI panic.

## Verification

Ran `go test -v ./pkg/serving/...`:
