### PR TITLE
chore: add arena v2 Makefile targets and gitignore patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,22 +1,37 @@
 # Binaries
-/bin/
+bin/
 *.exe
 *.dll
 *.so
 *.dylib
 
-# Test / coverage
-*.test
-*.out
-coverage.txt
+# Misc
+tmp/
+sdk/
+.kube
+*.tgz
+*.tar.gz
 
-# Go workspace / vendor
+# Python
+__pycache__/
+
+# Go
 vendor/
 go.work
 go.work.sum
+*.test
+*.out
+coverage.txt
+/arena-v2
 
-# IDE / OS
+# v2 e2e test CRDs (downloaded via make v2-e2e-setup)
+test/e2e/crds/
+
+# IDE
 .idea/
 .vscode/
-.DS_Store
+.claude
+.qoder
 
+# OS
+.DS_Store

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,63 @@
+# Arena v2 — AI Workload CLI for Kubernetes
+
+## Project Overview
+
+Arena v2 is a lightweight CLI for submitting AI training/inference tasks to Kubernetes.
+It directly generates Operator CRDs (PyTorchJob, TFJob, MPIJob) and related resources without Helm chart rendering.
+
+- **Module**: `github.com/kubeflow/arena`
+- **Branch**: `v2`
+- **Entry point**: `cmd/arena-v2/main.go`
+- **Existing v1 code Branch**: `v0.15.4` (do NOT modify)
+
+## Why Arena v2
+
+Arena v2 eliminates the Helm chart rendering pipeline, reduces code complexity, and adds YAML-first configuration. See [keps/arena-v2/README.md](keps/arena-v2/README.md) for the full design rationale, v1 vs v2 technical comparison, and upgrade path.
+
+## Build & Test
+
+Use `go build` or `make arena-v2` to build the Arena v2 CLI. Every build and test action must be added to the Makefile.
+
+```bash
+# Build the v2 binary
+go build -o bin/arena-v2 ./cmd/arena-v2/
+
+# Build with version info
+go build -ldflags "-X github.com/kubeflow/arena/pkg/cli.version=$(cat VERSION 2>/dev/null || echo 0.0.0-dev) \
+  -X github.com/kubeflow/arena/pkg/cli.gitCommit=$(git rev-parse --short HEAD) \
+  -X github.com/kubeflow/arena/pkg/cli.buildDate=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  -o bin/arena-v2 ./cmd/arena-v2/
+
+# Vet all v2 packages
+go vet ./pkg/constants/ ./pkg/log/ ./pkg/cli/ ./pkg/task/ ./pkg/provider/ ./pkg/client/ ./pkg/output/ ./cmd/arena-v2/
+
+# Dry-run test (no cluster required)
+./bin/arena-v2 job run -f examples/v2/pytorch-train.yaml --dry-run
+./bin/arena-v2 submit pytorch --name test --image pytorch:2.1 --gpus 2 --dry-run
+./bin/arena-v2 submit pytorch --name test --image pytorch:2.1 --dry-run "python train.py"
+
+# Run tests
+go test ./pkg/constants/ ./pkg/log/ ./pkg/task/ ./pkg/provider/ ./pkg/client/ ./pkg/cli/ ./pkg/output/ -v
+```
+
+## DO NOT
+
+1. **Do NOT modify v1 code.** Old Arena code lives in `cmd/arena/`, `pkg/commands/`, `pkg/apis/`, `pkg/training/`, `pkg/serving/`, `pkg/argsbuilder/`. Leave it untouched. All v2 work goes in the new packages listed above.
+
+2. **Do NOT use Helm chart rendering.** Arena v2 eliminates the Helm chart rendering pipeline from v1 — CRDs are built as Go structs → `unstructured.Unstructured`.
+
+3. **Do NOT import v1 packages from v2 code.** v2 packages (`pkg/constants`, `pkg/log`, `pkg/cli`, `pkg/task`, `pkg/provider`, `pkg/client`, `pkg/output`) must be self-contained. No imports from `pkg/commands`, `pkg/apis`, `pkg/training`, etc.
+
+4. **Do NOT use Kubeflow Training Operator Go types directly.** Use `unstructured.Unstructured` for CRD construction. This avoids a hard dependency on specific Operator API versions and makes the code resilient to Operator upgrades.
+
+5. **Do NOT add cloud provider SDKs.** Arena v2 is K8s-native only. No AWS/GCP/Azure SDK imports.
+
+6. **Do NOT create a server component.** Arena v2 is client-only (like kubectl). All cluster interaction goes through the K8s API.
+
+7. **The build target is `arena-v2`.** The `-v2` suffix distinguishes the new CLI from the v1 `arena` binary during the transition period. Use `arena-v2` consistently in Makefile targets, build scripts, and documentation.
+
+8. **Do NOT commit the compiled binary.** Add `arena-v2` to `.gitignore` if needed.
+
+9. **Do NOT break the `submit` legacy compat.** The `arena submit <type> --flags` interface must remain backward compatible with old Arena usage patterns.
+
+10. **Do NOT add Docker/container runtime dependencies.** Arena v2 creates K8s resources only; it does not build or push container images.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,109 @@
+.SILENT:
+
+# Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
+ifeq (,$(shell go env GOBIN))
+GOBIN=$(shell go env GOPATH)/bin
+else
+GOBIN=$(shell go env GOBIN)
+endif
+
+# Setting SHELL to bash allows bash commands to be executed by recipes.
+SHELL = /usr/bin/env bash -o pipefail
+.SHELLFLAGS = -ec
+
+PACKAGE ?= github.com/kubeflow/arena
+CURRENT_DIR ?= $(shell pwd)
+OS ?= $(shell go env GOOS)
+ARCH ?= $(shell go env GOARCH)
+
+VERSION ?= $(shell cat VERSION 2>/dev/null || echo "0.0.0-dev")
+BUILD_DATE := $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
+GIT_SHORT_COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+
+# Location to install binaries
+LOCALBIN ?= $(CURRENT_DIR)/bin
+
+##@ General
+
+.PHONY: help
+help: ## Display this help.
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-30s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+
+##@ Arena v2
+
+# Shared package lists for v2 targets
+V2_PACKAGES := ./pkg/constants/ ./pkg/log/ ./pkg/cli/ ./pkg/task/ ./pkg/provider/ ./pkg/client/ ./pkg/output/
+V2_ALL_PACKAGES := $(V2_PACKAGES) ./cmd/arena-v2/
+
+# Version info injected via ldflags at build time
+V2_LDFLAGS := -X ${PACKAGE}/pkg/cli.version=${VERSION} \
+  -X ${PACKAGE}/pkg/cli.gitCommit=${GIT_SHORT_COMMIT} \
+  -X ${PACKAGE}/pkg/cli.buildDate=${BUILD_DATE}
+
+$(LOCALBIN):
+	mkdir -p $(LOCALBIN)
+
+.PHONY: arena-v2
+arena-v2: $(LOCALBIN) ## Build arena v2 CLI for current platform.
+	@echo "Building arena v2 CLI..."
+	CGO_ENABLED=0 GOOS=$(OS) GOARCH=$(ARCH) go build -ldflags '$(V2_LDFLAGS)' -o $(LOCALBIN)/arena-v2 ./cmd/arena-v2/
+
+.PHONY: v2-test
+v2-test: ## Run arena v2 unit tests.
+	@echo "Running arena v2 unit tests..."
+	go test $(V2_PACKAGES) -v
+
+.PHONY: v2-vet
+v2-vet: ## Run go vet on arena v2 packages.
+	@echo "Running go vet on arena v2 packages..."
+	go vet $(V2_ALL_PACKAGES)
+
+.PHONY: v2-integration-test
+v2-integration-test: ## Run arena v2 integration tests (no cluster required).
+	@echo "Running arena v2 integration tests..."
+	go test -tags integration $(V2_PACKAGES) -run TestIntegration -v -timeout 5m
+
+.PHONY: v2-install
+v2-install: ## Install arena v2 CLI to GOBIN.
+	@echo "Installing arena v2 CLI to $(GOBIN)..."
+	go install -ldflags '$(V2_LDFLAGS)' ./cmd/arena-v2/
+
+# Portable SHA-256 checksum command.
+# macOS ships a BSD sha256sum that can't read checksums from stdin pipes,
+# so use shasum on Darwin and sha256sum everywhere else.
+ifeq ($(shell uname -s 2>/dev/null),Darwin)
+SHA256CMD := shasum -a 256
+else
+SHA256CMD := sha256sum
+endif
+
+# Pinned to immutable commit SHAs to prevent supply-chain risk from tag relocation.
+# Override with: make v2-e2e-setup TRAINER_SHA=<sha> MPI_OPERATOR_SHA=<sha>
+# trainer v1.9.3
+TRAINER_SHA ?= c77ee3ff4d21aa8e5027580d83361c1a426ee789
+# mpi-operator v0.8.0
+MPI_OPERATOR_SHA ?= 101db144e019e1de65aaded07745e9d805c2852a
+
+# Expected SHA256 checksums for the pinned CRD versions above.
+# Update these when bumping TRAINER_SHA or MPI_OPERATOR_SHA.
+PYTORCHJOBS_SHA256 ?= eb80e57a984cdc7ceefaaf3fc561e21b673c30cbb58589f2389528d2b2760d22
+TFJOBS_SHA256 ?= 1fea6d2d9d3fec4697db322d4490be67b0d616478f42566e4c48ae865130a8c8
+MPIJOBS_SHA256 ?= 78b0131f931fcc8d99f6ce0407281f41b62527e443ec691d26d9634b390ad3bb
+
+.PHONY: v2-e2e-setup
+v2-e2e-setup: ## Download Kubeflow Training Operator and MPI Operator CRDs for v2 e2e tests.
+	@mkdir -p test/e2e/crds
+	@echo "Downloading Kubeflow Training Operator CRDs..."
+	@curl --fail -sSL https://raw.githubusercontent.com/kubeflow/trainer/$(TRAINER_SHA)/manifests/base/crds/kubeflow.org_pytorchjobs.yaml -o test/e2e/crds/pytorchjobs.yaml
+	@echo "$(PYTORCHJOBS_SHA256)  test/e2e/crds/pytorchjobs.yaml" | $(SHA256CMD) --check --quiet || { echo "ERROR: pytorchjobs.yaml checksum mismatch"; exit 1; }
+	@curl --fail -sSL https://raw.githubusercontent.com/kubeflow/trainer/$(TRAINER_SHA)/manifests/base/crds/kubeflow.org_tfjobs.yaml -o test/e2e/crds/tfjobs.yaml
+	@echo "$(TFJOBS_SHA256)  test/e2e/crds/tfjobs.yaml" | $(SHA256CMD) --check --quiet || { echo "ERROR: tfjobs.yaml checksum mismatch"; exit 1; }
+	@echo "Downloading Kubeflow MPI Operator CRDs..."
+	@curl --fail -sSL https://raw.githubusercontent.com/kubeflow/mpi-operator/$(MPI_OPERATOR_SHA)/manifests/base/kubeflow.org_mpijobs.yaml -o test/e2e/crds/mpijobs.yaml
+	@echo "$(MPIJOBS_SHA256)  test/e2e/crds/mpijobs.yaml" | $(SHA256CMD) --check --quiet || { echo "ERROR: mpijobs.yaml checksum mismatch"; exit 1; }
+	@echo "CRDs downloaded and verified in test/e2e/crds/"
+
+.PHONY: v2-e2e-test
+v2-e2e-test: v2-e2e-setup arena-v2 ## Run arena v2 e2e tests (requires real K8s cluster).
+	@echo "Running arena v2 e2e tests..."
+	go test -tags v2e2e ./test/e2e/ -v -ginkgo.v -timeout 30m

