### PR TITLE
feat(e2e): add kind cluster setup and teardown for v2 e2e tests

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,0 +1,63 @@
+name: E2E Tests
+
+on:
+  pull_request:
+    branches: [master, develop-v2]
+  push:
+    branches: [master, develop-v2]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.actor }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  cpu-e2e-test:
+    name: CPU E2E Test (${{ matrix.kubernetes-version }}, ${{ matrix.install-method }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      E2E_BUSYBOX_IMAGE: docker.io/library/busybox:1.35
+      NAMESPACE: kubeflow
+    strategy:
+      fail-fast: false
+      matrix:
+        kubernetes-version: ["1.32.3"]
+        install-method: ["kustomize"]
+
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Setup cluster and install training-operator
+        uses: ./.github/workflows/template-setup-clusters
+        with:
+          kubernetes_version: ${{ matrix.kubernetes-version }}
+          training_operator_version: v1.9.3
+          install_method: ${{ matrix.install-method }}
+
+      - name: Build arena-v2 binary
+        run: make arena-v2
+
+      - name: Run e2e tests
+        run: make v2-e2e-test
+
+      - name: Print cluster diagnostics on failure
+        if: failure()
+        run: |
+          kubectl get nodes -o wide
+          kubectl get pods -n "${NAMESPACE}"
+          kubectl describe deploy/training-operator -n "${NAMESPACE}"
+          kubectl logs -n "${NAMESPACE}" -l control-plane=kubeflow-training-operator --tail=100
+
+      - name: Cleanup cluster
+        if: always()
+        run: make v2-e2e-teardown || true

--- a/.github/workflows/template-setup-clusters/action.yaml
+++ b/.github/workflows/template-setup-clusters/action.yaml
@@ -1,0 +1,32 @@
+name: Setup E2E Cluster
+description: Creates a Kind cluster and installs Kubeflow Training Operator for Arena v2 e2e tests
+
+inputs:
+  kubernetes_version:
+    description: Kubernetes version for the kind cluster
+    required: false
+    default: '1.32.3'
+  training_operator_version:
+    description: Training Operator repo ref (tag or branch)
+    required: false
+    default: 'v1.9.3'
+  install_method:
+    description: Installation method for training-operator (kustomize or helm)
+    required: false
+    default: 'kustomize'
+
+runs:
+  using: composite
+  steps:
+    - name: Install kind
+      uses: helm/kind-action@v1
+      with:
+        install_only: true
+
+    - name: Setup cluster and install training-operator
+      shell: bash
+      run: |
+        make v2-e2e-setup-cluster \
+          K8S_VERSION=${{ inputs.kubernetes_version }} \
+          TRAINER_REF=${{ inputs.training_operator_version }} \
+          INSTALL_METHOD=${{ inputs.install_method }}

--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,7 @@ v2-test: ## Run arena v2 unit tests.
 v2-vet: ## Run go vet on arena v2 packages.
 	@echo "Running go vet on arena v2 packages..."
 	go vet $(V2_ALL_PACKAGES)
+	go vet -tags v2e2e ./test/e2e/
 
 .PHONY: v2-fmt
 v2-fmt: ## Run gofmt on arena v2 packages.
@@ -82,10 +83,32 @@ v2-install: ## Install arena v2 CLI to GOBIN.
 	@echo "Installing arena v2 CLI to $(GOBIN)..."
 	go install -ldflags '$(V2_LDFLAGS)' ./cmd/arena-v2/
 
+# E2E cluster configuration (overridable via environment or command line)
+TRAINER_REPO ?= https://github.com/kubeflow/training-operator.git
+TRAINER_REF ?= v1.9.3
+INSTALL_METHOD ?= kustomize
+K8S_VERSION ?= 1.32.3
+KIND_CLUSTER_NAME ?= arena-v2
+NAMESPACE ?= kubeflow
+
+.PHONY: v2-e2e-setup-cluster
+v2-e2e-setup-cluster: ## Create kind cluster and install training-operator for v2 e2e tests.
+	TRAINER_REPO=$(TRAINER_REPO) \
+	TRAINER_REF=$(TRAINER_REF) \
+	INSTALL_METHOD=$(INSTALL_METHOD) \
+	K8S_VERSION=$(K8S_VERSION) \
+	KIND_CLUSTER_NAME=$(KIND_CLUSTER_NAME) \
+	NAMESPACE=$(NAMESPACE) \
+	./hack/e2e-setup-cluster.sh
+
 .PHONY: v2-e2e-test
-v2-e2e-test: arena-v2 ## Run arena v2 e2e tests (requires real K8s cluster with CRDs installed).
+v2-e2e-test: arena-v2 ## Run arena v2 e2e tests (requires cluster from v2-e2e-setup-cluster).
 	@echo "Running arena v2 e2e tests..."
-	go test ./test/e2e/ -v -ginkgo.v -timeout 30m
+	go test -tags v2e2e ./test/e2e/ -v -ginkgo.v -timeout 30m
+
+.PHONY: v2-e2e-teardown
+v2-e2e-teardown: ## Delete the kind cluster used for v2 e2e tests.
+	kind delete cluster --name $(KIND_CLUSTER_NAME)
 
 .PHONY: v2-release-snapshot
 v2-release-snapshot: ## Build arena v2 release snapshot locally (no tag required).

--- a/hack/e2e-setup-cluster.sh
+++ b/hack/e2e-setup-cluster.sh
@@ -71,11 +71,21 @@ kubectl wait deploy/training-operator \
   --for=condition=available \
   --timeout "${TIMEOUT}"
 
-# 4. Pre-load busybox image to avoid docker.io rate limits
-BUSYBOX_IMAGE="${E2E_BUSYBOX_IMAGE:-docker.io/library/busybox:1.35}"
-echo "Pre-loading ${BUSYBOX_IMAGE} into kind cluster..."
-docker pull "${BUSYBOX_IMAGE}"
-kind load docker-image "${BUSYBOX_IMAGE}" --name "${KIND_CLUSTER_NAME}"
+# 4. Pre-load images into kind to avoid docker.io rate limits
+kind_load_image() {
+  local image="$1"
+  echo "Pre-loading ${image} into kind cluster..."
+  docker pull "${image}"
+  kind load docker-image "${image}" --name "${KIND_CLUSTER_NAME}"
+}
+
+kind_load_image "${E2E_BUSYBOX_IMAGE:-docker.io/library/busybox:1.35}"
+
+# Extract and pre-load the training-operator image deployed by kustomize
+TRAINER_IMAGE=$(kubectl get deploy/training-operator \
+  -n "${NAMESPACE}" \
+  -o jsonpath='{.spec.template.spec.containers[0].image}')
+kind_load_image "${TRAINER_IMAGE}"
 
 # 5. Print cluster info
 echo ""

--- a/hack/e2e-setup-cluster.sh
+++ b/hack/e2e-setup-cluster.sh
@@ -22,13 +22,22 @@ set -o nounset
 set -o pipefail
 
 # Variables (overridable via environment)
-TRAINING_OPERATOR_VERSION="${TRAINING_OPERATOR_VERSION:-v1.9.3}"
+TRAINER_REPO="${TRAINER_REPO:-https://github.com/kubeflow/training-operator.git}"
+TRAINER_REF="${TRAINER_REF:-v1.9.3}"
+INSTALL_METHOD="${INSTALL_METHOD:-kustomize}"
 K8S_VERSION="${K8S_VERSION:-1.32.3}"
 KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-arena-v2}"
-NAMESPACE="kubeflow"
+NAMESPACE="${NAMESPACE:-kubeflow}"
 TIMEOUT="5m"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Clone trainer repo to temp directory
+TRAINER_DIR="$(mktemp -d /tmp/trainer-XXXXXX)"
+trap 'rm -rf "${TRAINER_DIR}"' EXIT
+
+echo "Cloning ${TRAINER_REPO} (ref: ${TRAINER_REF})..."
+git clone --depth 1 --branch "${TRAINER_REF}" "${TRAINER_REPO}" "${TRAINER_DIR}"
 
 # 1. Create kind cluster
 echo "Creating Kind cluster '${KIND_CLUSTER_NAME}' with Kubernetes v${K8S_VERSION}..."
@@ -38,9 +47,22 @@ kind create cluster \
   --config "${SCRIPT_DIR}/kind-config.yaml"
 
 # 2. Install training-operator
-echo "Installing Kubeflow Training Operator ${TRAINING_OPERATOR_VERSION}..."
-kubectl apply --server-side -k \
-  "github.com/kubeflow/training-operator.git/manifests/overlays/standalone?ref=${TRAINING_OPERATOR_VERSION}"
+case "${INSTALL_METHOD}" in
+  kustomize)
+    echo "Installing training-operator via kustomize..."
+    kubectl apply --server-side -k "${TRAINER_DIR}/manifests/overlays/standalone"
+    ;;
+  helm)
+    echo "Error: INSTALL_METHOD=helm is not currently supported."
+    echo "The training-operator v1 chart is not available at ref ${TRAINER_REF}."
+    echo "Use INSTALL_METHOD=kustomize (the default) instead."
+    exit 1
+    ;;
+  *)
+    echo "Error: INSTALL_METHOD must be 'kustomize' or 'helm', got '${INSTALL_METHOD}'"
+    exit 1
+    ;;
+esac
 
 # 3. Wait for training-operator deployment to be ready
 echo "Waiting for training-operator deployment to be ready..."
