### PR TITLE
chore(v1-release): complete v0.15.5 changelog and enable manual release trigger

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,29 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  check_tag:
+    runs-on: ubuntu-latest
+    outputs:
+      exists: ${{ steps.check.outputs.exists }}
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v7
+
+      - name: Check whether release tag already exists upstream
+        id: check
+        run: |
+          TAG="v$(cat VERSION)"
+          if git ls-remote --tags origin "refs/tags/${TAG}" | grep -q "refs/tags/${TAG}"; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "Tag ${TAG} already exists -- release is immutable, downstream jobs will skip."
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "Tag ${TAG} does not exist yet."
+          fi
+
   package-arena-installer:
+    needs: check_tag
+    if: needs.check_tag.outputs.exists != 'true' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release-'))
     runs-on: ubuntu-latest
 
     strategy:
@@ -56,6 +78,8 @@ jobs:
 
   build-arena-image:
     name: Build Arena container image
+    needs: check_tag
+    if: needs.check_tag.outputs.exists != 'true' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release-'))
 
     runs-on: ubuntu-latest
 
@@ -199,6 +223,10 @@ jobs:
       - name: Create and push tag
         run: |
           TAG="v${VERSION}"
+          if git ls-remote --tags origin "refs/tags/${TAG}" | grep -q "refs/tags/${TAG}"; then
+            echo "Tag ${TAG} already exists upstream -- skipping tag creation."
+            exit 0
+          fi
           git tag -a ${TAG} -m "Release v${VERSION}"
           git push origin ${TAG}
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,6 +6,7 @@ on:
       - master
     paths:
       - VERSION
+  workflow_dispatch:
 
 env:
   IMAGE_REGISTRY: ghcr.io

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@
 
 ### Bug Fixes
 
+- fix: prevent nil pointer dereference in servingJob and lwsJob methods ([#1476](https://github.com/kubeflow/arena/pull/1476) by [@vishalmore90](https://github.com/vishalmore90))
+- fix: resolve real username for client-certificate kubeconfigs ([#1475](https://github.com/kubeflow/arena/pull/1475) by [@darrencrosz](https://github.com/darrencrosz))
 - fix(pytorch-operator): update pytorch-operator image tag to 2845db5-aliyun ([#1456](https://github.com/kubeflow/arena/pull/1456) by [@vicoooo26](https://github.com/vicoooo26))
+- fix: return distributed serving update errors ([#1445](https://github.com/kubeflow/arena/pull/1445) by [@immanuwell](https://github.com/immanuwell))
 - fix(workflow): make job deletion idempotent ([#1440](https://github.com/kubeflow/arena/pull/1440) by [@vicoooo26](https://github.com/vicoooo26))
 - fix: add ownerReferences to resources created by arena ([#1407](https://github.com/kubeflow/arena/pull/1407) by [@FAUST-BENCHOU](https://github.com/FAUST-BENCHOU))
 - fix(pytorch-operator): update pytorch-operator image tag to 4598b3e-aliyun ([#1406](https://github.com/kubeflow/arena/pull/1406) by [@ChenYi015](https://github.com/ChenYi015))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [v0.15.5](https://github.com/kubeflow/arena/tree/v0.15.5) (2026-07-28)
+## [v0.15.5](https://github.com/kubeflow/arena/tree/v0.15.5) (2026-07-29)
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [v0.15.5](https://github.com/kubeflow/arena/tree/v0.15.5) (2026-07-14)
+## [v0.15.5](https://github.com/kubeflow/arena/tree/v0.15.5) (2026-07-28)
 
 ### Bug Fixes
 


### PR DESCRIPTION
## Purpose of this PR

Prepare for re-releasing v0.15.5 by backfilling missing changelog entries and adding a manual trigger to the Release workflow.

**Proposed changes:**

- Add missing v0.15.5 Bug Fixes entries for #1445, #1475, #1476 — these landed on master shortly before the changelog patch (#1474) but were not included in the v0.15.5 section.
- Add `workflow_dispatch` trigger to `.github/workflows/release.yaml` so maintainers can manually re-run a release for the current VERSION without bumping the version (e.g. re-publishing a draft after fixing its changelog).

## Change Category

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [x] Documentation update
- [x] CI/Release tooling

### Rationale

The v0.15.5 Draft Release was built from an intermediate commit. Three bug fixes (#1445, #1475, #1476) merged within minutes before the changelog patch (#1474) were omitted from the v0.15.5 section. Additionally, the Release workflow only fires on `push.paths: [VERSION]`, leaving no way to re-trigger a release for an unchanged version — which is exactly what is needed to re-publish the v0.15.5 draft with corrected artifacts and release notes.

## Test Plan

- [x] Verified `v0.15.4..release-v0.15.5` commit range matches CHANGELOG entries (all 25 user-facing PRs accounted for; only release-mechanics #1457 and changelog-patch #1474 correctly excluded).
- [x] Verified `release-v0.15.5` is a clean fast-forward descendant of `origin/master`.
- [ ] Trigger `workflow_dispatch` on a fork and confirm the Release workflow builds installer tarballs, pushes the multi-arch image, creates the `v0.15.5` tag, and creates the Draft Release.