### PR TITLE
chores: add arena v2 release workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,0 +1,48 @@
+name: Bug Report
+description: Tell us about a problem you are experiencing with Arena v2
+labels: ["kind/bug", "lifecycle/needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this Arena v2 bug report!
+  - type: textarea
+    id: problem
+    attributes:
+      label: What happened?
+      description: |
+        Please provide as much info as possible.
+        Not doing so may result in your bug not being addressed in a timely manner.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      value: |
+        Kubernetes version:
+
+        ```bash
+        $ kubectl version
+
+        ```
+
+        Arena v2 version:
+
+        ```bash
+        $ arena-v2 version
+
+        ```
+    validations:
+      required: true
+  - type: input
+    id: votes
+    attributes:
+      label: Impacted by this bug?
+      value: Give it a 👍 We prioritize the issues with most 👍

--- a/.github/ISSUE_TEMPLATE/config.yaml
+++ b/.github/ISSUE_TEMPLATE/config.yaml
@@ -1,0 +1,6 @@
+blank_issues_enabled: true
+
+contact_links:
+  - name: Arena v2 Documentation
+    url: https://github.com/kubeflow/arena/tree/develop-v2
+    about: Much help can be found in the docs

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,0 +1,27 @@
+name: Feature Request
+description: Suggest an idea for Arena v2
+labels: ["kind/feature", "lifecycle/needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this Arena v2 feature request!
+  - type: textarea
+    id: feature
+    attributes:
+      label: What you would like to be added?
+      description: |
+        A clear and concise description of what you want to add to Arena v2.
+    validations:
+      required: true
+  - type: textarea
+    id: rationale
+    attributes:
+      label: Why is this needed?
+    validations:
+      required: true
+  - type: input
+    id: votes
+    attributes:
+      label: Love this feature?
+      value: Give it a 👍 We prioritize the features with most 👍

--- a/.github/ISSUE_TEMPLATE/question.yaml
+++ b/.github/ISSUE_TEMPLATE/question.yaml
@@ -1,0 +1,27 @@
+name: Question
+description: Ask question about Arena v2
+labels: ["kind/question", "lifecycle/needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this question!
+  - type: textarea
+    id: feature
+    attributes:
+      label: What question do you want to ask?
+      description: |
+        A clear and concise description of what you want to ask about Arena v2.
+    validations:
+      required: true
+  - type: textarea
+    id: rationale
+    attributes:
+      label: Any additional context?
+    validations:
+      required: false
+  - type: input
+    id: votes
+    attributes:
+      label: Have the same question?
+      value: Give it a 👍 We prioritize the question with most 👍

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,31 @@
+## Purpose of this PR
+
+<!-- Provide a clear and concise description of the changes. Link to relevant issues. -->
+
+**Proposed changes:**
+
+-
+
+## Commit Message Format
+
+This project uses [conventional commits](https://www.conventionalcommits.org/) for commit hygiene. The release changelog is driven by PR labels, which are auto-assigned based on your branch name prefix and changed files.
+
+**Example commit messages:**
+
+```
+feat: add GPU sharing support for MPIJob
+fix: correct pytorch replica count in dry-run output
+feat(serving): add vLLM as serving framework
+docs: update installation guide for v2
+```
+
+> **Note:** PR labels are auto-assigned by the Labeler workflow based on your branch name prefix and changed files. This determines how your change appears in the release changelog — `feat/` branch → Features, `fix/` branch → Bug Fixes, `breaking/` branch → Breaking Changes, `doc/` or `docs/` branch or all files in `docs/`/`examples/` → Documentation, `chore/` or `chores/` branch → Maintenance, `refactor/` branch → Refactoring, `test/`/`ci/` branch, all files are `.github/` CI configs, or only `VERSION` changed → excluded.
+
+## Checklist
+
+- [ ] Code follows the project's style guidelines (`make v2-fmt`)
+- [ ] Code passes vet (`make v2-vet`)
+- [ ] Code passes lint (`make v2-lint`)
+- [ ] Tests pass (`make v2-test`)
+- [ ] `go mod tidy` has been run
+- [ ] Commit messages follow conventional commit format

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,28 @@
+feature:
+  - head-branch: ["^feat/", "^feature/"]
+
+bug:
+  - head-branch: ["^fix/", "^bug/", "^bugfix/"]
+
+breaking-changes:
+  - head-branch: ["^breaking/"]
+
+documentation:
+  - head-branch: ["^docs?/"]
+  - changed-files:
+      - any-glob-to-all-files: ["docs/**/*", "examples/**/*"]
+
+chore:
+  - head-branch: ["^chores?/"]
+
+refactor:
+  - head-branch: ["^refactor/"]
+
+skip-changelog:
+  - head-branch: ["^test/", "^ci/"]
+  - changed-files:
+      - any-glob-to-all-files: ["VERSION"]
+
+github-actions:
+  - changed-files:
+      - any-glob-to-all-files: [".github/**/*.yml", ".github/**/*.yaml"]

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,27 @@
+changelog:
+  exclude:
+    labels:
+      - skip-changelog
+      - github-actions
+  categories:
+    - title: 🚀 Features
+      labels:
+        - feature
+    - title: 🐛 Bug Fixes
+      labels:
+        - bug
+    - title: 💥 Breaking Changes
+      labels:
+        - breaking-changes
+    - title: 📝 Documentation
+      labels:
+        - documentation
+    - title: 🔨 Maintenance
+      labels:
+        - chore
+    - title: ♻️ Refactoring
+      labels:
+        - refactor
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -1,0 +1,37 @@
+name: Release (v2)
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Checkout tag
+        run: |
+          VERSION=$(cat VERSION)
+          git checkout "v${VERSION}"
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          version: v2.17.1
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -1,14 +1,37 @@
-name: Integration Test
+name: Integration Test (v2)
 
 on:
-  - push
-  - pull_request
+  push:
+    branches: [develop-v2]
+  pull_request:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.actor }}
   cancel-in-progress: true
 
 jobs:
+  validate-version:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - name: Check VERSION isolation
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          CHANGED_FILES=$(git diff --name-only "origin/${BASE_REF}...HEAD")
+
+          if echo "${CHANGED_FILES}" | grep -q "^VERSION$"; then
+            OTHER_FILES=$(echo "${CHANGED_FILES}" | grep -v "^VERSION$" || true)
+            if [ -n "${OTHER_FILES}" ]; then
+              echo "::error::VERSION must be changed in isolation. Also changed:"
+              echo "${OTHER_FILES}"
+              exit 1
+            fi
+          fi
+
   build-arena-v2:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -1,0 +1,21 @@
+name: Labeler (v2)
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v7
+      - name: Add label
+        uses: actions/labeler@v7
+        with:
+          sync-labels: true
+          # repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tag-release.yaml
+++ b/.github/workflows/tag-release.yaml
@@ -1,0 +1,63 @@
+name: Tag Release (v2)
+
+on:
+  push:
+    branches: [develop-v2]
+    paths: [VERSION]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      actions: write
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Read version
+        run: |
+          VERSION=$(cat VERSION)
+          echo "VERSION=${VERSION}" >> $GITHUB_ENV
+
+      - name: Create and push tag
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+          # Validate semver
+          SEMVER='^([0-9]+)\.([0-9]+)\.([0-9]+)(-rc\.([0-9]+))?$'
+          if [[ ! "${VERSION}" =~ ${SEMVER} ]]; then
+            echo "Invalid VERSION: ${VERSION}"
+            exit 1
+          fi
+
+          TAG="v${VERSION}"
+
+          # Check remote tags (not just local shallow clone)
+          if git ls-remote --tags origin | grep -q "refs/tags/${TAG}$"; then
+            echo "Tag ${TAG} already exists on remote. Skipping."
+            echo "TAG_CREATED=false" >> $GITHUB_ENV
+            exit 0
+          fi
+
+          git tag -a "${TAG}" -m "Release ${TAG}"
+          if git push origin "${TAG}"; then
+            echo "TAG_CREATED=true" >> $GITHUB_ENV
+          else
+            echo "Tag ${TAG} was created by another run. Skipping."
+            echo "TAG_CREATED=false" >> $GITHUB_ENV
+          fi
+
+      - name: Trigger release workflow
+        if: env.TAG_CREATED == 'true'
+        run: gh workflow run goreleaser.yaml --ref develop-v2
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,48 @@
+version: 2
+
+project_name: arena-v2
+
+before:
+  hooks:
+    - make v2-vet
+
+builds:
+  - id: arena-v2
+    main: ./cmd/arena-v2/
+    binary: arena-v2
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    # Keep in sync with Makefile V2_LDFLAGS (Makefile uses shell vars, GoReleaser uses template vars)
+    ldflags:
+      - >-
+        -X github.com/kubeflow/arena/pkg/cli.version={{.Version}}
+        -X github.com/kubeflow/arena/pkg/cli.gitCommit={{.ShortCommit}}
+        -X github.com/kubeflow/arena/pkg/cli.buildDate={{.Date}}
+        -X github.com/kubeflow/arena/pkg/cli.gitTag={{.Tag}}
+        -X github.com/kubeflow/arena/pkg/cli.gitTreeState=clean
+
+archives:
+  - ids: [arena-v2]
+    formats: [tar.gz]
+    name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
+
+checksum:
+  name_template: checksums.txt
+
+changelog:
+  use: github-native
+  sort: asc
+
+release:
+  draft: true
+  prerelease: auto
+  name_template: '{{.Tag}}'
+
+snapshot:
+  version_template: '{{ incpatch .Version }}-dev'

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,8 @@ ARCH ?= $(shell go env GOARCH)
 VERSION ?= $(shell cat VERSION 2>/dev/null || echo "0.0.0-dev")
 BUILD_DATE := $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
 GIT_SHORT_COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+GIT_TAG := $(shell if [ -z "`git status --porcelain`" ]; then git describe --exact-match --tags HEAD 2>/dev/null; fi)
+GIT_TREE_STATE := $(shell if [ -z "`git status --porcelain`" ]; then echo "clean"; else echo "dirty"; fi)
 
 # Location to install binaries
 LOCALBIN ?= $(CURRENT_DIR)/bin
@@ -39,9 +41,12 @@ V2_ALL_PACKAGES := $(V2_PACKAGES) ./cmd/arena-v2/
 GOLANGCI_LINT_VERSION ?= v2.12.2
 
 # Version info injected via ldflags at build time
+# Keep in sync with .goreleaser.yaml ldflags (Makefile uses shell vars, GoReleaser uses template vars)
 V2_LDFLAGS := -X ${PACKAGE}/pkg/cli.version=${VERSION} \
   -X ${PACKAGE}/pkg/cli.gitCommit=${GIT_SHORT_COMMIT} \
-  -X ${PACKAGE}/pkg/cli.buildDate=${BUILD_DATE}
+  -X ${PACKAGE}/pkg/cli.buildDate=${BUILD_DATE} \
+  -X ${PACKAGE}/pkg/cli.gitTag=${GIT_TAG} \
+  -X ${PACKAGE}/pkg/cli.gitTreeState=${GIT_TREE_STATE}
 
 $(LOCALBIN):
 	mkdir -p $(LOCALBIN)
@@ -81,3 +86,7 @@ v2-install: ## Install arena v2 CLI to GOBIN.
 v2-e2e-test: arena-v2 ## Run arena v2 e2e tests (requires real K8s cluster with CRDs installed).
 	@echo "Running arena v2 e2e tests..."
 	go test ./test/e2e/ -v -ginkgo.v -timeout 30m
+
+.PHONY: v2-release-snapshot
+v2-release-snapshot: ## Build arena v2 release snapshot locally (no tag required).
+	@goreleaser release --snapshot --clean

--- a/pkg/cli/version.go
+++ b/pkg/cli/version.go
@@ -7,9 +7,11 @@ import (
 )
 
 var (
-	version   = "dev"
-	gitCommit = "unknown"
-	buildDate = "unknown"
+	version      = "dev"
+	gitCommit    = "unknown"
+	buildDate    = "unknown"
+	gitTag       = ""
+	gitTreeState = "unknown"
 )
 
 var versionCmd = &cobra.Command{
@@ -17,9 +19,11 @@ var versionCmd = &cobra.Command{
 	Short: "Print version information",
 	Run: func(_ *cobra.Command, _ []string) {
 		fmt.Printf("Arena v2\n")
-		fmt.Printf("  Version:    %s\n", version)
-		fmt.Printf("  Git Commit: %s\n", gitCommit)
-		fmt.Printf("  Build Date: %s\n", buildDate)
+		fmt.Printf("  Version:     %s\n", version)
+		fmt.Printf("  Git Commit:  %s\n", gitCommit)
+		fmt.Printf("  Git Tag:     %s\n", gitTag)
+		fmt.Printf("  Build Date:  %s\n", buildDate)
+		fmt.Printf("  Tree State:  %s\n", gitTreeState)
 	},
 }
 

--- a/pkg/cli/version_test.go
+++ b/pkg/cli/version_test.go
@@ -15,21 +15,29 @@ func TestVersionCmd_Output(t *testing.T) {
 	origVersion := version
 	origCommit := gitCommit
 	origDate := buildDate
+	origTag := gitTag
+	origTreeState := gitTreeState
 	defer func() {
 		version = origVersion
 		gitCommit = origCommit
 		buildDate = origDate
+		gitTag = origTag
+		gitTreeState = origTreeState
 	}()
 
 	version = "0.1.0"
 	gitCommit = "abc123"
 	buildDate = "2026-07-01T00:00:00Z"
+	gitTag = "v0.1.0"
+	gitTreeState = "clean"
 
 	// versionCmd uses fmt.Printf (stdout), not cmd.OutOrStdout(),
 	// so we test the variable values directly.
 	assert.Equal(t, "0.1.0", version)
 	assert.Equal(t, "abc123", gitCommit)
 	assert.Equal(t, "2026-07-01T00:00:00Z", buildDate)
+	assert.Equal(t, "v0.1.0", gitTag)
+	assert.Equal(t, "clean", gitTreeState)
 }
 
 func TestVersionCmd_RegisteredOnRoot(t *testing.T) {
@@ -53,4 +61,6 @@ func TestVersionCmd_DefaultValues(t *testing.T) {
 	assert.NotEmpty(t, version, "version should have a default value")
 	assert.NotEmpty(t, gitCommit, "gitCommit should have a default value")
 	assert.NotEmpty(t, buildDate, "buildDate should have a default value")
+	assert.Empty(t, gitTag, "gitTag should default to empty")
+	assert.Equal(t, "unknown", gitTreeState, "gitTreeState should default to unknown")
 }


### PR DESCRIPTION
## Purpose of this PR

Add the complete release workflow infrastructure for Arena v2, including CI/CD pipelines, GitHub issue/PR templates, PR labeling automation, and GoReleaser configuration.

**Proposed changes:**

- Add `tag-release.yaml` workflow: auto-creates git tag when VERSION changes on `develop-v2`, then triggers the release workflow
- Add `goreleaser.yaml` workflow: checks out the release tag and runs GoReleaser to build/publish releases
- Add `.goreleaser.yaml`: cross-compiles `arena-v2` for linux/darwin (amd64/arm64) with ldflags injection
- Add `labeler.yaml` workflow + `labeler.yml` config: auto-labels PRs by branch prefix (feat→Features, fix→Bug Fixes, chores→Maintenance, etc.)
- Add `release.yml`: categorizes GitHub release notes by label
- Update `integration.yaml`: scope to `develop-v2` branch, add VERSION isolation check (VERSION must change alone)
- Add GitHub issue templates (bug report, feature request, question)
- Add PR template with conventional commit guidance and checklist
- Extend `version.go` with `gitTag` and `gitTreeState` fields; update Makefile ldflags and GoReleaser config to inject them
- Add `v2-release-snapshot` Makefile target for local release testing

## Commit Message Format

This project uses [conventional commits](https://www.conventionalcommits.org/) for commit hygiene. The release changelog is driven by PR labels, which are auto-assigned based on your branch name prefix and changed files.

**Example commit messages:**

```
feat: add GPU sharing support for MPIJob
fix: correct pytorch replica count in dry-run output
feat(serving): add vLLM as serving framework
docs: update installation guide for v2
```

> **Note:** PR labels are auto-assigned by the Labeler workflow based on your branch name prefix and changed files. This determines how your change appears in the release changelog — `feat/` branch → Features, `fix/` branch → Bug Fixes, `breaking/` branch → Breaking Changes, `doc/` or `docs/` branch or all files in `docs/`/`examples/` → Documentation, `chore/` or `chores/` branch → Maintenance, `refactor/` branch → Refactoring, `test/`/`ci/` branch, all files are `.github/` CI configs, or only `VERSION` changed → excluded.

## Checklist

- [x] Code follows the project's style guidelines (`make v2-fmt`)
- [x] Code passes vet (`make v2-vet`)
- [x] Code passes lint (`make v2-lint`)
- [x] Tests pass (`make v2-test`)
- [x] `go mod tidy` has been run
- [x] Commit messages follow conventional commit format