@@ -49,7 +71,13 @@ kubectl wait deploy/training-operator \
   --for=condition=available \
   --timeout "${TIMEOUT}"
 
-# 4. Print cluster info
+# 4. Pre-load busybox image to avoid docker.io rate limits
+BUSYBOX_IMAGE="${E2E_BUSYBOX_IMAGE:-docker.io/library/busybox:1.35}"
+echo "Pre-loading ${BUSYBOX_IMAGE} into kind cluster..."
+docker pull "${BUSYBOX_IMAGE}"
+kind load docker-image "${BUSYBOX_IMAGE}" --name "${KIND_CLUSTER_NAME}"
+
+# 5. Print cluster info
 echo ""
 echo "=== Cluster Info ==="
 kubectl get nodes

--- a/hack/e2e-setup-cluster.sh
+++ b/hack/e2e-setup-cluster.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script creates a Kind cluster and installs the Kubeflow Training Operator
+# for Arena v2 e2e tests.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# Variables (overridable via environment)
+TRAINING_OPERATOR_VERSION="${TRAINING_OPERATOR_VERSION:-v1.9.3}"
+K8S_VERSION="${K8S_VERSION:-1.32.3}"
+KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-arena-v2}"
+NAMESPACE="kubeflow"
+TIMEOUT="5m"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# 1. Create kind cluster
+echo "Creating Kind cluster '${KIND_CLUSTER_NAME}' with Kubernetes v${K8S_VERSION}..."
+kind create cluster \
+  --name "${KIND_CLUSTER_NAME}" \
+  --image "kindest/node:v${K8S_VERSION}" \
+  --config "${SCRIPT_DIR}/kind-config.yaml"
+
+# 2. Install training-operator
+echo "Installing Kubeflow Training Operator ${TRAINING_OPERATOR_VERSION}..."
+kubectl apply --server-side -k \
+  "github.com/kubeflow/training-operator.git/manifests/overlays/standalone?ref=${TRAINING_OPERATOR_VERSION}"
+
+# 3. Wait for training-operator deployment to be ready
+echo "Waiting for training-operator deployment to be ready..."
+kubectl wait deploy/training-operator \
+  -n "${NAMESPACE}" \
+  --for=condition=available \
+  --timeout "${TIMEOUT}"
+
+# 4. Print cluster info
+echo ""
+echo "=== Cluster Info ==="
+kubectl get nodes
+echo ""
+kubectl get pods -n "${NAMESPACE}"
+echo ""
+echo "Cluster '${KIND_CLUSTER_NAME}' is ready for e2e tests."

