### PR TITLE
fix: support hostname LoadBalancer ingress for TensorBoard

### DIFF
--- a/pkg/training/tensorboard.go
+++ b/pkg/training/tensorboard.go
@@ -49,9 +49,15 @@ func tensorboardURL(name, namespace string, services []*corev1.Service, nodes []
 	// Get Address for loadbalancer
 	if service.Spec.Type == corev1.ServiceTypeLoadBalancer {
 		if len(service.Status.LoadBalancer.Ingress) > 0 {
-			return fmt.Sprintf("http://%s:%d",
-				service.Status.LoadBalancer.Ingress[0].IP,
-				service.Spec.Ports[0].Port), nil
+			address := service.Status.LoadBalancer.Ingress[0].IP
+			if address == "" {
+				address = service.Status.LoadBalancer.Ingress[0].Hostname
+			}
+			if address != "" {
+				return fmt.Sprintf("http://%s:%d",
+					address,
+					service.Spec.Ports[0].Port), nil
+			}
 		}
 	}
 

--- a/pkg/training/tensorboard_test.go
+++ b/pkg/training/tensorboard_test.go
@@ -1,0 +1,74 @@
+// Copyright 2026 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package training
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestTensorboardURLUsesLoadBalancerHostname(t *testing.T) {
+	url, err := tensorboardURL("job", "default", []*corev1.Service{{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Labels:    map[string]string{"release": "job"},
+		},
+		Spec: corev1.ServiceSpec{
+			Type:  corev1.ServiceTypeLoadBalancer,
+			Ports: []corev1.ServicePort{{Port: 6006}},
+		},
+		Status: corev1.ServiceStatus{
+			LoadBalancer: corev1.LoadBalancerStatus{
+				Ingress: []corev1.LoadBalancerIngress{{Hostname: "a123456.elb.amazonaws.com"}},
+			},
+		},
+	}}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const want = "http://a123456.elb.amazonaws.com:6006"
+	if url != want {
+		t.Fatalf("got %q, want %q", url, want)
+	}
+}
+
+func TestTensorboardURLUsesLoadBalancerIP(t *testing.T) {
+	url, err := tensorboardURL("job", "default", []*corev1.Service{{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Labels:    map[string]string{"release": "job"},
+		},
+		Spec: corev1.ServiceSpec{
+			Type:  corev1.ServiceTypeLoadBalancer,
+			Ports: []corev1.ServicePort{{Port: 6006}},
+		},
+		Status: corev1.ServiceStatus{
+			LoadBalancer: corev1.LoadBalancerStatus{
+				Ingress: []corev1.LoadBalancerIngress{{IP: "192.0.2.10"}},
+			},
+		},
+	}}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const want = "http://192.0.2.10:6006"
+	if url != want {
+		t.Fatalf("got %q, want %q", url, want)
+	}
+}


### PR DESCRIPTION
## Purpose of this PR

Fix the TensorBoard URL for DNS based LoadBalancer services

Proposed changes:

- Use the ingress hostname when no IP is set
- Add coverage for hostname and IP ingress

## Change Category

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

On AWS style LoadBalancers, `arena get JOB` printed `http://:6006`. It now prints the hostname URL

Reproduce:

1. Enable TensorBoard with a `LoadBalancer` service that has `status.loadBalancer.ingress[0].hostname`
2. Run `arena get JOB`

Before: `http://:6006`
After: `http://a123456.elb.amazonaws.com:6006`