### PR TITLE
docs: correct quoting of dotted resource keys in docs

### DIFF
--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -50,12 +50,12 @@ worker:
 arena job run -f train.yaml --set worker.replicas=8
 
 # Override GPU count — quote the resource key because it contains dots
-arena job run -f train.yaml --set worker.resources.'nvidia.com/gpu'=2
+arena job run -f train.yaml --set worker.resources.\'nvidia.com/gpu\'=2
 
 # Override multiple fields at once
 arena job run -f train.yaml \
   --set worker.replicas=2 \
-  --set worker.resources.'nvidia.com/gpu'=1 \
+  --set worker.resources.\'nvidia.com/gpu\'=1 \
   --set envs.NCCL_DEBUG=INFO
 ```
 
@@ -456,7 +456,7 @@ arena submit pytorchjob --name exp01 --workers 5 --gpus 2 --cpu 8 --memory 32Gi 
 arena job run -f train.yaml \
   --set name=exp01 \
   --set worker.replicas=4 \
-  --set worker.resources.'nvidia.com/gpu'=2
+  --set worker.resources.\'nvidia.com/gpu\'=2
 ```
 
 ### No Helm dependency in v2

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -71,7 +71,7 @@ Solution: Add a `run` field to your YAML (e.g. `run: python -c "print('Hello')"`
 ### Q: How do I use `--set` with resource names containing dots (e.g. `nvidia.com/gpu`)?
 Use single quotes around the dotted segment:
 ```bash
-arena job run -f job.yaml --set worker.resources.'nvidia.com/gpu'=2
+arena job run -f job.yaml --set worker.resources.\'nvidia.com/gpu\'=2
 ```
 Single-quoted segments are treated as literal keys and not split on dots. See [yaml-schema.md](yaml-schema.md) for the full `--set` syntax.
 
@@ -81,7 +81,7 @@ Solution: Use the format `--set key=value`, e.g. `--set worker.replicas=4`.
 
 ### Q: `failed to parse --set "'foo": mismatched single quote in expression`
 Cause: A single-quoted segment in the `--set` expression is missing its closing quote.
-Solution: Ensure every opening single quote has a matching closing quote, e.g. `--set worker.resources.'nvidia.com/gpu'=2`.
+Solution: Ensure every opening single quote has a matching closing quote, e.g. `--set worker.resources.\'nvidia.com/gpu\'=2`.
 
 ### Q: What should the `version` field in YAML be?
 The current schema version is `0.1.0` (format: `MAJOR.MINOR.PATCH`). If omitted, it defaults to `0.1.0` automatically. Using a version newer than `0.1.x` produces: `version "0.2.0" is newer than supported (current: 0.1.x)`.
@@ -144,7 +144,7 @@ Solution: Check logs with `arena job logs <name>` to identify the application er
 
 ### Q: Pods stuck in "Pending"
 Cause: The Kubernetes scheduler cannot find suitable nodes for the pods. This is often due to GPU shortage, node selector mismatch, or insufficient resources.
-Solution: Run `kubectl describe pod <pod-name>` and check the Events section for scheduling failures. Verify GPU availability with `kubectl get nodes -o custom-columns=NAME:.metadata.name,GPUS:.status.capacity['nvidia\.com/gpu']`.
+Solution: Run `kubectl describe pod <pod-name>` and check the Events section for scheduling failures. Verify GPU availability with `kubectl get nodes -o "custom-columns=NAME:.metadata.name,GPUS:.status.capacity['nvidia\.com/gpu']"`.
 
 ### Q: Job status shows "Suspended"
 Cause: The job has the `suspend` lifecycle field set to `true`. Suspended jobs do not launch any pods.

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -156,7 +156,7 @@ Field names in v2 use `snake_case` per the schema specification.
 
 | v1 Flag | v2 YAML Field | Notes |
 |---------|---------------|-------|
-| `--gpus` | `worker.resources.nvidia.com/gpu` | String value (e.g. `"1"`). |
+| `--gpus` | `worker.resources.'nvidia.com/gpu'` | String value (e.g. `"1"`). |
 | `--cpu` | `worker.resources.cpu` | String value. |
 | `--memory` | `worker.resources.memory` | String value (e.g. `"8Gi"`). |
 | `--device` | `worker.resources.<device-name>` | v1 `--device vendor.com/device=count` maps to v2 flat `vendor.com/device: count` in `resources`. e.g. `--device hugepages-2Mi=32Gi`. |
@@ -257,7 +257,7 @@ overriding storage mount points.
 | `--ps` (count) | `ps.replicas` | Integer. |
 | `--ps-cpu`, `--ps-cpu-limit` | `ps.resources.cpu` | |
 | `--ps-memory`, `--ps-memory-limit` | `ps.resources.memory` | |
-| `--ps-gpus` | `ps.resources.nvidia.com/gpu` | |
+| `--ps-gpus` | `ps.resources.'nvidia.com/gpu'` | |
 | `--chief` (bool) | `chief` | Presence of `chief` block enables the role. |
 | `--chief-cpu`, `--chief-memory`, etc. | `chief.resources` | |
 | `--evaluator` (bool) | `evaluator` | Presence of `evaluator` block enables the role. |

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -183,7 +183,7 @@ pytorch-example   Running   0              3/3       5m
 mpi-resnet        Running   2              3/3       1h
 ```
 
-The **GPU_REQUESTED** column is the total GPUs requested across all roles, calculated as `replicas × per-pod GPU` (from `resources.requests["nvidia.com/gpu"]` on the first container of each role). For example, a job with 2 workers each requesting 2 GPUs shows `4`.
+The **GPU_REQUESTED** column is the total GPUs requested across all roles, calculated as `replicas × per-pod GPU`. For example, a job with 2 workers each requesting 2 GPUs shows `4`.
 
 Use the wide format for namespace, framework, and API version detail:
 


### PR DESCRIPTION
  ## Purpose of this PR

  The `--set` expression syntax uses single-quoted segments for keys containing dots (e.g. `nvidia.com/gpu`), but the docs were inconsistent: shell examples showed bare single quotes that break on copy-paste, and migration tables listed the resource key unquoted.

  **Proposed changes:**

  - Fix shell escaping in `--set` examples so single-quoted segments are escaped with backslashes (`\'nvidia.com/gpu\'`) in best-practices.md and faq.md
  - Add single quotes around `nvidia.com/gpu` in the v1→v2 resource-mapping tables in migration.md
  - Fix kubectl `custom-columns` argument to be double-quoted in faq.md
  - Simplify the `GPU_REQUESTED` description in monitoring.md

  ## Checklist 

  - [x] Commit messages follow conventional commit format