--- a/hack/kind-config.yaml
+++ b/hack/kind-config.yaml
@@ -1,0 +1,4 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+  - role: control-plane

--- a/test/e2e/check_test.go
+++ b/test/e2e/check_test.go
@@ -1,3 +1,5 @@
+//go:build v2e2e
+
 package e2e_test
 
 import (

--- a/test/e2e/cli_overrides_test.go
+++ b/test/e2e/cli_overrides_test.go
@@ -1,3 +1,5 @@
+//go:build v2e2e
+
 package e2e_test
 
 import (

--- a/test/e2e/dryrun_test.go
+++ b/test/e2e/dryrun_test.go
@@ -1,3 +1,5 @@
+//go:build v2e2e
+
 package e2e_test
 
 import (

--- a/test/e2e/error_paths_test.go
+++ b/test/e2e/error_paths_test.go
@@ -1,3 +1,5 @@
+//go:build v2e2e
+
 package e2e_test
 
 import (
@@ -114,7 +116,7 @@ run: python train.py
 		submitCmd := exec.Command(arenaV2Bin, "submit", "pytorch",
 			"--name", jobName,
 			"--namespace", namespace,
-			"--image", "docker.io/library/busybox:1.36",
+			"--image", busyboxImage(),
 			"--workers", "1",
 			"sleep 300")
 		submitCmd.Stdout = &out
@@ -127,7 +129,7 @@ run: python train.py
 		submitCmd2 := exec.Command(arenaV2Bin, "submit", "pytorch",
 			"--name", jobName,
 			"--namespace", namespace,
-			"--image", "docker.io/library/busybox:1.36",
+			"--image", busyboxImage(),
 			"--workers", "1",
 			"sleep 300")
 		submitCmd2.Stdout = &out
@@ -165,10 +167,10 @@ spec:
         spec:
           containers:
             - name: pytorch
-              image: docker.io/library/busybox:1.36
+              image: %s
               command: ["sleep", "300"]
           restartPolicy: OnFailure
-`, jobName)
+`, jobName, busyboxImage())
 
 		var out bytes.Buffer
 		kubectlCmd := exec.Command("kubectl", "apply", "-f", "-")

--- a/test/e2e/features_test.go
+++ b/test/e2e/features_test.go
@@ -1,3 +1,5 @@
+//go:build v2e2e
+
 package e2e_test
 
 import (

--- a/test/e2e/format_test.go
+++ b/test/e2e/format_test.go
@@ -1,3 +1,5 @@
+//go:build v2e2e
+
 package e2e_test
 
 import (

--- a/test/e2e/get_formats_test.go
+++ b/test/e2e/get_formats_test.go
@@ -1,3 +1,5 @@
+//go:build v2e2e
+
 package e2e_test
 
 import (

--- a/test/e2e/lifecycle_e2e_test.go
+++ b/test/e2e/lifecycle_e2e_test.go
@@ -1,3 +1,5 @@
+//go:build v2e2e
+
 package e2e_test
 
 import (
@@ -37,7 +39,7 @@ var _ = Describe("Suspend and Resume", func() {
 		submitCmd := exec.Command(arenaV2Bin, "submit", "pytorch",
 			"--name", jobName,
 			"--namespace", namespace,
-			"--image", "docker.io/library/busybox:1.36",
+			"--image", busyboxImage(),
 			"--workers", "1",
 			"sleep 300",
 		)

--- a/test/e2e/logs_e2e_test.go
+++ b/test/e2e/logs_e2e_test.go
@@ -1,3 +1,5 @@
+//go:build v2e2e
+
 package e2e_test
 
 import (
@@ -10,8 +12,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-// TODO: Re-enable these tests after fixing the Kind cluster pod reconciling issue in GitHub workflows.
-var _ = Describe("Logs", Pending, func() {
+var _ = Describe("Logs", func() {
 	var (
 		jobName   string
 		namespace string
@@ -38,7 +39,7 @@ var _ = Describe("Logs", Pending, func() {
 		submitCmd := exec.Command(arenaV2Bin, "submit", "pytorch",
 			"--name", jobName,
 			"--namespace", namespace,
-			"--image", "registry-cn-beijing.ack.aliyuncs.com/acs/busybox:1.35",
+			"--image", busyboxImage(),
 			"--workers", "1",
 			"sh -c 'echo hello-world; sleep 120'",
 		)
@@ -48,13 +49,24 @@ var _ = Describe("Logs", Pending, func() {
 		Expect(err).NotTo(HaveOccurred(), "submit output: %s", out.String())
 		out.Reset()
 
-		By("Waiting for pod to be ready")
-		waitCmd := exec.Command("kubectl", "wait", "--for=condition=PodReady",
+		By("Waiting for pod to be created")
+		createCmd := exec.Command("kubectl", "wait", "--for=create",
 			"pod", "-l", "training.kubeflow.org/job-name="+jobName,
 			"-n", namespace, "--timeout=120s")
-		waitCmd.Stdout = &out
-		waitCmd.Stderr = &out
-		_ = waitCmd.Run()
+		createCmd.Stdout = &out
+		createCmd.Stderr = &out
+		err = createCmd.Run()
+		Expect(err).NotTo(HaveOccurred(), "pod was not created: %s", out.String())
+		out.Reset()
+
+		By("Waiting for pod to be ready")
+		readyCmd := exec.Command("kubectl", "wait", "--for=condition=Ready",
+			"pod", "-l", "training.kubeflow.org/job-name="+jobName,
+			"-n", namespace, "--timeout=120s")
+		readyCmd.Stdout = &out
+		readyCmd.Stderr = &out
+		err = readyCmd.Run()
+		Expect(err).NotTo(HaveOccurred(), "pod did not become ready: %s", out.String())
 		out.Reset()
 
 		By("Fetching logs")
@@ -74,7 +86,7 @@ var _ = Describe("Logs", Pending, func() {
 		submitCmd := exec.Command(arenaV2Bin, "submit", "pytorch",
 			"--name", jobName,
 			"--namespace", namespace,
-			"--image", "registry-cn-beijing.ack.aliyuncs.com/acs/busybox:1.35",
+			"--image", busyboxImage(),
 			"--workers", "1",
 			"sh -c 'for i in $(seq 1 20); do echo line-$i; done; sleep 120'",
 		)
@@ -84,13 +96,24 @@ var _ = Describe("Logs", Pending, func() {
 		Expect(err).NotTo(HaveOccurred(), "submit output: %s", out.String())
 		out.Reset()
 
-		By("Waiting for pod to be ready")
-		waitCmd := exec.Command("kubectl", "wait", "--for=condition=PodReady",
+		By("Waiting for pod to be created")
+		createCmd := exec.Command("kubectl", "wait", "--for=create",
 			"pod", "-l", "training.kubeflow.org/job-name="+jobName,
 			"-n", namespace, "--timeout=120s")
-		waitCmd.Stdout = &out
-		waitCmd.Stderr = &out
-		_ = waitCmd.Run()
+		createCmd.Stdout = &out
+		createCmd.Stderr = &out
+		err = createCmd.Run()
+		Expect(err).NotTo(HaveOccurred(), "pod was not created: %s", out.String())
+		out.Reset()
+
+		By("Waiting for pod to be ready")
+		readyCmd := exec.Command("kubectl", "wait", "--for=condition=Ready",
+			"pod", "-l", "training.kubeflow.org/job-name="+jobName,
+			"-n", namespace, "--timeout=120s")
+		readyCmd.Stdout = &out
+		readyCmd.Stderr = &out
+		err = readyCmd.Run()
+		Expect(err).NotTo(HaveOccurred(), "pod did not become ready: %s", out.String())
 		out.Reset()
 
 		By("Fetching logs with --tail 5")

--- a/test/e2e/mpi_test.go
+++ b/test/e2e/mpi_test.go
@@ -1,3 +1,5 @@
+//go:build v2e2e
+
 // MPI lifecycle tests: CRUD smoke tests that verify job submit, get, and
 // delete operations using placeholder images. These do not wait for pod
 // readiness or validate training outcomes.
@@ -124,14 +126,14 @@ var _ = Describe("MPI-based Jobs", func() {
 	}
 
 	It("MPI job lifecycle", func() {
-		frameworkLifecycle("mpi", "registry-cn-beijing.ack.aliyuncs.com/acs/busybox")
+		frameworkLifecycle("mpi", busyboxImage())
 	})
 
 	It("Horovod job lifecycle", func() {
-		frameworkLifecycle("horovod", "registry-cn-beijing.ack.aliyuncs.com/acs/busybox")
+		frameworkLifecycle("horovod", busyboxImage())
 	})
 
 	It("DeepSpeed job lifecycle", func() {
-		frameworkLifecycle("deepspeed", "registry-cn-beijing.ack.aliyuncs.com/acs/busybox")
+		frameworkLifecycle("deepspeed", busyboxImage())
 	})
 })

--- a/test/e2e/pytorch_test.go
+++ b/test/e2e/pytorch_test.go
@@ -1,3 +1,5 @@
+//go:build v2e2e
+
 // PyTorch lifecycle tests: CRUD smoke tests that verify job submit, list,
 // get, and delete operations using placeholder images. These do not wait
 // for pod readiness or validate training outcomes.

--- a/test/e2e/set_overrides_e2e_test.go
+++ b/test/e2e/set_overrides_e2e_test.go
@@ -1,3 +1,5 @@
+//go:build v2e2e
+
 package e2e_test
 
 import (

--- a/test/e2e/storage_test.go
+++ b/test/e2e/storage_test.go
@@ -1,3 +1,5 @@
+//go:build v2e2e
+
 package e2e_test
 
 import (

--- a/test/e2e/submit_dryrun_test.go
+++ b/test/e2e/submit_dryrun_test.go
@@ -1,3 +1,5 @@
+//go:build v2e2e
+
 package e2e_test
 
 import (

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -1,3 +1,5 @@
+//go:build v2e2e
+
 // Package e2e_test contains end-to-end tests for the arena v2 CLI.
 //
 // The lifecycle tests in this suite are CRUD smoke tests: they verify that
@@ -26,6 +28,15 @@ func TestArenaV2(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
+	operatorNamespace := os.Getenv("NAMESPACE")
+	if operatorNamespace == "" {
+		operatorNamespace = "kubeflow"
+	}
+	cmd := exec.Command("kubectl", "get", "deploy/training-operator", "-n", operatorNamespace)
+	if err := cmd.Run(); err != nil {
+		Fail(fmt.Sprintf("training-operator not found in %s namespace — run `make v2-e2e-setup-cluster` first", operatorNamespace))
+	}
+
 	localBin := filepath.Join("..", "..", "bin", "arena-v2")
 	if p, err := exec.LookPath(localBin); err == nil {
 		arenaV2Bin = p
@@ -91,4 +102,13 @@ func mpiJobStorageVersion() string {
 		Fail(fmt.Sprintf("failed to query MPIJob CRD storage version: %v — ensure mpijobs.kubeflow.org CRD is installed", err))
 	}
 	return "kubeflow.org/" + string(out)
+}
+
+// busyboxImage returns the busybox image for e2e tests. Override with
+// E2E_BUSYBOX_IMAGE for alternative registries (e.g. mirror registries).
+func busyboxImage() string {
+	if img := os.Getenv("E2E_BUSYBOX_IMAGE"); img != "" {
+		return img
+	}
+	return "docker.io/library/busybox:1.35"
 }

--- a/test/e2e/tensorboard_e2e_test.go
+++ b/test/e2e/tensorboard_e2e_test.go
@@ -1,3 +1,5 @@
+//go:build v2e2e
+
 package e2e_test
 
 import (

--- a/test/e2e/tfjob_test.go
+++ b/test/e2e/tfjob_test.go
@@ -1,3 +1,5 @@
+//go:build v2e2e
+
 // TensorFlow lifecycle tests: CRUD smoke tests that verify job submit, list,
 // get, and delete operations using placeholder images. These do not wait
 // for pod readiness or validate training outcomes.

--- a/test/e2e/top_e2e_test.go
+++ b/test/e2e/top_e2e_test.go
@@ -1,3 +1,5 @@
+//go:build v2e2e
+
 package e2e_test
 
 import (

--- a/test/e2e/yaml_delete_test.go
+++ b/test/e2e/yaml_delete_test.go
@@ -1,3 +1,5 @@
+//go:build v2e2e
+
 package e2e_test
 
 import (

--- a/test/e2e/yaml_submit_test.go
+++ b/test/e2e/yaml_submit_test.go
@@ -1,3 +1,5 @@
+//go:build v2e2e
+
 package e2e_test
 
 import (


### PR DESCRIPTION
## Summary

Add e2e cluster setup/teardown infrastructure for Arena v2 e2e tests. Developers can now spin up a local kind cluster with training-operator pre-installed via `make v2-e2e-setup-cluster`, run the full e2e suite, and tear it down with `make v2-e2e-teardown`.

## Changes

- Add `hack/e2e-setup-cluster.sh` script and `hack/kind-config.yaml` for creating a kind cluster with training-operator
- Add `v2-e2e-setup-cluster` and `v2-e2e-teardown` Makefile targets
- Add `.github/workflows/e2e.yaml` GitHub Actions workflow for automated e2e runs
- Add reusable `template-setup-clusters/action.yaml` composite action
- Add `busyboxImage()` helper to make e2e test images configurable via `E2E_BUSYBOX_IMAGE` env var
- Add training-operator existence check in `BeforeSuite` to fail fast with a helpful message
- Add pod creation wait step in `logs_e2e_test.go` for more reliable log tests

## Test Plan

- [ ] `make v2-e2e-setup-cluster` creates a kind cluster with training-operator
- [ ] `make v2-e2e-test` runs the full e2e suite against the cluster
- [ ] `make v2-e2e-teardown` cleans up the kind cluster
- [x] `go vet ./test/e2e/...` passes
- [x] `go build ./cmd/arena-v2/` passes