### PR TITLE
fix(helm): process --set-file options in GenerateHelmTemplate

### DIFF
--- a/pkg/util/helm/util.go
+++ b/pkg/util/helm/util.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -190,30 +191,88 @@ func GenerateValueFile(values interface{}) (valueFileName string, err error) {
 
 // GenerateHelmTemplate generates helm manifests with the given valuesFile.
 func GenerateHelmTemplate(name string, namespace string, valuesFile string, chartPath string, options ...string) (templateFileName string, err error) {
-	tempName := fmt.Sprintf("%s.yaml", name)
-	templateFile, err := os.CreateTemp("", tempName)
-	if err != nil {
-		return templateFileName, err
-	}
-	defer templateFile.Close()
-	templateFileName = templateFile.Name()
+    tempName := fmt.Sprintf("%s.yaml", name)
+    templateFile, err := os.CreateTemp("", tempName)
+    if err != nil {
+        return templateFileName, err
+    }
+    defer templateFile.Close()
+    templateFileName = templateFile.Name()
 
-	values, err := chartutil.ReadValuesFile(valuesFile)
-	if err != nil {
-		return templateFileName, fmt.Errorf("failed to read values from file %s: %v", valuesFile, err)
-	}
+    values, err := chartutil.ReadValuesFile(valuesFile)
+    if err != nil {
+        return templateFileName, fmt.Errorf("failed to read values from file %s: %v", valuesFile, err)
+    }
 
-	release, err := Template(name, namespace, chartPath, values)
-	if err != nil {
-		return templateFileName, fmt.Errorf("failed to generate helm manifests %s: %v", name, err)
-	}
+    // Process --set-file options to read file contents into the values map
+    if len(options) > 0 {
+        if err := processSetFileOptions(values, options); err != nil {
+            return templateFileName, fmt.Errorf("failed to process set-file options: %v", err)
+        }
+    }
 
-	_, err = templateFile.WriteString(release.Manifest)
-	if err != nil {
-		return templateFileName, fmt.Errorf("failed to write helm manifests to file %s: %v", templateFileName, err)
-	}
+    release, err := Template(name, namespace, chartPath, values)
+    if err != nil {
+        return templateFileName, fmt.Errorf("failed to generate helm manifests %s: %v", name, err)
+    }
 
-	return templateFileName, nil
+    _, err = templateFile.WriteString(release.Manifest)
+    if err != nil {
+        return templateFileName, fmt.Errorf("failed to write helm manifests to file %s: %v", templateFileName, err)
+    }
+
+    return templateFileName, nil
+}
+
+// processSetFileOptions parses --set-file options, reads the file contents,
+// and merges them into the Helm values map.
+func processSetFileOptions(values map[string]interface{}, options []string) error {
+    for _, opt := range options {
+        // Strip the --set-file prefix if it is present
+        opt = strings.TrimPrefix(opt, "--set-file ")
+        opt = strings.TrimPrefix(opt, "--set-file=")
+
+        // Split into key and file path
+        parts := strings.SplitN(opt, "=", 2)
+        if len(parts) != 2 {
+            continue // Skip malformed options
+        }
+        key := parts[0]
+        filePath := parts[1]
+
+        // Read the file content
+        content, err := os.ReadFile(filePath)
+        if err != nil {
+            return fmt.Errorf("failed to read set-file %s: %v", filePath, err)
+        }
+
+        // Merge into values map at nested keys
+        setNestedValue(values, key, string(content))
+    }
+    return nil
+}
+
+// setNestedValue sets a value in a map at a given dotted key path (e.g. "a.b.c").
+func setNestedValue(values map[string]interface{}, key string, value interface{}) {
+    parts := strings.Split(key, ".")
+    current := values
+    for i, part := range parts {
+        if i == len(parts)-1 {
+            current[part] = value
+        } else {
+            if _, ok := current[part]; !ok {
+                current[part] = make(map[string]interface{})
+            }
+            if next, ok := current[part].(map[string]interface{}); ok {
+                current = next
+            } else {
+                // Overwrite non-map types with a map to proceed
+                newMap := make(map[string]interface{})
+                current[part] = newMap
+                current = newMap
+            }
+        }
+    }
 }
 
 // GetChartName returns the name of the chart.

--- a/pkg/util/helm/util.go
+++ b/pkg/util/helm/util.go
@@ -15,6 +15,7 @@
 package helm
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -191,88 +192,37 @@ func GenerateValueFile(values interface{}) (valueFileName string, err error) {
 
 // GenerateHelmTemplate generates helm manifests with the given valuesFile.
 func GenerateHelmTemplate(name string, namespace string, valuesFile string, chartPath string, options ...string) (templateFileName string, err error) {
-    tempName := fmt.Sprintf("%s.yaml", name)
-    templateFile, err := os.CreateTemp("", tempName)
-    if err != nil {
-        return templateFileName, err
-    }
-    defer templateFile.Close()
-    templateFileName = templateFile.Name()
+	tempName := fmt.Sprintf("%s.yaml", name)
+	templateFile, err := os.CreateTemp("", tempName)
+	if err != nil {
+		return templateFileName, err
+	}
+	defer templateFile.Close()
+	templateFileName = templateFile.Name()
 
-    values, err := chartutil.ReadValuesFile(valuesFile)
-    if err != nil {
-        return templateFileName, fmt.Errorf("failed to read values from file %s: %v", valuesFile, err)
-    }
+	values, err := chartutil.ReadValuesFile(valuesFile)
+	if err != nil {
+		return templateFileName, fmt.Errorf("failed to read values from file %s: %v", valuesFile, err)
+	}
 
-    // Process --set-file options to read file contents into the values map
-    if len(options) > 0 {
-        if err := processSetFileOptions(values, options); err != nil {
-            return templateFileName, fmt.Errorf("failed to process set-file options: %v", err)
-        }
-    }
+	// Process --set-file options to read file contents into the values map
+	if len(options) > 0 {
+		if err := processSetFileOptions(values, options); err != nil {
+			return templateFileName, fmt.Errorf("failed to process set-file options: %w", err)
+		}
+	}
 
-    release, err := Template(name, namespace, chartPath, values)
-    if err != nil {
-        return templateFileName, fmt.Errorf("failed to generate helm manifests %s: %v", name, err)
-    }
+	release, err := Template(name, namespace, chartPath, values)
+	if err != nil {
+		return templateFileName, fmt.Errorf("failed to generate helm manifests %s: %v", name, err)
+	}
 
-    _, err = templateFile.WriteString(release.Manifest)
-    if err != nil {
-        return templateFileName, fmt.Errorf("failed to write helm manifests to file %s: %v", templateFileName, err)
-    }
+	_, err = templateFile.WriteString(release.Manifest)
+	if err != nil {
+		return templateFileName, fmt.Errorf("failed to write helm manifests to file %s: %v", templateFileName, err)
+	}
 
-    return templateFileName, nil
-}
-
-// processSetFileOptions parses --set-file options, reads the file contents,
-// and merges them into the Helm values map.
-func processSetFileOptions(values map[string]interface{}, options []string) error {
-    for _, opt := range options {
-        // Strip the --set-file prefix if it is present
-        opt = strings.TrimPrefix(opt, "--set-file ")
-        opt = strings.TrimPrefix(opt, "--set-file=")
-
-        // Split into key and file path
-        parts := strings.SplitN(opt, "=", 2)
-        if len(parts) != 2 {
-            continue // Skip malformed options
-        }
-        key := parts[0]
-        filePath := parts[1]
-
-        // Read the file content
-        content, err := os.ReadFile(filePath)
-        if err != nil {
-            return fmt.Errorf("failed to read set-file %s: %v", filePath, err)
-        }
-
-        // Merge into values map at nested keys
-        setNestedValue(values, key, string(content))
-    }
-    return nil
-}
-
-// setNestedValue sets a value in a map at a given dotted key path (e.g. "a.b.c").
-func setNestedValue(values map[string]interface{}, key string, value interface{}) {
-    parts := strings.Split(key, ".")
-    current := values
-    for i, part := range parts {
-        if i == len(parts)-1 {
-            current[part] = value
-        } else {
-            if _, ok := current[part]; !ok {
-                current[part] = make(map[string]interface{})
-            }
-            if next, ok := current[part].(map[string]interface{}); ok {
-                current = next
-            } else {
-                // Overwrite non-map types with a map to proceed
-                newMap := make(map[string]interface{})
-                current[part] = newMap
-                current = newMap
-            }
-        }
-    }
+	return templateFileName, nil
 }
 
 // GetChartName returns the name of the chart.
@@ -296,3 +246,99 @@ func toYaml(values interface{}, file *os.File) error {
 	}
 	return err
 }
+
+// processSetFileOptions parses --set-file options from the given slice,
+// reads the referenced file contents from disk, and merges them into the
+// supplied values map. Only options whose token begins with "--set-file"
+// are processed; any other entries (e.g. --set, --namespace) are ignored
+// so callers may pass a mixed slice of Helm options safely.
+//
+// Each --set-file entry must be in one of the following forms:
+//
+//	--set-file key=path
+//	--set-file=key=path
+//
+// where "key" is a dotted path into the values map (e.g.
+// "configFiles.<hash>.config-N.content") and "path" points to a file on
+// disk whose contents will be injected as a string value.
+//
+// If an intermediate key in the dotted path already exists in the values
+// map but is not itself a map[string]interface{}, processSetFileOptions
+// returns an error to avoid silently dropping user-supplied values.
+// Malformed options and unreadable files also produce errors.
+func processSetFileOptions(values map[string]interface{}, options []string) error {
+	for _, opt := range options {
+		if !strings.HasPrefix(opt, "--set-file") {
+			continue
+		}
+
+		var assignment string
+		switch {
+		case strings.HasPrefix(opt, "--set-file="):
+			assignment = strings.TrimPrefix(opt, "--set-file=")
+		case opt == "--set-file":
+			return fmt.Errorf("malformed --set-file option %q: expected key=path", opt)
+		default:
+			// "--set-file key=path" form: strip the flag token and any
+			// whitespace separating it from the key=value assignment.
+			assignment = strings.TrimSpace(strings.TrimPrefix(opt, "--set-file"))
+		}
+
+		idx := strings.Index(assignment, "=")
+		if idx <= 0 || idx == len(assignment)-1 {
+			return fmt.Errorf("malformed --set-file option %q: expected key=path", opt)
+		}
+		key := strings.TrimSpace(assignment[:idx])
+		filePath := strings.TrimSpace(assignment[idx+1:])
+		if key == "" || filePath == "" {
+			return fmt.Errorf("malformed --set-file option %q: expected key=path", opt)
+		}
+
+		content, err := os.ReadFile(filePath)
+		if err != nil {
+			return fmt.Errorf("failed to read --set-file %q: %w", filePath, err)
+		}
+
+		if err := setNestedValue(values, key, string(content)); err != nil {
+			return fmt.Errorf("failed to set --set-file value for %q: %w", key, err)
+		}
+	}
+	return nil
+}
+
+// setNestedValue sets a value in a map at a given dotted key path (e.g. "a.b.c").
+// If an intermediate key already exists in the values map but is not a
+// map[string]interface{}, an error is returned to prevent silent data loss.
+func setNestedValue(values map[string]interface{}, key string, value interface{}) error {
+	parts := strings.Split(key, ".")
+	current := values
+
+	for i, part := range parts {
+		if part == "" {
+			return fmt.Errorf("empty key segment in %q", key)
+		}
+
+		isLast := i == len(parts)-1
+		if isLast {
+			current[part] = value
+			return nil
+		}
+
+		next, ok := current[part]
+		if !ok {
+			child := map[string]interface{}{}
+			current[part] = child
+			current = child
+			continue
+		}
+
+		child, ok := next.(map[string]interface{})
+		if !ok {
+			return fmt.Errorf("cannot set %q: intermediate key %q is not a map (got %T): %w", key, part, next, errIntermediateNotMap)
+		}
+		current = child
+	}
+	return nil
+}
+
+var errIntermediateNotMap = errors.New("intermediate value is not a map")

--- a/pkg/util/helm/util_test.go
+++ b/pkg/util/helm/util_test.go
@@ -1,0 +1,199 @@
+// Copyright 2018 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// Copyright 2024 The Kubeflow Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package helm
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestProcessSetFileOptions(t *testing.T) {
+	dir := t.TempDir()
+
+	fooPath := filepath.Join(dir, "foo.txt")
+	if err := os.WriteFile(fooPath, []byte("foo-content"), 0o644); err != nil {
+		t.Fatalf("write foo: %v", err)
+	}
+
+	barPath := filepath.Join(dir, "bar.txt")
+	if err := os.WriteFile(barPath, []byte("bar-content"), 0o644); err != nil {
+		t.Fatalf("write bar: %v", err)
+	}
+
+	t.Run("happy path single nested key", func(t *testing.T) {
+		vals := map[string]interface{}{}
+		opts := []string{fmt.Sprintf("--set-file configFiles.abc.content=%s", fooPath)}
+		if err := processSetFileOptions(vals, opts); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		got, ok := getNestedString(vals, "configFiles", "abc", "content")
+		if !ok {
+			t.Fatalf("value not set; got %#v", vals)
+		}
+		if got != "foo-content" {
+			t.Fatalf("expected foo-content, got %q", got)
+		}
+	})
+
+	t.Run("nested keys merge into existing map without data loss", func(t *testing.T) {
+		vals := map[string]interface{}{
+			"configFiles": map[string]interface{}{
+				"existing": map[string]interface{}{
+					"keep": "keep-val",
+				},
+			},
+		}
+		opts := []string{
+			fmt.Sprintf("--set-file configFiles.existing.content=%s", fooPath),
+			fmt.Sprintf("--set-file configFiles.other.content=%s", barPath),
+		}
+		if err := processSetFileOptions(vals, opts); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if v, ok := getNestedString(vals, "configFiles", "existing", "keep"); !ok || v != "keep-val" {
+			t.Fatalf("expected pre-existing 'keep' value to be preserved; got %#v", vals)
+		}
+		if v, ok := getNestedString(vals, "configFiles", "existing", "content"); !ok || v != "foo-content" {
+			t.Fatalf("expected new content for 'existing'; got %#v", vals)
+		}
+		if v, ok := getNestedString(vals, "configFiles", "other", "content"); !ok || v != "bar-content" {
+			t.Fatalf("expected content for 'other'; got %#v", vals)
+		}
+	})
+
+	t.Run("ignores non --set-file options", func(t *testing.T) {
+		vals := map[string]interface{}{}
+		opts := []string{
+			"--set foo=bar",
+			fmt.Sprintf("--set-file configFiles.abc.content=%s", fooPath),
+			"--namespace default",
+			"--debug",
+		}
+		if err := processSetFileOptions(vals, opts); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if _, exists := vals["foo"]; exists {
+			t.Fatalf("--set option must not be processed as a set-file; got %#v", vals)
+		}
+		if _, exists := vals["namespace"]; exists {
+			t.Fatalf("--namespace option must not be processed; got %#v", vals)
+		}
+		if v, ok := getNestedString(vals, "configFiles", "abc", "content"); !ok || v != "foo-content" {
+			t.Fatalf("expected set-file content to be applied; got %#v", vals)
+		}
+	})
+
+	t.Run("supports --set-file=key=path form", func(t *testing.T) {
+		vals := map[string]interface{}{}
+		opts := []string{fmt.Sprintf("--set-file=configFiles.abc.content=%s", fooPath)}
+		if err := processSetFileOptions(vals, opts); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if v, ok := getNestedString(vals, "configFiles", "abc", "content"); !ok || v != "foo-content" {
+			t.Fatalf("expected content via equals-form flag; got %#v", vals)
+		}
+	})
+
+	t.Run("missing file returns wrapped error", func(t *testing.T) {
+		vals := map[string]interface{}{}
+		missing := filepath.Join(dir, "does-not-exist.txt")
+		opts := []string{fmt.Sprintf("--set-file key=%s", missing)}
+		err := processSetFileOptions(vals, opts)
+		if err == nil {
+			t.Fatal("expected error for missing file, got nil")
+		}
+		if !strings.Contains(err.Error(), "failed to read") {
+			t.Fatalf("expected error to mention read failure; got %v", err)
+		}
+	})
+
+	t.Run("malformed option missing equals returns error", func(t *testing.T) {
+		vals := map[string]interface{}{}
+		opts := []string{"--set-file no-equals-sign"}
+		if err := processSetFileOptions(vals, opts); err == nil {
+			t.Fatal("expected error for malformed option, got nil")
+		}
+	})
+
+	t.Run("empty key returns error", func(t *testing.T) {
+		vals := map[string]interface{}{}
+		opts := []string{fmt.Sprintf("--set-file =%s", fooPath)}
+		if err := processSetFileOptions(vals, opts); err == nil {
+			t.Fatal("expected error for empty key, got nil")
+		}
+	})
+
+	t.Run("intermediate non-map value returns error instead of overwriting", func(t *testing.T) {
+		vals := map[string]interface{}{
+			"configFiles": "already-a-string",
+		}
+		opts := []string{fmt.Sprintf("--set-file configFiles.abc.content=%s", fooPath)}
+		err := processSetFileOptions(vals, opts)
+		if err == nil {
+			t.Fatal("expected error for non-map intermediate key, got nil")
+		}
+		// Verify the pre-existing scalar was NOT overwritten.
+		if s, ok := vals["configFiles"].(string); !ok || s != "already-a-string" {
+			t.Fatalf("pre-existing scalar should be preserved on error; got %#v", vals["configFiles"])
+		}
+	})
+
+	t.Run("empty segment in dotted key returns error", func(t *testing.T) {
+		vals := map[string]interface{}{}
+		opts := []string{fmt.Sprintf("--set-file configFiles..content=%s", fooPath)}
+		if err := processSetFileOptions(vals, opts); err == nil {
+			t.Fatal("expected error for empty key segment, got nil")
+		}
+	})
+}
+
+// getNestedString is a small test helper that walks a nested
+// map[string]interface{} chain and returns the terminal string value.
+func getNestedString(vals map[string]interface{}, parts ...string) (string, bool) {
+	current := vals
+	for i, p := range parts {
+		v, ok := current[p]
+		if !ok {
+			return "", false
+		}
+		if i == len(parts)-1 {
+			s, ok := v.(string)
+			return s, ok
+		}
+		m, ok := v.(map[string]interface{})
+		if !ok {
+			return "", false
+		}
+		current = m
+	}
+	return "", false
+}

--- a/pkg/util/helm/util_test.go
+++ b/pkg/util/helm/util_test.go
@@ -1,16 +1,3 @@
-// Copyright 2018 The Kubeflow Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//       http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
 // Copyright 2024 The Kubeflow Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
## Purpose of this PR

Fixes (#1434) the `arena serve kserve --config-file` Helm template rendering error (`invalid value; expected string`).

As described in the issue, the migration to the Helm Go SDK in commit `19b5133e` broke `--config-file`. The `GenerateHelmTemplate()` function accepts an `options` parameter (which contains `--set-file` options generated from `--config-file`), but never uses it. This causes the Helm template to receive `nil` instead of the file content, leading to the rendering error.

**Proposed changes:**

- Added a `processSetFileOptions()` function in `pkg/util/helm/util.go` that parses `--set-file` options, reads the referenced file contents from disk, and merges them into the values map.
- Added a `setNestedValue()` helper function to correctly set dotted keys (e.g., `configFiles.<hash>.config-N.content`) into the nested map structure.
- Modified `GenerateHelmTemplate()` to call `processSetFileOptions()` when options are present.
- Added a unit test `TestProcessSetFileOptions` in `pkg/util/helm/util_test.go` to verify the file content is correctly nested into the values map.

This restores the `--config-file` functionality without requiring the `--helm-binary=true` workaround, and maintains backward compatibility.

## Change Category

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that could affect existing functionality)
- [ ] Documentation update

### Rationale

The root cause was that the `GenerateHelmTemplate` function ignored the `options` parameter entirely after migrating from the Helm CLI to the Helm Go SDK. By processing these options the same way the Helm CLI does (reading the file content and injecting it into the values map), the template receives the expected string content and renders successfully.