--- a/cmd/arena-v2/main.go
+++ b/cmd/arena-v2/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("arena-v2: not yet implemented")
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/kubeflow/arena
 
-go 1.25.1
+go 1.26.1

--- a/keps/arena-v2/README.md
+++ b/keps/arena-v2/README.md
@@ -1,0 +1,381 @@
+# Arena v2: AI Workload CLI Redesign
+
+## Table of Contents
+
+- [Arena v2: AI Workload CLI Redesign](#arena-v2-ai-workload-cli-redesign)
+  - [Table of Contents](#table-of-contents)
+  - [Summary](#summary)
+  - [Motivation](#motivation)
+    - [Goals](#goals)
+    - [Non-Goals](#non-goals)
+  - [Proposal](#proposal)
+    - [Architecture Overview](#architecture-overview)
+    - [User Stories](#user-stories)
+    - [Notes/Constraints/Caveats](#notesconstraintscaveats)
+  - [Design Details](#design-details)
+    - [Core Design Principles](#core-design-principles)
+      - [1. Simpler maintenance](#1-simpler-maintenance)
+      - [2. Faster iteration](#2-faster-iteration)
+      - [3. Better user experience](#3-better-user-experience)
+      - [4. Fewer failure modes](#4-fewer-failure-modes)
+      - [5. Reduced attack surface](#5-reduced-attack-surface)
+      - [6. Resource lifecycle](#6-resource-lifecycle)
+    - [Detailed Component Comparison](#detailed-component-comparison)
+    - [Migration Notes](#migration-notes)
+      - [PyTorch: `worker.replicas` (v2) vs `--workers` (v1)](#pytorch-workerreplicas-v2-vs---workers-v1)
+    - [Test Plan](#test-plan)
+    - [Graduation Criteria](#graduation-criteria)
+    - [Upgrade / Downgrade Strategy](#upgrade--downgrade-strategy)
+    - [Version Skew Strategy](#version-skew-strategy)
+  - [Production Readiness Review Questionnaire](#production-readiness-review-questionnaire)
+    - [Feature Enablement and Rollback](#feature-enablement-and-rollback)
+    - [Rollout, Upgrade and Rollback Planning](#rollout-upgrade-and-rollback-planning)
+    - [Monitoring Requirements](#monitoring-requirements)
+    - [Dependencies](#dependencies)
+    - [Scalability](#scalability)
+    - [Troubleshooting](#troubleshooting)
+  - [References](#references)
+
+## Summary
+
+Arena v2 is a complete architectural redesign of Arena, addressing fundamental limitations in v1 that make the tool difficult to maintain, extend, and use at scale. The redesign eliminates Helm dependencies, reduces code complexity, introduces YAML-first configuration, and replaces shell-outs with direct Kubernetes API calls.
+
+## Motivation
+
+Arena v1, while functional, suffers from architectural decisions that create significant maintenance burden, slow iteration cycles, and poor user experience at scale.
+
+### Goals
+
+Arena v2 addresses fundamental architectural limitations in Arena v1:
+
+1. **Eliminate Helm dependency** — Generate K8s resources directly in Go, not through Helm chart rendering. This removes 23 Helm charts and the entire Helm Go SDK dependency tree.
+
+2. **YAML-first configuration** — v1 is flag-only (40+ CLI flags for a TFJob) and saves **final** Helm chart values into a ConfigMap. v2 introduces a structured YAML schema where users can version, review, and reuse job configurations as code. CLI flags remain available for quick submissions.
+
+3. **Reduce code complexity** — v1's training submission path spans thousands of lines of Go code across `pkg/commands/`, `pkg/training/`, `pkg/argsbuilder/`, `pkg/apis/`, and `pkg/workflow/`.
+
+4. **Direct K8s API usage** — v1 submits jobs through a 6-step pipeline: serialize args → render Helm chart → save to temp files → create ConfigMap → shell out to `kubectl apply` → patch owner references. v2 adds owner references to created resources and calls the K8s dynamic client API directly: `kc.CreateUnstructured(ctx, gvr, crd)`. No temp files, no shell-outs.
+
+5. **Type-agnostic CRD generation** — Use `unstructured.Unstructured` instead of operator-specific Go types. This decouples Arena from specific Training Operator API versions and makes the code resilient to operator upgrades.
+
+### Non-Goals
+
+- **Breaking existing v1 workflows** — v2 provides legacy compatibility through the `arena submit` command that maps v1 flags to v2's internal model.
+- **Supporting all v1 features immediately** — v2 implements features incrementally across three phases, prioritizing core training workloads first.
+- **Replacing all Arena binaries immediately** — v2 coexists with v1 during the transition period, using separate binary names (`arena-v2` during development, `arena` as the final build target).
+
+## Proposal
+
+### Architecture Overview
+
+Arena v2 adopts a modular architecture that separates concerns and reduces coupling:
+
+```
+cmd/arena-v2/main.go          → Entry point
+pkg/constants/                 → Shared constants (image names, labels, annotations)
+pkg/log/                       → Structured logging
+pkg/cli/                       → Cobra commands (root, status, top, check, job, submit, version, completion)
+pkg/task/                      → Task data model, YAML loader, flag overrides
+pkg/provider/                  → Provider interface + implementations (PyTorchJob, MPIJob)
+pkg/client/                    → K8s dynamic + typed client wrapper
+pkg/output/                    → Table formatting for CLI output
+```
+
+**Provider Interface**: Each framework (PyTorchJob, MPIJob) implements `provider.Provider`:
+
+- `BuildCRD(task) → *unstructured.Unstructured` — Task spec to Operator CRD
+- `GetJobStatus()` / `GetPods()` / `GetLogPod()` — Read back status
+- `DefaultValues(task)` — Framework-specific defaults
+
+Adding a new operator = implementing this interface. No Helm charts needed.
+
+### User Stories
+
+**Story 1: Data scientist submitting a distributed training job**
+
+As a data scientist, I want to define my training job configuration in a YAML file so that I can version it in Git, review changes with my team, and reuse the same configuration across multiple experiments without retyping 40+ CLI flags.
+
+**Story 2: Platform engineer adding a new framework**
+
+As a platform engineer, I want to add support for a new training framework (e.g., DeepSpeed) by implementing a single Go file rather than creating a Helm chart, argsbuilder, command file, and type definitions across 5+ files.
+
+**Story 3: Operator maintaining backward compatibility**
+
+As a cluster operator maintaining existing CI/CD pipelines, I want to continue using `arena submit pytorchjob --name my-job --workers 4 --gpus 2 "python train.py"` without rewriting my automation scripts, while the platform team gradually adopts v2's YAML-based workflows.
+
+### Notes/Constraints/Caveats
+
+- v2 is a separate project that lives in the `v2` branch and is built from scratch. It does not import any v1 packages.
+- The `arena-v2` binary name is temporary for development. The final build target is `arena` — the `-v2` suffix is removed once v2 reaches feature parity.
+- v2's legacy `arena submit` command provides v1-style flag-based submission by mapping old flags to v2's internal `Task` model. Users can continue using v1 syntax without rewriting scripts.
+
+## Design Details
+
+### Core Design Principles
+
+#### 1. Simpler maintenance
+
+The tfjob Helm chart template in v1 is 1,323 lines of nested conditionals for PS/Worker/Chief/Evaluator roles. Every field must be duplicated across different blocks (node selectors, tolerations, volumes, init containers, security contexts). In v2, the same logic is a few hundred lines of Go that programmatically constructs corresponding CR field maps.
+
+#### 2. Faster iteration
+
+Adding a new field in v1 requires changes in five places: types struct, argsbuilder, Helm chart `values.yaml`, Helm chart template, and command file. In v2, adding a field requires updating the YAML schema, the Go struct definition, and the provider's relevant methods.
+
+#### 3. Better user experience
+
+v1's flag-only interface forces users to retype 20-50 flags for every submission. There is no way to save, review, or version job configurations. v2's YAML schema lets users define jobs once in a file, commit to Git, and share with teammates. CLI flags remain available for quick one-off submissions.
+
+#### 4. Fewer failure modes
+
+v1's 6-step submission pipeline has 5 points where temp files or ConfigMaps can leak if the process crashes mid-submission. v2's direct API call is atomic — either the CRD is created or it isn't.
+
+#### 5. Reduced attack surface
+
+v1 shells out to `helm` and `kubectl`, which requires these binaries in `PATH` and exposes command-line injection risks if user input is not properly escaped. v2 uses Go libraries only — no shell execution.
+
+#### 6. Resource lifecycle
+
+A single `arena job run` submission creates multiple K8s resources: the Operator CRD (PyTorchJob/MPIJob), optionally a TensorBoard Deployment+Service, and a ConfigMap storing the original YAML and generated manifest. In v1, these resources are tracked via a resource list in the ConfigMap and deleted through a 3-step pipeline (read ConfigMap → delete resources → delete ConfigMap), which risks resource leaks if the list is incomplete or the process crashes mid-delete.
+
+v2 adopts a different pattern: deletion is simplified to a single operation. Deleting the top-level training job CR triggers K8s garbage collection to cascade-delete all owned resources. This eliminates resource leaks and simplifies `arena job delete` to a single API call. Likewise, all owned resources are cleaned up alongside the training job CR when its `ttlSecondsAfterFinished` expires.
+
+```
+PyTorchJob CRD
+  ├── owns → ConfigMap "my-job" (stores effective training job YAML; a new CRD could replace the native ConfigMap)
+  ├── owns → TensorBoard Deployment
+  └── owns → TensorBoard Service
+```
+
+### Detailed Component Comparison
+
+| Aspect | Arena v1 | Arena v2 |
+|--------|----------|----------|
+| **Job submission** | Helm chart rendering + `kubectl apply` shell-out | Direct K8s dynamic client API |
+| **Configuration** | CLI flags only (no YAML) | YAML schema + CLI flags |
+| **Helm dependency** | Yes — `helm.sh/helm/v3` + 23 charts | No |
+| **kubectl dependency** | Yes — shells out to `kubectl apply/delete` | No — uses `client-go` directly |
+| **Training Go code** | thousands of lines | a few hundred lines |
+| **Helm charts** | 23 charts maintained alongside Go code | 0 |
+| **Temp files per submission** | 3 (values.yaml, rendered manifest, app-info) | 0 |
+| **Resource lifecycle** | 3-step delete (read ConfigMap → delete resources → delete ConfigMap) | 1-step delete (delete anchor resource → K8s GC cascades) |
+| **Per-role config** | 40+ CLI flags (e.g., `--worker-image`, `--ps-cpu`, `--chief-memory`) | `chief/ps/evaluator/launcher/master/worker` block in YAML with independent per-role declaration |
+| **Adding a new operator** | Implement Go types + argsbuilder + command + Helm chart + chart template | Implement `provider.Provider` interface |
+| **Operator version coupling** | Tightly coupled — must update Go types when operator CRD API changes | Loosely coupled — `unstructured.Unstructured` is version-agnostic |
+| **Binary size** | Larger (Helm SDK + transitive deps) | Smaller (only `client-go` + `cobra`) |
+
+### Migration Notes
+
+#### PyTorch: `worker.replicas` (v2) vs `--workers` (v1)
+
+> **PyTorch-specific:** Only v1's PyTorch submit path subtracts the master from `--workers`.
+
+**Key difference:** v1's `--workers=N` includes the master (internally decremented by 1), while v2's `worker.replicas=N` excludes it — the master is always an additional Pod.
+
+**Migration formula:** `worker.replicas = --workers - 1`. Since `--workers` is always ≥ 1, when `--workers` is 1, `worker.replicas` would be 0, which violates the > 0 constraint. In this case, omit the worker block and specify the master block instead.
+
+In v2, the PyTorch master is fixed at 1 replica, inherits worker config by default if `master` block is omitted, and can be independently configured via the `master` block. **Total GPU-using replicas** = `worker.replicas + 1`.
+
+For framework-specific mappings across all providers, see the [worker.replicas → Provider Mapping](yaml-schema.md#workerreplicas--provider-mapping) section in the YAML schema specification.
+
+### Test Plan
+
+The test plan for Arena v2 includes:
+
+**Unit tests:**
+
+- YAML schema parsing and validation
+- Flag-to-YAML override merging logic
+- Provider CRD generation (PyTorchJob, MPIJob)
+- K8s client wrapper error handling
+
+**Integration tests:**
+
+- End-to-end job submission with `--dry-run` flag
+- Legacy `arena submit` command compatibility
+- Multi-operator scenarios (submit PyTorchJob, then query status, then delete)
+
+**E2E tests:**
+
+- Submit real training jobs to a test cluster
+- Verify CRD structure matches operator expectations
+- Test job lifecycle (submit → running → completed/failed)
+- Validate per-role configuration (worker vs. master vs. launcher)
+  - PyTorch job with only `master` specified (`worker` omitted; single-node mode)
+  - PyTorch job with both `worker` and `master` specified (multi-node mode)
+  - MPI job using default CPU-only launcher (no explicit `launcher` block)
+  - MPI job with both `worker` and `launcher` specified
+
+### Graduation Criteria
+
+**Alpha/MVP (Phase 1 - current):**
+
+- v1 remains the default for production use
+- Core training submission (PyTorchJob, MPIJob) with YAML schema
+  - without `scheduling` semantics support
+- Basic commands (`arena version`, `arena help`)
+- Display cluster resource info (`arena top`)
+- Supports basic job manipulations and status queries (e.g., `arena job delete`, `arena job get`, `arena job list`, `arena job status`, `arena job logs`). The `arena job` prefix provides equivalent functionality to v1 `arena delete/get/list/status/logs` commands.
+- Add new sub-commands
+  - `job`
+    - `run`, launch a training job from a YAML file
+    - `suspend`, suspend a running training job (operation, not YAML config)
+    - `resume`, resume a suspended training job (operation, not YAML config)
+  - `check`, check if the cluster has the required CRD installed
+- Dry-run mode for CRD inspection
+
+**Beta (Phase 2 - next):**
+
+- Legacy `arena submit` command for backward compatibility
+- Support `scheduling` semantics
+- Users begin migrating simple jobs to v2
+- Comprehensive CLI flag coverage matching v1 functionality
+- Output formats: JSON, YAML, wide
+- InferenceTask kind (planned to leverage [RBG](https://github.com/sgl-project/rbg) for serving orchestration)
+  - Add new sub-commands
+    - `serve`
+- Add DeepSpeed, TensorFlow, Ray support and examples
+- Support overriding stable YAML fields via CLI flags (such as `name`, `worker.replicas`, etc.)
+
+**Stable (Phase 3 - future):**
+
+- Support overriding the entire YAML schema via CLI flags
+- Platform-agnostic configuration via `arena configure`
+- v1 is deprecated but still maintained for bug fixes
+- Agent, evaluation, and benchmark task kinds
+- `arena migrate` tool for converting v1 flag-based invocations to v2 YAML files
+- Add Horovod support and examples
+
+### Upgrade / Downgrade Strategy
+
+**Upgrade path:**
+
+- v2 and v1 coexist during the transition period
+- Users can gradually migrate workloads from v1 to v2
+- No breaking changes to existing v1 workflows
+- Legacy `arena submit` command ensures backward compatibility
+
+**Downgrade path:**
+
+- If v2 introduces regressions, users can continue using v1 binary
+- v2 does not modify v1 code or Helm charts
+- Separate binary names (`arena-v2` during development) prevent conflicts
+
+**Migration tooling:**
+
+- Future `arena migrate` command will convert v1 flag-based invocations to v2 YAML files
+- Helps users transition existing automation scripts without manual rewriting
+
+### Version Skew Strategy
+
+**Operator version compatibility:**
+
+- v2 uses `unstructured.Unstructured` for CRD generation, making it version-agnostic
+- No dependency on specific Training Operator API versions
+- Works with Training Operator and MPI Operator
+
+**Kubernetes version compatibility:**
+
+- v2 depends only on `client-go` and `cobra`
+- Supports any Kubernetes version that client-go supports
+- No dependency on Helm or kubectl binaries
+
+## Production Readiness Review Questionnaire
+
+### Feature Enablement and Rollback
+
+**How can this feature be enabled/disabled?**
+
+- v2 is a separate binary (`arena-v2`) during development, allowing users to opt-in
+- Once v2 reaches feature parity, it replaces the `arena` v1 binary
+- Users can continue using v1 by not installing v2
+
+**Can the feature be disabled once it has been enabled?**
+
+- Yes, users can simply not use the v2 binary
+- v2 does not modify v1 code or configuration
+- No cluster-level changes are required
+
+### Rollout, Upgrade and Rollback Planning
+
+**How will this be rolled out?**
+
+- v2 is being developed in the `v2` branch, in parallel with v1
+- Users can test v2 in non-production environments first
+- Gradual adoption as v2 reaches feature parity with v1
+
+**What is the rollout plan?**
+
+- Phase 1 (current): Core training submission, v1 remains default
+- Phase 2 (next): Advanced features, users begin migrating simple jobs
+- Phase 3 (future): Full feature parity, v1 deprecated
+
+**How will rollback work if something goes wrong?**
+
+- Users can revert to the v1 binary at any time
+- v2 does not modify cluster state or v1 configuration
+- No data migration or rollback procedures required
+
+### Monitoring Requirements
+
+**How can an operator determine if the feature is working correctly?**
+
+- v2 provides `--dry-run` flag for inspecting generated CRDs before submission
+- Job submission logs show API calls and responses
+- `arena job get` and `arena job list` commands show job status
+
+**How can this feature be monitored?**
+
+- Kubernetes metrics for created CRDs (PyTorchJob, MPIJob)
+- Job completion/failure rates
+- Submission latency (time from CLI invocation to CRD creation)
+
+### Dependencies
+
+**Does this feature depend on any specific services or components?**
+
+- v2 depends only on `client-go` for Kubernetes API access
+- No dependency on Helm, kubectl, or external binaries
+- Training Operator and MPI Operator are mandatory. KubeRay will become a requirement when Ray support is added.
+
+**Are there any new dependencies introduced?**
+
+- No new dependencies beyond `client-go` and `cobra`
+- v2 removes the Helm dependency entirely
+
+### Scalability
+
+**How does this feature scale?**
+
+- v2 generates CRDs locally and submits them to the Kubernetes API
+- No local resource consumption beyond the CLI process
+- Scalability is limited by Kubernetes API server capacity, not v2
+
+**What are the scalability limits?**
+
+- Same as v1: limited by Kubernetes cluster capacity and operator performance
+- v2 may be slightly faster due to elimination of Helm rendering and shell-outs
+
+### Troubleshooting
+
+**How can issues be diagnosed?**
+
+- `--dry-run` flag shows generated CRD before submission
+- Verbose logging mode (if implemented) shows API calls and responses
+- `arena job get <job-name>` shows job status and pod information
+- `arena job logs <job-name>` shows training logs
+
+**What are common failure modes?**
+
+- CRD validation errors (malformed task spec)
+- Kubernetes API errors (permission denied, resource quota exceeded)
+- Operator errors (job submission failed, pod scheduling failed)
+- Network errors (cluster unreachable)
+
+## References
+
+- **Arena v1 codebase**: https://github.com/kubeflow/arena/tree/v0.15.4
+- **YAML schema specification**: `keps/arena-v2/yaml-schema.md` (YAML Schema section)
+- **CLI flag mapping**: `keps/arena-v2/cli-flag-mapping.md`
+- **Kubeflow Trainer**: https://github.com/kubeflow/trainer/tree/release-1.9
+- **Kubeflow MPI Operator**: https://github.com/kubeflow/mpi-operator/tree/master
+- **client-go**: https://github.com/kubernetes/client-go

--- a/keps/arena-v2/cli-flag-mapping.md
+++ b/keps/arena-v2/cli-flag-mapping.md
@@ -1,0 +1,215 @@
+# Arena V1 Flag → V2 YAML Schema Audit
+
+This document maps all arena v1 training CLI flags to arena v2 YAML schema coverage.
+
+**Scope:** v1 `arena submit` flags → v2 `arena job run` YAML schema
+**Source of truth:** arena v2 YAML Schema + arena v1 CLI
+
+> **Note:** v2 CLI flag-to-YAML override mechanism will be designed separately as a generic `--set`-style approach (similar to Helm). This document tracks v1 flag → v2 YAML schema coverage and implementation status.
+
+---
+
+## 1. Coverage Summary
+
+| Category | v2 Covered | v2 Missing / Notes |
+|----------|-----------|------------|
+| Identity | ✅ name, labels, annotations, namespace | — |
+| Resources | ✅ cpu, memory, nvidia.com/gpu, extended resources (`--device`) | — |
+| Scheduling | ✅ node_selector, tolerations, priority, priority_class_name, gang, scheduler_name, affinity (policy/constraint/target/rules), queue | not yet implemented |
+| Data | ✅ storages (PVC, hostpath, tmp, shm, configmap, secret) | — |
+| Env | ✅ envs (plain/secretKeyRef/configMapKeyRef) | — |
+| Execution | ✅ restart, image_pull_policy, image_pull_secrets, shell, working_dir | — |
+| Lifecycle | ✅ clean_pod_policy, active_deadline, ttl_after_finished, backoff_limit, success_policy | — |
+| Sync | ✅ sync (git/rsync/hdfs) | — |
+| Model | ❌ |  not planned |
+| TFJob roles | ✅ | provider not yet implemented |
+| MPIJob | ✅ mounts_on_launcher, run_launcher_as_worker, slots_per_worker | — |
+| PyTorch | ✅ nproc_per_node | — |
+| Horovod | ✅ cpu, memory | ❌ `--ssh-port` not in schema (always use port 22); provider not yet implemented |
+| DeepSpeed | ✅ | provider not yet implemented |
+| Ray | ✅ (framework placeholder only) | provider not yet implemented |
+
+**Legend:** ✅ = designed in arena v2 schema, ❌ = not in schema, — = N/A
+
+---
+
+## 2. Common Job Run Flags (shared by most frameworks)
+
+### 2a. Identity
+
+| v1 Flag | Type | Default | v2 YAML | Status |
+|---------|------|---------|---------|--------|
+| `--name` | string | required | `name` | ✅ |
+| `--namespace` | string | optional | `namespace` | ✅ |
+
+### 2b. Resources
+
+| v1 Flag | Type | Default | v2 YAML | Status |
+|---------|------|---------|---------|--------|
+| `--gpus` | int | `0` | `nvidia.com/gpu` field in `worker.resources` block | ✅ |
+| `--cpu` | string | `""` | `worker.resources.cpu` | ✅ |
+| `--memory` | string | `""` | `worker.resources.memory` | ✅ |
+| `--device` | string[] | `[]` | `<device-name>` field in `worker.resources` block | ✅ e.g. `--device hugepages-2Mi=32Gi` |
+| `--workers` | int | `1` | `worker.replicas` | ✅ (see the [Migration Notes](README.md#migration-notes) section) |
+
+**Note:** v1 `--device vendor.com/device=count` maps to v2 flat `vendor.com/device: count` field in `resources` block.
+
+### 2c. Scheduling
+
+| v1 Flag | Type | Default | v2 YAML | Status |
+|---------|------|---------|---------|--------|
+| `--selector` | string[] | `[]` | `scheduling.node_selector` | ✅ |
+| `--toleration` | string[] | `[]` | `scheduling.tolerations` | ✅ |
+| `-p, --priority` | int | `0` | `scheduling.priority` | ✅ Pod spec priority field |
+| `--priority-class-name` | string | `""` | `scheduling.priority_class_name` | ✅ Pod spec priorityClassName field |
+| `--gang` | bool | `false` | `scheduling.gang.enabled` | ✅ |
+| `--scheduler` | string | `""` | `scheduling.scheduler_name` | ✅ |
+| `--affinity-policy` | string | `""` | `scheduling.affinity.policy` | ✅ `none` / `spread` / `binpack` |
+| `--affinity-constraint` | string | `""` | `scheduling.affinity.constraint` | ✅ `preferred` / `required` |
+| `--queue` | string | `""` | `scheduling.queue` | ✅ (YAML field exists) |
+| `--rdma` | bool | `false` | — | ❌ NOT PLANNED |
+
+### 2d. Data and Volumes
+
+| v1 Flag | Type | Default | v2 YAML | Status |
+|---------|------|---------|---------|--------|
+| `-d, --data` | string[] | `[]` | `storages[].pvc` + `storages[].mount_path` | ✅ |
+| `--data-dir` | string[] | `[]` | `storages[].hostpath` + `storages[].mount_path` | ✅ |
+| `--config-file` | string[] | `[]` | `storages[].configmap + storages[].mount_path` | ✅ |
+| `--share-memory` | string | `"2Gi"` | `storages[].shm` | ✅ (emptyDir medium: Memory at /dev/shm) |
+
+### 2e. Environment and Labels
+
+| v1 Flag | Type | Default | v2 YAML | Status |
+|---------|------|---------|---------|--------|
+| `-e, --env` | string[] | `[]` | `envs` | ✅ (plain, secretKeyRef, configMapKeyRef) |
+| `-a, --annotation` | string[] | `[]` | `annotations` | ✅ |
+| `-l, --label` | string[] | `[]` | `labels` | ✅ |
+
+### 2f. Execution
+
+| v1 Flag | Type | Default | v2 YAML | Status |
+|---------|------|---------|---------|--------|
+| `--working-dir` | string | image default | `working_dir` | ✅ |
+| `--shell` | string | `/bin/sh` | `shell` | ✅ (invalid values fall back to /bin/sh) |
+| `--image` | string | required | `image` | ✅ |
+| `--image-pull-policy` | string | `"Always"` | `image_pull_policy` | ✅ |
+| `--image-pull-secret` | string[] | `[]` | `image_pull_secrets` | ✅ (reference-only, no auto-create) |
+| `--hostNetwork` | bool | `false` | `host_network` | ✅ |
+| `--hostIPC` | bool | `false` | `host_ipc` | ✅ |
+| `--hostPID` | bool | `false` | `host_pid` | ✅ |
+
+### 2g. Model Registry
+
+| v1 Flag | Type | Default | v2 YAML | Status |
+|---------|------|---------|---------|--------|
+| `--model-name` | string | `""` | — | ❌ NOT PLANNED |
+| `--model-source` | string | `""` | — | ❌ NOT PLANNED |
+
+---
+
+## 3. Sync Code Flags
+
+| v1 Flag | Type | Default | v2 YAML | Status |
+|---------|------|---------|---------|--------|
+| `--sync-mode` | string | `""` | `sync[].git/rsync/hdfs` (type key) | ✅ |
+| `--sync-source` | string | `""` | `sync[].git/rsync/hdfs` (value) | ✅ |
+| `--sync-image` | string | `""` | `sync[].image` | ✅ |
+
+---
+
+## 4. Tensorboard Flags
+
+| v1 Flag | Type | Default | v2 YAML | Status |
+|---------|------|---------|---------|--------|
+| `--tensorboard` | bool | `false` | `logging.tensorboard.enabled` | ✅ |
+| `--tensorboard-image` | string | `""` | `logging.tensorboard.image` | ✅ |
+| `--logdir` | string | `"/training_logs"` | `logging.tensorboard.logdir` | ✅ |
+
+---
+
+## 5. Job Lifecycle
+
+| v1 Flag | Type | Default | v2 YAML | Status |
+|---------|------|---------|---------|--------|
+| `--clean-task-policy` | string | varies | `lifecycle.clean_pod_policy` | ✅ (`None` / `Running` / `All`) |
+| `--running-timeout` | duration | `0` | `lifecycle.active_deadline` | ✅ |
+| `--ttl-after-finished` | duration | `0` | `lifecycle.ttl_after_finished` | ✅ |
+| `--job-backoff-limit` | int | `6` | `lifecycle.backoff_limit` | ✅ (use v2 `lifecycle.backoff_limit` default value) |
+| `--retry` (redundant, functions identically to `--job-backoff-limit`) | int | `0` | `lifecycle.backoff_limit` | ✅ (use v2 `lifecycle.backoff_limit` default value) |
+| `--success-policy` | string | varies | `lifecycle.success_policy` | ✅ (`ChiefWorker` / `AllWorkers`, TFJob only) |
+
+---
+
+## 6. Framework-Specific Flags
+
+### 6a. TFJob
+
+| v1 Flag | v2 YAML | Status |
+|---------|---------|--------|
+| `--ps` (count) | `ps.replicas` | ✅ |
+| `--ps-image` | — | ❌ not yet implemented |
+| `--ps-cpu`, `--ps-cpu-limit`, `--ps-memory`, `--ps-memory-limit` | `ps.resources` | ✅ |
+| `--ps-gpus` | `ps.resources.nvidia.com/gpu` | ✅ |
+| `--ps-selector` | — | ❌ not yet implemented |
+| `--ps-affinity-policy` | — | ❌ not yet implemented |
+| `--chief` (bool) | `chief` | ✅ |
+| `--chief-cpu`, `--chief-memory`, etc. | `chief.resources` | ✅ |
+| `--chief-selector` | — | ❌ not yet implemented |
+| `--evaluator` (bool) | `evaluator` | ✅ |
+| `--evaluator-cpu`, `--evaluator-memory`, etc | `evaluator.resources` | ✅ |
+| `--evaluator-selector` | — | ❌ not yet implemented |
+| `--worker-image` | — | ❌ not yet implemented |
+| `--worker-port` | — | ❌ not yet implemented |
+| `--worker-cpu`, `--worker-memory`, etc. | `worker.resources` | ✅ |
+| `--worker-selector` | — | ❌ not yet implemented |
+| `--worker-affinity-policy` | — | ❌ not yet implemented |
+| `--success-policy` | `lifecycle.success_policy` | ✅ (moved to lifecycle block) |
+| `--role-sequence` | — | ❌ Implementation detail, not user-facing |
+
+### 6b. PyTorchJob
+
+| v1 Flag | v2 YAML | Status |
+|---------|---------|--------|
+| `--cpu` | worker and master `resources.cpu` | ✅ |
+| `--memory` | worker and master `resources.memory` | ✅ |
+| `--nproc-per-node` | `framework.options.nproc_per_node` | ✅ (`auto` / `gpu` / `cpu` / int) |
+
+### 6c. MPIJob
+
+| v1 Flag | v2 YAML | Status |
+|---------|---------|--------|
+| `--cpu` | `worker.resources.cpu` | ✅ |
+| `--memory` | `worker.resources.memory` | ✅ |
+| `--gputopology` | `host_network` + `worker.resources` + `labels` (`gpu-topology` / `gpu-topology-replica`) | ✅ |
+| `--mounts-on-launcher` | `framework.options.mounts_on_launcher` | ✅ |
+| (no v1 flag) | `framework.options.run_launcher_as_worker` | ✅ (YAML field exists, no v1 equivalent) |
+| (no v1 flag) | `framework.options.slots_per_worker` | ✅ (YAML field exists, no v1 equivalent) |
+
+### 6d. Horovod
+
+| v1 Flag | v2 YAML | Status |
+|---------|---------|--------|
+| `--ssh-port` | — | ❌ NOT IN SCHEMA (always use port 22) |
+| `--cpu` | `worker.resources.cpu` | ✅ |
+| `--memory` | `worker.resources.memory` | ✅ |
+
+### 6e. DeepSpeed
+
+| v1 Flag | v2 YAML | Status |
+|---------|---------|--------|
+| `--cpu` | `worker.resources.cpu` | ✅ |
+| `--memory` | `worker.resources.memory` | ✅ |
+| `--launcher-selector` | — | ❌ not yet implemented |
+| `--job-restart-policy` | `restart` | ✅ |
+| `--ssh-secret` | — | ❌ NOT IN SCHEMA (No ssh secret is required because the MPI Operator already handles it) |
+| `--launcher-annotation` | — | ❌ not yet implemented |
+| `--worker-annotation` | — | ❌ not yet implemented |
+
+### 6f. RayJob
+
+Not mapped here — will be designed when Ray provider is added.
+
+### 6g. Elastic Training (ETJob)
+
+Not mapped here and not planned.

--- a/keps/arena-v2/yaml-schema.md
+++ b/keps/arena-v2/yaml-schema.md
@@ -1,0 +1,564 @@
+## YAML Schema
+
+### Minimal Example
+
+```yaml
+version: 0.1.0
+name: my-job
+framework:
+  name: pytorch
+image: pytorch/pytorch:2.1
+run: python train.py --epochs 10
+worker:
+  replicas: 1
+  resources:
+    nvidia.com/gpu: 1
+```
+
+### Full Schema
+
+```yaml
+# ─── Schema Version ───
+version: 0.1.0                       # Required. Schema version for forward compatibility.
+
+# ─── Identity ───
+name: llm-finetune                   # Required. K8s resource name.
+namespace: ml-team                   # Optional. Default: kubeconfig context.
+description: "experiment run"        # Optional
+labels:                              # Optional
+  team: platform
+annotations:                         # Optional
+  note: "experiment run"
+
+image: nvcr.io/nvidia/pytorch:23.10  # Required. Container image.
+run: torchrun train.py --epochs 10   # Required. Training command, executed via shell.
+shell: /bin/sh                       # Optional. Shell interpreter path. Default: /bin/sh. Empty and null values fall back to the default.
+working_dir: /root                   # Optional. Container working directory (default: image default)
+
+# ─── Task ───
+framework:                           # Required. Object with provider config.
+  name: pytorch                      # Required. (pytorch | mpi | tensorflow | horovod | ray | deepspeed)
+  options:                            # Optional
+    nproc_per_node: auto             # auto | gpu | cpu | int → torchrun --nproc-per-node
+
+envs:                                # Optional. Common envs.
+  NCCL_DEBUG: INFO
+  NCCL_IB_DISABLE: "0"
+
+# ─── Scale ───
+worker:                             # Required for MPI-based frameworks
+  replicas: 4                       # Required if the worker block is present. Must be > 0 if specified.
+  envs:                             # Optional
+    NCCL_DEBUG: DEBUG               # Merges with top-level envs (worker value overrides)
+  resources:                        # Recommended, but not required. Pod resources will be unset if this block is omitted.
+    nvidia.com/gpu: 8
+    cpu: 32
+    memory: 128Gi
+
+# For framework-specific role blocks (launcher, chief, ps, evaluator) and their default behaviors,
+# see the framework-specific configuration section below.
+master:                             # Only valid for PyTorch. Required if the worker block is omitted.
+  replicas: 1                       # Optional. Master replicas must be 1.
+  envs:                             # Optional
+    NCCL_DEBUG: DEBUG               # Merges with top-level envs (master value overrides)
+  resources:                        # Optional
+    nvidia.com/gpu: 8               # Optional
+
+# ─── Sync & Init ───
+sync:                                # Optional
+  - git: https://github.com/org/training-code.git   # git clone
+    branch: main                     # Optional. Default: main.
+    local_path: /code                # Required
+    image: git-sync:v3.3.5           # Optional
+    mounts:                          # Optional. Override storages by name
+    - name: code                     # A new storage entry will be appended if no matching entry is found in the storages block
+      tmp: 1Gi
+      mount_path: /code
+
+  - rsync: 10.88.29.56::backup/data/logoRecoTrain.zip   # rsync from a remote source
+    local_path: /dataset            # Required
+    image: rsync:v3.1.0-aliyun       # Optional
+    mounts:                          # Optional. Override storages by name
+    - name: dataset                  # Override the 'dataset' storage defined in storages
+      mount_path: /dataset           # Mounted at /dataset instead of its default /data
+
+  - hdfs: hdfs://namenode:8020/models/resnet # download from a remote HDFS path
+    local_path: /models            # Required
+    image: apache/hadoop:3.5.0       # Optional
+    mounts:                          # Optional. Override storages by name
+    - name: checkpoints
+      mount_path: /models
+
+# ─── storages ───
+# inject into all pods
+storages:                 # Optional
+  - name: dataset         # Required
+    mount_path: /data     # Required if the storage type is not shm.
+    sub_path: /data       # Optional
+    pvc: dataset-pvc      # Exactly one storage type is required. (pvc | shm | tmp | hostpath | configmap | secret)
+  - name: checkpoints
+    mount_path: /ckpts
+    pvc: ckpt-pvc
+  - name: shm
+    shm: 64Gi             # Optional. Default: 2Gi
+    # mount_path: /dev/shm # Optional. Default: /dev/shm
+  - name: tmp
+    tmp: 128Gi
+    mount_path: /tmp
+  - name: host
+    hostpath: /runtime-mnt
+    mount_path: /runtime
+  - name: conf
+    configmap: foo
+    key: conf.yaml       # Optional. Omitting key mounts the entire ConfigMap as a folder.
+    mount_path: /app/conf.yaml  # If key is specified, it represents the exact target file name; otherwise, it represents the directory name.
+  - name: credentials
+    secret: bar
+    key: id_rsa          # Optional. Omitting key mounts the entire Secret as a folder.
+    mount_path: /root/.ssh/id_rsa  # If key is specified, it represents the exact target file name; otherwise, it represents the directory name.
+
+# ─── Scheduling (K8s-specific) ───
+# inject into all pods
+scheduling:                            # Optional
+  priority: 100                        # Integer → pod spec priority field
+  priority_class_name: high-priority   # String → pod spec priorityClassName field
+  gang:                                # Gang scheduling (Volcano/coscheduling)
+    enabled: false                          
+  scheduler_name: default              # Custom scheduler (optional)
+  queue: low-priority                  # Queue name (optional)
+  node_selector:
+    disktype: ssd
+    zone: us-west-2a
+  tolerations:
+    - key: nvidia.com/gpu
+      operator: Exists
+      effect: NoSchedule
+  affinity:                          # Optional
+    policy: spread                   # Optional. Default: none. (none | spread | binpack)
+    constraint: preferred            # Optional. Default: preferred. (preferred | required)
+    target: node                     # Required if policy is not none. (pod | node)
+    rules:                           # Required if policy is not none.
+    - weight: 1                      # Only for constraint: preferred
+      # topology_key: nvidia.com/gpu   # Only for target: pod
+      match_expressions:
+      - key: foo
+        operator: In
+        values:
+        - bar
+      match_fields:                   # Only for target: node
+      - key: foo
+        operator: In
+        values:
+        - bar
+      match_labels:
+        a: b
+      # namespaces: ["a", "b"]         # Only for target: pod (filter namespaces by name)
+      # namespace_selector:            # Only for target: pod (filter namespaces by label)
+      #   match_labels:
+      #     team: platform
+      #   match_expressions:
+      #   - key: foo
+      #     operator: In
+      #     values:
+      #     - bar
+
+# ─── Lifecycle ───
+# inject into all pods 
+lifecycle:                           # Optional
+  clean_pod_policy: Running          # None | Running | All
+  active_deadline: 2h                # Max active duration
+  ttl_after_finished: 7d             # Auto-delete after this duration
+  backoff_limit: 6                   # Max restart count
+  success_policy: ChiefWorker        # "" (default) | AllWorkers (TFJob only). ChiefWorker is accepted as an alias for "" for backwards compatibility.
+
+# ─── Runtime ───
+# inject into all pods 
+image_pull_policy: Always            # Optional. Always | IfNotPresent | Never
+image_pull_secrets:                  # Optional
+  - registry-secret                  # Reference existing Secret
+service_account: training-sa         # Optional
+restart: OnFailure                   # Optional. Always | OnFailure | Never
+host_network: false                  # Optional. true | false
+host_ipc: false                      # Optional. true | false
+host_pid: false                      # Optional. true | false
+
+# ─── Logging ───
+# create additional pods
+logging:                             # Optional
+  tensorboard:
+    enabled: false
+    logdir: /training_logs             # Required if tensorboard enabled. TensorBoard --logdir arg
+    image: tensorflow/tensorflow:2.15  # Optional. Override default image
+  # wandb:                             # future feature
+  #   enabled: true
+  #   project: my-project
+  #   entity: my-team
+```
+
+### resources
+
+Fields under `worker.resources` are all **scalar** values, applied identically to both `requests` and `limits`. When both `cpu` and `memory` are specified, this guarantees the **Guaranteed QoS** class; GPU-only specs without CPU/memory do not qualify for Guaranteed QoS in Kubernetes.
+
+```yaml
+worker:
+  resources:
+    nvidia.com/gpu: 8
+    cpu: 32
+    memory: 128Gi
+```
+
+**Implementation**: When building the CRD, user-specified scalar values are written to both `requests` and `limits` in the Pod spec with identical values. K8s assigns the Guaranteed QoS class only when both CPU and memory are specified with equal requests and limits.
+
+**Why Guaranteed only**: Training workloads are long-running, GPU-intensive jobs that require stable resource guarantees. Burstable QoS (requests < limits) leads to priority eviction under node contention, which is unsuitable for training scenarios.
+
+### image_pull_secrets
+
+`image_pull_secrets` references existing `imagePullSecret` resources by name:
+
+| Form | YAML | Behavior |
+|---|---|---|
+| String | `- registry-secret` | Reference existing `imagePullSecret` by name |
+
+```yaml
+image_pull_secrets:
+  - nvcr-registry                  # Must already exist in the namespace
+  - gcr-creds
+```
+
+Users create imagePullSecrets externally:
+
+```bash
+kubectl create secret docker-registry nvcr-registry \
+  --docker-server=nvcr.io \
+  --docker-username=$NVCR_USER \
+  --docker-password=$NVCR_TOKEN
+```
+
+### Secrets Design Principles
+
+arena-v2 **does not create K8s Secrets** — it only references existing ones. Rationale:
+
+1. **arena-v2 is a client-side tool** (like kubectl). Creating Secrets is a state-mutating operation that conflicts with the "CRD generation only" design.
+2. **Standard K8s ecosystem practice**: External Secrets Operator, Vault Agent, Sealed Secrets, and similar tooling all operate around the reference model.
+3. **v1 also lacks Secret creation** — v1 users are already accustomed to managing Secrets via `kubectl create secret` first.
+4. **Security**: arena-v2 never reads, encodes, or transmits sensitive credentials. Secrets are managed by cluster administrators or external systems.
+
+**Secret reference via `envs` field (secretKeyRef)**:
+
+```yaml
+envs:
+  HF_TOKEN:
+    secret: my-hf-creds            # Reference existing K8s Secret "my-hf-creds"
+    key: token
+  WANDB_KEY:
+    secret: my-hf-creds
+    key: wandb-key
+  DB_HOST:
+    configmap: db-config
+    key: host
+```
+
+### envs Value Forms
+
+`envs` values accept three forms:
+
+| Form | YAML | Behavior |
+| --- | --- | --- |
+| Plain | `BATCH_SIZE: "32"` | Literal value in Pod spec |
+| Secret ref | `DB_PASSWORD: {secret: name, key: k}` | `secretKeyRef` to existing K8s Secret |
+| ConfigMap ref | `CONFIG_PATH: {configmap: name, key: k}` | `configMapKeyRef` to existing K8s ConfigMap |
+
+### framework-specific configuration
+
+`framework` accepts one form: an **object** where the `name` key holds the provider name, and the `options` key contains provider-specific settings.
+
+Different training frameworks have different roles, and the default behaviors for replicas, envs, and resources vary accordingly. The corresponding configurations and descriptions are shown below.
+
+```yaml
+framework:
+  name: pytorch
+  options:
+    nproc_per_node: auto             # auto | gpu | cpu | int → torchrun --nproc-per-node
+
+worker:                              # Optional if the master block is specified.
+  ...
+master:                              # Required if the worker block is omitted. If the master block is omitted while the worker block is specified, it inherits the worker configuration (replicas fixed to 1). Otherwise, it uses its own configuration.
+  ...
+```
+
+```yaml
+framework:
+  name: mpi
+  options:
+    slots_per_worker: 4              # MPI slots per worker node
+    mounts_on_launcher: true         # Launcher also mounts PVCs (default: false)
+    run_launcher_as_worker: false    # Optional: Launcher also runs as worker (default: false)
+
+launcher:   # Optional. Defaults to a CPU-only configuration (replicas fixed to 1) if omitted. Uses its own configuration if specified.
+  ...
+worker:     # Required
+  ...
+```
+
+```yaml
+# Due to TensorFlow's diverse distributed strategies, roles (chief, worker, ps, evaluator) must be explicitly specified; no defaults are applied.
+framework:
+  name: tensorflow
+
+worker:     # Optional if another role block is specified. If this block is omitted, no pods will be created.
+  ...
+
+chief:      # Optional if another role block is specified. If this block is omitted, no pods will be created.
+  ...
+
+ps:         # Optional if another role block is specified. If this block is omitted, no pods will be created.
+  ...
+
+evaluator:  # Optional if another role block is specified. If this block is omitted, no pods will be created.
+  ...
+
+```
+
+```yaml
+framework:
+  name: deepspeed
+
+worker:     # Required
+  ...
+launcher:   # Optional. Defaults to a CPU-only configuration (replicas fixed to 1) if omitted. Uses its own configuration if specified.
+  ...
+```
+
+```yaml
+framework:
+  name: ray # No detailed design for Ray — currently a placeholder
+```
+
+```yaml
+framework:
+  name: horovod
+
+worker:     # Required
+  ...
+launcher:   # Optional. Defaults to a CPU-only configuration (replicas fixed to 1) if omitted. Uses its own configuration if specified.
+  ...
+```
+
+**GPU-using** roles vary by training framework, as shown in the framework-specific mapping table below.
+
+| Framework | GPU-using roles | Notes |
+|---|---|---|
+| pytorch | master/worker | master inherits worker's image, resources, and envs by default; replicas fixed to 1 |
+| mpi | worker | launcher does not use GPU, does not inherit worker's config |
+| tensorflow | worker/chief/evaluator | chief/ps/evaluator do not inherit worker's config |
+| deepspeed | worker | launcher does not use GPU, does not inherit worker's config |
+| horovod | worker | launcher does not use GPU, does not inherit worker's config |
+
+**MPI/DeepSpeed/Horovod Launchers do not inherit worker's config by default** — the Provider automatically sets independent resource config for the Launcher (typically no GPU) during CRD generation, avoiding GPU waste on Launcher pods.
+
+**PyTorch Master vs Worker**: Master inherits the worker's image, resources, and envs by default. Master replica count is fixed at 1; **total GPU-using replicas** = `worker.replicas + 1`.
+
+### lifecycle (Job Lifecycle Policies)
+
+```yaml
+lifecycle:
+  clean_pod_policy: Running          # None | Running | All — which pods to clean after completion
+  active_deadline: 2h                # Max wall-clock duration → activeDeadlineSeconds
+  ttl_after_finished: 7d             # Auto-delete Job after this duration → ttlSecondsAfterFinished
+  backoff_limit: 6                   # Max restart count → backoffLimit
+  success_policy: ChiefWorker        # "" (default) | AllWorkers (TFJob only). ChiefWorker is accepted as an alias for "" for backwards compatibility.
+```
+
+`clean_pod_policy` controls which pods the Operator deletes after job completion:
+- `None` — keep all pods
+- `Running` — delete only running pods (failed/succeeded pods remain for log inspection)
+- `All` — delete all pods
+
+**lifecycle vs restart field boundary:**
+- `lifecycle` wraps the training-operator's `RunPolicy` (Job-level policies): `clean_pod_policy`, `backoff_limit`, `ttl_after_finished`, `active_deadline`, `success_policy`.
+- `restart` wraps `ReplicaSpec.RestartPolicy` (Replica-level), which is **not part of** `lifecycle`. The top-level `restart` is injected as the default for all Replicas.
+- Platform-level retries (exit-code-triggered, preemption re-queueing, resource retention) are **outside arena-v2's scope** — they require external controller + queue scheduler integration beyond a client-side tool. `restart` + `backoff_limit` already covers training-operator's pod-level restart.
+
+### run and shell (Command Execution Model)
+
+`run` is the training command string, executed via shell. `shell` specifies the interpreter path:
+
+| `shell` value | K8s Pod Spec Generation | Use Case |
+|---|---|---|
+| Omitted (default `/bin/sh`) | `command: ["/bin/sh", "-c"]`, `args: ["<run>"]` | Most scenarios, consistent with v1 behavior |
+| `/bin/bash` | `command: ["/bin/bash", "-c"]`, `args: ["<run>"]` | Requires bash features (`source`, `[[ ]]`, arrays, etc.) |
+
+**Invalid value handling**: `null` and empty string `""` both fall back to the default `/bin/sh`.
+
+**Why not `sh -c "bash -c ..."` workaround:**
+- **Signal delivery lost**: K8s sends SIGTERM to PID 1 (sh), which by default does not forward to the child bash process, breaking graceful shutdown
+- **Unreliable exit codes**: sh without `set -e` may swallow non-zero exit codes from the bash child, causing K8s to mark the Pod as Succeeded instead of Failed
+- **Nested escaping**: Quotes, `$`, and backslashes in user commands require double-escaping, which is error-prone
+
+### Resource Lifecycle
+
+A single `arena job run` invocation may create multiple K8s resources:
+
+```
+arena job run -f train.yaml
+  ├─ PyTorchJob CRD              ← Primary resource (Operator manages Pod lifecycle)
+  ├─ TensorBoard Deployment+Service ← If logging.tensorboard is enabled
+  └─ ConfigMap (metadata)        ← Stores effective training job YAML
+```
+
+**Design choice: Each task type uses its corresponding top-level resource as the anchor, with all other resources setting ownerReferences to it.**
+
+```
+PyTorchJob CRD
+  ├── owns → ConfigMap "my-job" (stores original YAML; a new CRD could replace the native ConfigMap)
+  ├── owns → TensorBoard Deployment
+  └── owns → TensorBoard Service
+```
+
+**Implementation approach:**
+
+1. Create the primary CRD (e.g. PyTorchJob) first to obtain its UID.
+2. Create the ConfigMap with the original YAML and generated manifest, setting `ownerReferences` to the CRD.
+3. Create any additional resources (TensorBoard Deployment, Service) with `ownerReferences` pointing to the CRD.
+4. On `arena job delete`, delete the CRD — K8s garbage collection cascades to all resources with matching `ownerReferences`.
+
+**`arena job delete` implementation (single step):** Delete the primary CRD. K8s GC cascades deletion to all resources that reference it.
+
+**`arena job get` implementation:** Read the ConfigMap by job name to retrieve the original YAML for display.
+
+**Comparison with v1:**
+
+| | v1 (Helm) | v2 (CRD anchor) |
+|---|---|---|
+| Metadata storage | ConfigMap `data.app` | ConfigMap `data.arena-v2.yaml` |
+| Resource tracking | Resource list in ConfigMap | K8s ownerReferences (automatic) |
+| `arena job delete` steps | 3 steps: read CM → delete resources → delete CM | **1 step: delete CRD** |
+| Resource leak risk | High (list may be incomplete) | **None (K8s GC handles it)** |
+
+**OwnerReferences semantics**: `kubectl get configmap -o yaml` will show ownerReferences relationships.
+
+- **Training Operator is unaffected**: the reconciler reads CRD spec/status to manage Pods, not ownerReferences
+- **Transparent to arena CLI users**: users interact via `arena job get/delete`, not direct CRD manipulation
+- **Helm uses this pattern**: Helm release Secrets serve as anchors managing all chart resources — a mature K8s ecosystem pattern
+
+### suspend / resume (Operational Pause)
+
+Pause/resume are **operations**, not configuration — they do not belong in the YAML schema. When integrating with queue systems like Kueue, applying a label/annotation on the CRD or patching `runPolicy.suspend` is sufficient.
+
+```bash
+arena job suspend <name>      # Suspend task
+arena job resume <name>    # Resume task
+```
+
+### sync & init (Code/Data Injection)
+
+**`sync` — high-level data/code injection (sugar for initContainer):**
+
+`sync` supports three source types:
+
+| Type | Source | Init Container |
+|---|---|---|
+| `git` | Git repository URL | `git-sync` clone |
+| `rsync` | Remote storage source | `rsync` |
+| `hdfs` | HDFS path | `apache/hadoop` init container with `hdfs dfs -get` |
+
+```yaml
+sync:
+  - git: https://github.com/org/training-code.git
+    branch: main                     # Optional. Default: main.
+    local_path: /workspace
+    mounts:
+    - name: code
+      mount_path: /workspace
+      sub_path: /
+
+  - rsync: 10.88.29.56::backup/data/logoRecoTrain.zip    # rsync from a remote source
+    local_path: /dataset
+    mounts:
+    - name: dataset
+      mount_path: /dataset
+
+  - hdfs: hdfs://namenode:8020/models/resnet
+    local_path: /models
+    mounts:
+    - name: checkpoints
+      mount_path: /models
+```
+
+Each entry creates an initContainer and volumes inherited from `storages`. The `mounts` field overrides these inherited configurations by name, and the final volumes are mounted at `mount_path` in both the initContainer and main container across all pods.
+
+**Override-by-name example:**
+
+```yaml
+storages:
+  - name: dataset
+    mount_path: /data                # Default mount path from storages
+    pvc: dataset-pvc
+
+sync:
+  - git: https://github.com/org/code.git
+    local_path: /code
+    mounts:
+    - name: dataset                  # Matches storages entry → overrides mount_path to /dataset
+      mount_path: /dataset
+    - name: code                     # No matching storages entry → a new emptyDir volume is appended
+      tmp: 1Gi
+      mount_path: /code
+```
+
+**`init` — generic initContainer injection:**
+
+```yaml
+init:
+  - name: download-model
+    image: busybox
+    run: wget -O /data/model.bin https://example.com/model.bin
+    mounts:
+    - name: data
+      mount_path: /data
+
+  - name: prepare-dataset
+    image: custom-etl:latest
+    run: /prepare.sh
+    shell: /bin/bash
+```
+
+`init[].run` has the same semantics as the top-level `run`: a command string executed via shell.
+`init[].shell` specifies the interpreter path for init containers. If omitted, it inherits the top-level `shell` value (which itself defaults to `/bin/sh`).
+
+Init containers generated by `sync` use exec form (CLI auto-generates the command without shell wrapping) — no `run`/`shell` fields needed.
+
+`sync` and `init` can coexist. `sync` entries are processed before `init` entries.
+
+### worker.replicas → Provider Mapping
+
+```
+User writes: worker.replicas: 4
+  pytorch    → PyTorchJob  { Master(1) + Worker(4) }   = 5 pods
+  mpi        → MPIJob      { Launcher(1) + Worker(4) }  = 5 pods
+  tensorflow → TFJob       { Worker(4) }   = 4 pods
+
+User writes: worker.replicas: 1
+  pytorch    → PyTorchJob  { Master(1) + Worker(1) }   = 2 pods
+  mpi        → MPIJob      { Launcher(1) + Worker(1) }  = 2 pods
+  tensorflow → TFJob       { Worker(1) }   = 1 pods
+
+User writes: worker.replicas: 0. Validation fails.
+User omits: worker. Validation passes only if the framework is PyTorch and the master block is specified.
+```
+
+### Affinity Design Principles
+
+`scheduling.affinity` uses an orthogonal `policy × constraint × target` design:
+
+- **policy**: `none` | `spread` | `binpack` — expresses scheduling intent
+- **constraint**: `preferred` | `required` — maps to K8s preferredDuringScheduling / requiredDuringScheduling
+- **target**: `pod` | `node` — determines whether to generate podAffinity or nodeAffinity
+
+`rules[]` is required when `policy` is not none. It supports full K8s `affinity` semantics.
+
+**Design principles:**
+
+- No additional fields introduced (e.g. `direction`, `match`, `scope`) — `policy`/`constraint`/`target` already orthogonally cover all semantics
+- Users only need to understand three dimensions: policy (intent) + constraint (strength) + target (object)
+- `rules[]` is a direct mapping of K8s native fields with no extra abstraction

--- a/pkg/cli/doc.go
+++ b/pkg/cli/doc.go
@@ -1,0 +1,2 @@
+// Package cli implements the Arena v2 command-line interface.
+package cli

--- a/pkg/client/doc.go
+++ b/pkg/client/doc.go
@@ -1,0 +1,2 @@
+// Package client provides the Kubernetes dynamic and typed client wrapper for Arena v2.
+package client

--- a/pkg/constants/doc.go
+++ b/pkg/constants/doc.go
@@ -1,0 +1,2 @@
+// Package constants defines shared constants for Arena v2.
+package constants

--- a/pkg/log/doc.go
+++ b/pkg/log/doc.go
@@ -1,0 +1,2 @@
+// Package log provides structured logging for Arena v2.
+package log

--- a/pkg/output/doc.go
+++ b/pkg/output/doc.go
@@ -1,0 +1,2 @@
+// Package output provides table formatting for Arena v2 CLI output.
+package output

--- a/pkg/provider/doc.go
+++ b/pkg/provider/doc.go
@@ -1,0 +1,2 @@
+// Package provider defines the provider interface and job implementations for Arena v2.
+package provider

--- a/pkg/task/doc.go
+++ b/pkg/task/doc.go
@@ -1,0 +1,2 @@
+// Package task defines the task data model, YAML loader, and flag overrides for Arena v2.
+package task


### PR DESCRIPTION
## Summary
- Add Makefile with v2 build, test, vet, install, and e2e targets
- Add v2-specific patterns to .gitignore (test/e2e/crds/, .claude, /arena-v2)
- Add placeholder package scaffolding (doc.go + main.go) so make targets are runnable
- Add KEP design docs (README, cli-flag-mapping, yaml-schema)

Part of the Arena v2 CLI series (PR 1/7).

Resubmission of closed PR #1477. The branch was rebased onto `develop-v2` to share a common ancestor, which required a force-push — GitHub does not allow reopening a PR after force-push, so a new PR is opened.

### Review comments from #1477 addressed:
- **Empty package dirs**: Added placeholder `doc.go` for all `V2_PACKAGES` and `main.go` for `cmd/arena-v2/` so `make arena-v2`, `make v2-test`, `make v2-vet` are runnable
- **shasum portability**: Added `SHA256CMD` detection in Makefile (`sha256sum` on Linux, `shasum` on macOS/BSD)
- **gitignore pattern**: Changed `arena-v2` to `/arena-v2` (leading slash to match root binary only)
- **KEP module layout**: Added `pkg/constants/` and `pkg/log/` to Architecture Overview in KEP README
- **go.mod version**: Kept `go 1.26.1` (installed and verified; later PRs in series require it)
- **AGENTS.md/CLAUDE.md**: Kept — contains project-wide build instructions and standards valuable to all contributors

## Test plan
- [x] `make arena-v2` builds successfully
- [x] `make v2-test` runs without errors
- [x] `make v2-vet` passes
- [x] Existing code unaffected