### PR TITLE
fix(affinity): correct K8s semantics for node spread/binpack

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -63,19 +63,77 @@ scheduling:
 
 ### affinity
 
-`affinity` uses an orthogonal `policy x constraint x target` design (see
-[yaml-schema.md](yaml-schema.md) for the design rationale):
+`affinity` uses an orthogonal `target × policy × constraint` design:
 
-- **policy** (`none` | `spread` | `binpack`): scheduling intent. Defaults to
-  `none`. When not `none`, `rules[]` is required.
+- **target** (`pod` | `node`): determines the topology domain. `pod` uses
+  `topology_key` (user-specified: hostname, zone, rack). `node` uses hostname
+  (fixed). Required when `policy` is not `none`.
+- **policy** (`none` | `spread` | `binpack`): distribution strategy. `spread`
+  distributes pods across topology domains; `binpack` concentrates them into
+  the same domain. Defaults to `none`. When `none` or unset, no affinity is
+  generated — any `rules` are ignored with a warning.
 - **constraint** (`preferred` | `required`): strength. Maps to Kubernetes
   preferred/required scheduling. Defaults to `preferred`. `preferred` rules must
   set `weight` between 1 and 100.
-- **target** (`pod` | `node`): generates podAffinity or nodeAffinity. Required
-  when `rules[]` is present.
-- **rules[]**: direct mapping of native Kubernetes affinity fields
-  (`topology_key`, `weight`, `match_expressions`, `match_fields`,
-  `match_labels`, `namespaces`, `namespace_selector`).
+- **rules[]**: scope selection. Required for `target: pod` (defines which pods
+  to match and the topology domain). Optional for `target: node` (adds
+  nodeAffinity to limit eligible nodes; omit to apply distribution to all
+  nodes).
+
+**K8s mechanisms generated:**
+
+| target | policy | K8s mechanism |
+|---|---|---|
+| pod | spread | podAntiAffinity |
+| pod | binpack | podAffinity |
+| node | spread | topologySpreadConstraints (+ optional nodeAffinity) |
+| node | binpack | podAffinity (+ optional nodeAffinity) |
+
+For `node` + `binpack` with `constraint: preferred`, the generated self
+podAffinity always uses weight 100; rule `weight` values only apply to the
+nodeAffinity preferences derived from `rules[]`.
+
+For `target: node`, the generated podAffinity/topologySpreadConstraints use a self-referential labelSelector and a hardcoded `kubernetes.io/hostname` topologyKey — see [YAML Schema — Scheduling](yaml-schema.md#scheduling) for details.
+
+**Multiple node rules are ORed.** Each rule becomes one `nodeSelectorTerm`, and
+Kubernetes treats multiple terms as OR (a node matching *any* rule is eligible),
+while `match_expressions` *within* one rule are ANDed. To require all
+conditions, put them in a single rule:
+
+```yaml
+# OR: nodes with A100 GPUs, OR nodes in us-east-1a
+rules:
+  - match_expressions:
+      - {key: gpu-type, operator: In, values: [A100]}
+  - match_expressions:
+      - {key: topology.kubernetes.io/zone, operator: In, values: [us-east-1a]}
+
+# AND: nodes with A100 GPUs in us-east-1a
+rules:
+  - match_expressions:
+      - {key: gpu-type, operator: In, values: [A100]}
+      - {key: topology.kubernetes.io/zone, operator: In, values: [us-east-1a]}
+```
+
+For OR over values of the *same* key, prefer a single expression with
+`operator: In` and multiple `values`.
+
+**How rules interact with spread.** With `constraint: required`, the scheduler
+first filters nodes by the rules-derived nodeAffinity, then computes spread skew
+only over the eligible nodes (the default `nodeAffinityPolicy: Honor` behavior).
+With `constraint: preferred`, nodeAffinity is a scoring preference and does not
+narrow the spread domains — both constraints are soft, so this only affects
+scoring, never schedulability.
+
+**All pods of the job count toward spread/binpack.** The self-referential
+labelSelector matches every pod carrying the job's
+`training.kubeflow.org/job-name` label — including the PyTorch master and the
+MPI launcher, not just workers. For MPI jobs, the launcher occupies one slot in
+the `maxSkew: 1` calculation, which can slightly skew worker distribution.
+This label is injected by training-operator (>= v1.5) and mpi-operator
+v2beta1; the legacy standalone mpi-operator v1 labels pods `mpi-job-name`
+instead, so `target: node` spread/binpack self-selectors silently never match
+there.
 
 ### Complete scheduling example
 

--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -63,7 +63,7 @@ See [yaml-schema.md](yaml-schema.md) for the full field reference.
 
 ### Always dry-run before submitting
 
-`--dry-run` builds the CRD (and TensorBoard resources if enabled) and prints them as JSON without touching the cluster. Use it to validate field values, verify provider mapping, and catch schema errors early.
+`--dry-run` builds the CRD (and TensorBoard resources if enabled) and prints them as JSON or YAML without touching the cluster. Use it to validate field values, verify provider mapping, and catch schema errors early.
 
 ```shell
 arena job run -f train.yaml --dry-run

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -43,7 +43,7 @@ arena job run -f <file> [flags]
 | Flag | Shorthand | Type | Default | Description |
 |------|-----------|------|---------|-------------|
 | `--file` | `-f` | string | `""` | Path to YAML file (required) |
-| `--dry-run` | | bool | `false` | Print CRD as JSON without submitting |
+| `--dry-run` | | bool | `false` | Print CRD as JSON or YAML without submitting |
 | `--set` | | stringArray | `nil` | Override YAML field (Helm-style: `key=value`, repeatable) |
 
 Also inherits [global flags](#global-flags) and `--output` from `arena job`.
@@ -67,7 +67,7 @@ $ arena job run -f examples/v2/quickstart/pytorch-simple.yaml --dry-run
 Job pytorch-simple submitted successfully
 ```
 
-With `--dry-run`, the generated CRD is printed as indented JSON. If TensorBoard is enabled, the Deployment and Service resources are also printed, separated by `---`.
+With `--dry-run`, the generated CRD is printed as indented JSON (default) or YAML (`-o yaml`). If TensorBoard is enabled, the Deployment and Service resources are also printed, separated by `---`.
 
 ---
 
@@ -518,11 +518,12 @@ Trailing arguments after `--` are used as the run command.
 
 **Dry-run:**
 
-| Flag | Type | Default | Description |
-|------|------|---------|-------------|
-| `--dry-run` | bool | `false` | Print CRD as JSON without submitting |
+| Flag | Shorthand | Type | Default | Description |
+|------|-----------|------|---------|-------------|
+| `--dry-run` | | bool | `false` | Print CRD as JSON or YAML without submitting |
+| `--output` | `-o` | string | `json` (when `--dry-run`) | Dry-run output format: `json` or `yaml` |
 
-Also inherits [global flags](#global-flags) and `--output` from `arena job`.
+Also inherits [global flags](#global-flags).
 
 ### Examples
 

--- a/docs/yaml-schema.md
+++ b/docs/yaml-schema.md
@@ -203,35 +203,49 @@ scheduling:
 
 | Dimension | Values | Description |
 |---|---|---|
-| `policy` | `none`, `spread`, `binpack` | Scheduling intent. Default: `none`. |
+| `policy` | `none`, `spread`, `binpack` | Scheduling intent. Default: `none`. `spread` = distribute across topology domains; `binpack` = concentrate into same domain. When `none` or unset, no affinity is generated — any `rules` are ignored with a warning. |
 | `constraint` | `preferred`, `required` | Strength (preferred vs required). Default: `preferred`. |
-| `target` | `pod`, `node` | Generate podAffinity or nodeAffinity. Required when `policy` is not `none`. |
+| `target` | `pod`, `node` | Topology domain. `pod` = user-specified via `topology_key`; `node` = hostname (fixed). Required when `policy` is not `none`. |
 
-`rules[]` is required when `policy` is not `none` and maps directly to K8s affinity rule fields:
+`rules[]` is required when `policy` is not `none` and `target` is `pod`. For `target: node`, rules are optional (they add nodeAffinity to limit eligible nodes). Multiple node rules are ORed (a node matching any rule is eligible); conditions within one rule are ANDed — see [Advanced — affinity](advanced.md#affinity).
 
 | Rule field | Applies to | Description |
 |---|---|---|
 | `weight` | preferred constraint | Weight (1-100). |
-| `topology_key` | target: pod | Topology domain key. |
-| `match_labels` | both | Label match. |
+| `topology_key` | target: pod | Topology domain key (e.g. `kubernetes.io/hostname`, `topology.kubernetes.io/zone`). Defaults to `kubernetes.io/hostname` if omitted. |
+| `match_labels` | both | Label match. pod: match pods; node: select nodes (nodeAffinity). |
 | `match_expressions` | both | Label selector requirements (key, operator, values). |
-| `match_fields` | target: node | Node field selector. |
+| `match_fields` | target: node | Node field selector (e.g. `metadata.name`). |
 | `namespaces` | target: pod | Filter namespaces by name. |
 | `namespace_selector` | target: pod | Filter namespaces by label selector. |
+
+**K8s mechanism mapping:**
+
+| target | policy | K8s mechanism |
+|---|---|---|
+| pod | spread | podAntiAffinity |
+| pod | binpack | podAffinity |
+| node | spread | topologySpreadConstraints (+ optional nodeAffinity) |
+| node | binpack | podAffinity (+ optional nodeAffinity) |
+
+For `target: node`, the generated podAffinity (binpack) and topologySpreadConstraints (spread) use a **self-referential labelSelector** — they match pods carrying the `training.kubeflow.org/job-name` label (injected by the Kubeflow Training Operator onto all pods it creates) to co-locate or spread pods from the same job. The `topologyKey` is hardcoded to `kubernetes.io/hostname`.
 
 ```yaml
 scheduling:
   affinity:
-    policy: spread                   # Spread pods across topology domains
-    constraint: preferred            # Best-effort (not hard requirement)
-    target: node                     # Use nodeAffinity
+    policy: spread
+    constraint: preferred
+    target: node                     # Spread across nodes (hostname topology)
+    # rules optional for target: node — omit to spread across all nodes
     rules:
-      - weight: 1
+      - weight: 100
+        match_labels:
+          accelerator: nvidia
         match_fields:
           - key: metadata.name
             operator: In
             values:
-              - node-1
+              - node-gpu-01
 ```
 
 ### Storage

--- a/pkg/cli/helpers.go
+++ b/pkg/cli/helpers.go
@@ -1,36 +1,82 @@
 package cli
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
 
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/kubeflow/arena/pkg/client"
 	"github.com/kubeflow/arena/pkg/constants"
 	"github.com/kubeflow/arena/pkg/log"
+	outputpkg "github.com/kubeflow/arena/pkg/output"
 	"github.com/kubeflow/arena/pkg/provider"
 	"github.com/kubeflow/arena/pkg/task"
 )
 
-// printCRD marshals a CRD as indented JSON and prints it to stdout.
-func printCRD(crd *unstructured.Unstructured) error {
-	data, err := json.MarshalIndent(crd.Object, "", "  ")
-	if err != nil {
-		return fmt.Errorf("failed to marshal CRD: %w", err)
+// dryRunFormat returns the output format for dry-run.
+// Only json and yaml are meaningful for CRD output.
+func dryRunFormat() (outputpkg.Format, error) {
+	f := outputpkg.Format(outputFormat)
+	switch f {
+	case outputpkg.FormatYAML, outputpkg.FormatJSON:
+		return f, nil
+	default:
+		return "", fmt.Errorf("dry-run only supports -o json or yaml, got %q", outputFormat)
 	}
-	fmt.Println(string(data))
+}
+
+// applyDryRunOutputDefault switches the shared output format from the table
+// default to json when --dry-run is set and the user did not pass -o/--output.
+func applyDryRunOutputDefault(cmd *cobra.Command, dryRun bool) {
+	if dryRun && !cmd.Flags().Changed("output") {
+		outputFormat = string(outputpkg.FormatJSON)
+	}
+}
+
+// printCRD marshals a CRD as indented JSON or YAML and prints it to stdout.
+func printCRD(crd *unstructured.Unstructured, format outputpkg.Format) error {
+	switch format {
+	case outputpkg.FormatYAML:
+		var buf bytes.Buffer
+		enc := yaml.NewEncoder(&buf)
+		enc.SetIndent(2)
+		if err := enc.Encode(crd.Object); err != nil {
+			return fmt.Errorf("failed to marshal CRD as YAML: %w", err)
+		}
+		if err := enc.Close(); err != nil {
+			return fmt.Errorf("failed to close YAML encoder: %w", err)
+		}
+		fmt.Print(buf.String())
+	case outputpkg.FormatJSON:
+		data, err := json.MarshalIndent(crd.Object, "", "  ")
+		if err != nil {
+			return fmt.Errorf("failed to marshal CRD as JSON: %w", err)
+		}
+		fmt.Println(string(data))
+	default:
+		return fmt.Errorf("unsupported CRD output format %q", format)
+	}
 	return nil
 }
 
 // printDryRun prints the CRD and all auxiliary resources that would be created
 // during a real submission (TensorBoard Deployment and Service if enabled).
-// Each resource is printed as indented JSON separated by "---" for readability.
+// Output format respects -o/--output (json or yaml; defaults to json).
+// Multiple resources are separated by "---" for readability.
 func printDryRun(crd *unstructured.Unstructured, t *task.Task) error {
-	if err := printCRD(crd); err != nil {
+	format, err := dryRunFormat()
+	if err != nil {
+		return err
+	}
+
+	if err := printCRD(crd, format); err != nil {
 		return fmt.Errorf("failed to print CRD: %w", err)
 	}
 
@@ -63,7 +109,7 @@ func printDryRun(crd *unstructured.Unstructured, t *task.Task) error {
 			ownerRef,
 		)
 		fmt.Println("---")
-		if err := printCRD(deploy); err != nil {
+		if err := printCRD(deploy, format); err != nil {
 			return fmt.Errorf("failed to print TensorBoard Deployment: %w", err)
 		}
 
@@ -74,7 +120,7 @@ func printDryRun(crd *unstructured.Unstructured, t *task.Task) error {
 			ownerRef,
 		)
 		fmt.Println("---")
-		if err := printCRD(svc); err != nil {
+		if err := printCRD(svc, format); err != nil {
 			return fmt.Errorf("failed to print TensorBoard Service: %w", err)
 		}
 	}

--- a/pkg/cli/helpers.go
+++ b/pkg/cli/helpers.go
@@ -190,6 +190,11 @@ func submitCRD(ctx context.Context, k8sClient *client.Client, t *task.Task, fram
 		return err
 	}
 
+	if a := t.Scheduling.Affinity; a != nil && (a.Policy == "" || a.Policy == "none") && len(a.Rules) > 0 {
+		log.Warning("affinity.policy is unset or 'none'; affinity rules are ignored and no affinity is generated",
+			"rules", len(a.Rules))
+	}
+
 	if isMPIFamily(t.Framework.Name) {
 		if mpiP, ok := p.(*provider.MPIProvider); ok {
 			if k8sClient != nil {

--- a/pkg/cli/helpers_test.go
+++ b/pkg/cli/helpers_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -14,7 +15,81 @@ import (
 	"k8s.io/client-go/dynamic/fake"
 
 	"github.com/kubeflow/arena/pkg/client"
+	outputpkg "github.com/kubeflow/arena/pkg/output"
 )
+
+func TestDryRunFormat(t *testing.T) {
+	orig := outputFormat
+	t.Cleanup(func() { outputFormat = orig })
+
+	tests := []struct {
+		format  string
+		want    outputpkg.Format
+		wantErr bool
+	}{
+		{"json", outputpkg.FormatJSON, false},
+		{"yaml", outputpkg.FormatYAML, false},
+		{"table", "", true},
+		{"wide", "", true},
+		{"", "", true},
+	}
+	for _, tt := range tests {
+		t.Run("format_"+tt.format, func(t *testing.T) {
+			outputFormat = tt.format
+			got, err := dryRunFormat()
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "dry-run only supports -o json or yaml")
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+
+func TestPrintCRD_UnsupportedFormat(t *testing.T) {
+	crd := &unstructured.Unstructured{Object: map[string]interface{}{"kind": "PyTorchJob"}}
+	err := printCRD(crd, outputpkg.FormatTable)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported CRD output format")
+}
+
+func TestPrintCRD_YAMLAndJSON(t *testing.T) {
+	crd := &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "kubeflow.org/v1",
+		"kind":       "PyTorchJob",
+	}}
+	require.NoError(t, printCRD(crd, outputpkg.FormatYAML))
+	require.NoError(t, printCRD(crd, outputpkg.FormatJSON))
+}
+
+func TestApplyDryRunOutputDefault(t *testing.T) {
+	orig := outputFormat
+	t.Cleanup(func() { outputFormat = orig })
+
+	newCmd := func() *cobra.Command {
+		cmd := &cobra.Command{Use: "x"}
+		cmd.Flags().StringVarP(&outputFormat, "output", "o", string(outputpkg.DefaultFormat), "")
+		return cmd
+	}
+
+	// dry-run without explicit -o: defaults to json
+	outputFormat = string(outputpkg.DefaultFormat)
+	applyDryRunOutputDefault(newCmd(), true)
+	assert.Equal(t, string(outputpkg.FormatJSON), outputFormat)
+
+	// dry-run with explicit -o yaml: kept
+	cmd := newCmd()
+	require.NoError(t, cmd.Flags().Set("output", "yaml"))
+	applyDryRunOutputDefault(cmd, true)
+	assert.Equal(t, "yaml", outputFormat)
+
+	// no dry-run: untouched
+	outputFormat = string(outputpkg.DefaultFormat)
+	applyDryRunOutputDefault(newCmd(), false)
+	assert.Equal(t, string(outputpkg.DefaultFormat), outputFormat)
+}
 
 func TestIsMPIFamily(t *testing.T) {
 	tests := []struct {

--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -30,6 +30,8 @@ Use --set to override YAML fields with Helm-style dot-notation paths.`,
 			return errors.New("--file is required")
 		}
 
+		applyDryRunOutputDefault(cmd, runDryRun)
+
 		log.Debug("loading task from file", "file", runFile)
 
 		// Read raw YAML
@@ -81,7 +83,7 @@ func getProvider(frameworkName string) (provider.Provider, error) {
 
 func init() {
 	runCmd.Flags().StringVarP(&runFile, "file", "f", "", "path to YAML file")
-	runCmd.Flags().BoolVar(&runDryRun, "dry-run", false, "print CRD as JSON without submitting")
+	runCmd.Flags().BoolVar(&runDryRun, "dry-run", false, "print CRD as JSON (default) or YAML (-o yaml) without submitting")
 	runCmd.Flags().StringArrayVar(&runSetExprs, "set", nil,
 		"override YAML field (Helm-style: key=value, repeatable)")
 

--- a/pkg/cli/run_test.go
+++ b/pkg/cli/run_test.go
@@ -511,8 +511,10 @@ scheduling:
     constraint: preferred
     target: pod
     rules:
-      - topologyKey: kubernetes.io/hostname
+      - topology_key: kubernetes.io/hostname
         weight: 100
+        match_labels:
+          app: web
 `
 	tmpFile := writeTestYAML(t, yaml)
 	runFile = tmpFile

--- a/pkg/cli/submit.go
+++ b/pkg/cli/submit.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/kubeflow/arena/pkg/client"
 	"github.com/kubeflow/arena/pkg/constants"
+	outputpkg "github.com/kubeflow/arena/pkg/output"
 	"github.com/kubeflow/arena/pkg/task"
 )
 
@@ -77,6 +78,8 @@ Trailing arguments after -- are used as the run command.`,
 			return fmt.Errorf("unsupported framework type: %q (must be pytorch, tensorflow, mpi, horovod, deepspeed, or ray)",
 				args[0])
 		}
+
+		applyDryRunOutputDefault(cmd, submitDryRun)
 
 		// Trailing args after -- become the run command
 		trailingArgs := []string{}
@@ -429,7 +432,9 @@ func init() {
 	submitCmd.Flags().BoolVar(&submitMountsOnLauncher, "mounts-on-launcher", false, "MPI: mount volumes on launcher")
 
 	// Dry-run
-	submitCmd.Flags().BoolVar(&submitDryRun, "dry-run", false, "print CRD as JSON without submitting")
+	submitCmd.Flags().BoolVar(&submitDryRun, "dry-run", false, "print CRD as JSON (default) or YAML (-o yaml) without submitting")
+	submitCmd.Flags().StringVarP(&outputFormat, "output", "o", string(outputpkg.DefaultFormat), outputpkg.FormatHelpText)
+	_ = submitCmd.RegisterFlagCompletionFunc("output", completeOutputFormat)
 
 	_ = submitCmd.MarkFlagRequired("name")
 	_ = submitCmd.MarkFlagRequired("image")

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -102,6 +102,7 @@ const (
 const (
 	EmptyDirMediumMemory = "Memory"
 	AffinityOperatorIn   = "In"
+	DefaultTopologyKey   = "kubernetes.io/hostname"
 )
 
 // Client configuration defaults.

--- a/pkg/provider/affinity_test.go
+++ b/pkg/provider/affinity_test.go
@@ -1,17 +1,36 @@
 package provider
 
 import (
-	"strings"
+	"bytes"
+	"encoding/json"
 	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 
 	"github.com/kubeflow/arena/pkg/task"
 )
 
+// assertK8sAffinityValid validates that the generated affinity map deserializes
+// cleanly into corev1.Affinity with no unknown fields. This catches structural
+// errors like missing "preference" wrappers or wrong nesting levels.
+func assertK8sAffinityValid(t *testing.T, affinityMap map[string]interface{}) corev1.Affinity {
+	t.Helper()
+
+	data, err := json.Marshal(affinityMap)
+	require.NoError(t, err, "failed to marshal affinity map")
+
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+
+	var affinity corev1.Affinity
+	require.NoError(t, dec.Decode(&affinity),
+		"affinity map should be structurally valid as corev1.Affinity")
+	return affinity
+}
+
 func TestBuildAffinity_Nil(t *testing.T) {
-	result, err := buildAffinity(nil, "test-job")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	result := buildAffinity(nil, "test-job")
 	if result != nil {
 		t.Errorf("expected nil for nil affinity, got %v", result)
 	}
@@ -19,10 +38,7 @@ func TestBuildAffinity_Nil(t *testing.T) {
 
 func TestBuildAffinity_Empty(t *testing.T) {
 	a := &task.Affinity{}
-	result, err := buildAffinity(a, "test-job")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	result := buildAffinity(a, "test-job")
 	if result != nil {
 		t.Errorf("expected nil for empty affinity, got %v", result)
 	}
@@ -34,16 +50,35 @@ func TestBuildAffinity_PolicyOnlyNoRules(t *testing.T) {
 		Policy: "spread",
 		Target: "pod",
 	}
-	result, err := buildAffinity(a, "test-job")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	result := buildAffinity(a, "test-job")
 	if result != nil {
 		t.Errorf("expected nil result for policy without rules, got %v", result)
 	}
 }
 
 func TestBuildAffinity_RulesWithPodTarget(t *testing.T) {
+	a := &task.Affinity{
+		Target: "pod",
+		Policy: "binpack",
+		Rules: []task.AffinityRule{
+			{
+				TopologyKey: "kubernetes.io/hostname",
+				Weight:      50,
+				MatchLabels: map[string]string{"app": "test"},
+			},
+		},
+	}
+	result := buildAffinity(a, "test-job")
+	if result == nil {
+		t.Fatal("expected non-nil result for rules with pod target")
+	}
+	assertK8sAffinityValid(t, result)
+	if _, ok := result["podAffinity"]; !ok {
+		t.Errorf("expected podAffinity for binpack policy, got %v", result)
+	}
+}
+
+func TestBuildAffinity_UnsetPolicyGeneratesNothing(t *testing.T) {
 	a := &task.Affinity{
 		Target: "pod",
 		Rules: []task.AffinityRule{
@@ -54,39 +89,37 @@ func TestBuildAffinity_RulesWithPodTarget(t *testing.T) {
 			},
 		},
 	}
-	result, err := buildAffinity(a, "test-job")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	if result := buildAffinity(a, "test-job"); result != nil {
+		t.Errorf("expected nil for unset policy even with rules, got %v", result)
 	}
-	if result == nil {
-		t.Fatal("expected non-nil result for rules with pod target")
+
+	a.Target = "node"
+	a.Rules = []task.AffinityRule{
+		{MatchExpressions: []task.MatchExpression{{Key: "gpu-type", Operator: "Exists"}}},
 	}
-	// Should generate podAffinity or podAntiAffinity
-	if _, ok := result["podAffinity"]; !ok {
-		if _, ok := result["podAntiAffinity"]; !ok {
-			t.Errorf("expected podAffinity or podAntiAffinity, got %v", result)
-		}
+	if result := buildAffinity(a, "test-job"); result != nil {
+		t.Errorf("expected nil for unset policy with node target, got %v", result)
 	}
 }
 
 func TestBuildAffinity_RulesWithNodeTarget(t *testing.T) {
 	a := &task.Affinity{
 		Target: "node",
+		Policy: "spread",
 		Rules: []task.AffinityRule{
 			{
+				Weight: 1,
 				MatchExpressions: []task.MatchExpression{
 					{Key: "gpu-type", Operator: "In", Values: []string{"A100"}},
 				},
 			},
 		},
 	}
-	result, err := buildAffinity(a, "test-job")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	result := buildAffinity(a, "test-job")
 	if result == nil {
 		t.Fatal("expected non-nil result for rules with node target")
 	}
+	assertK8sAffinityValid(t, result)
 	// Should generate nodeAffinity
 	if _, ok := result["nodeAffinity"]; !ok {
 		t.Errorf("expected nodeAffinity, got %v", result)
@@ -101,10 +134,7 @@ func TestBuildPodAffinityTerms_PreferredWithValidWeight(t *testing.T) {
 			MatchLabels: map[string]string{"app": "test"},
 		},
 	}
-	terms, err := buildPodAffinityTerms(rules, "preferred")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	terms := buildPodAffinityTerms(rules, "preferred")
 	if len(terms) != 1 {
 		t.Fatalf("expected 1 term, got %d", len(terms))
 	}
@@ -112,7 +142,7 @@ func TestBuildPodAffinityTerms_PreferredWithValidWeight(t *testing.T) {
 	if !ok {
 		t.Fatal("expected map[string]interface{} for weighted term")
 	}
-	if w, ok := weightedTerm["weight"].(int); !ok || w != 50 {
+	if w, ok := weightedTerm["weight"].(int64); !ok || w != 50 {
 		t.Errorf("expected outer weight=50, got %v", weightedTerm["weight"])
 	}
 	podTerm, ok := weightedTerm["podAffinityTerm"].(map[string]interface{})
@@ -127,32 +157,6 @@ func TestBuildPodAffinityTerms_PreferredWithValidWeight(t *testing.T) {
 	}
 }
 
-func TestBuildPodAffinityTerms_PreferredWithInvalidWeight_Zero(t *testing.T) {
-	rules := []task.AffinityRule{
-		{TopologyKey: "kubernetes.io/hostname", Weight: 0},
-	}
-	_, err := buildPodAffinityTerms(rules, "preferred")
-	if err == nil {
-		t.Fatal("expected error for weight=0, got nil")
-	}
-	if !strings.Contains(err.Error(), "must be 1-100") {
-		t.Errorf("error should mention valid range, got: %v", err)
-	}
-}
-
-func TestBuildPodAffinityTerms_PreferredWithInvalidWeight_TooHigh(t *testing.T) {
-	rules := []task.AffinityRule{
-		{TopologyKey: "kubernetes.io/hostname", Weight: 101},
-	}
-	_, err := buildPodAffinityTerms(rules, "preferred")
-	if err == nil {
-		t.Fatal("expected error for weight=101, got nil")
-	}
-	if !strings.Contains(err.Error(), "101") {
-		t.Errorf("error should mention the invalid weight value, got: %v", err)
-	}
-}
-
 func TestBuildPodAffinityTerms_RequiredIgnoresWeight(t *testing.T) {
 	rules := []task.AffinityRule{
 		{
@@ -161,10 +165,7 @@ func TestBuildPodAffinityTerms_RequiredIgnoresWeight(t *testing.T) {
 			MatchLabels: map[string]string{"app": "test"},
 		},
 	}
-	terms, err := buildPodAffinityTerms(rules, "required")
-	if err != nil {
-		t.Fatalf("unexpected error in required mode: %v", err)
-	}
+	terms := buildPodAffinityTerms(rules, "required")
 	if len(terms) != 1 {
 		t.Fatalf("expected 1 term, got %d", len(terms))
 	}
@@ -193,10 +194,8 @@ func TestBuildAffinity_PreferredSpread_NoWeightInsidePodAffinityTerm(t *testing.
 			},
 		},
 	}
-	result, err := buildAffinity(a, "test-job")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	result := buildAffinity(a, "test-job")
+	assertK8sAffinityValid(t, result)
 	antiAffinity, ok := result["podAntiAffinity"].(map[string]interface{})
 	if !ok {
 		t.Fatal("expected podAntiAffinity for spread policy")
@@ -212,7 +211,7 @@ func TestBuildAffinity_PreferredSpread_NoWeightInsidePodAffinityTerm(t *testing.
 	if !ok {
 		t.Fatal("expected weighted term map")
 	}
-	if w, ok := wt["weight"].(int); !ok || w != 50 {
+	if w, ok := wt["weight"].(int64); !ok || w != 50 {
 		t.Errorf("expected outer weight=50, got %v", wt["weight"])
 	}
 	podTerm, ok := wt["podAffinityTerm"].(map[string]interface{})
@@ -221,24 +220,6 @@ func TestBuildAffinity_PreferredSpread_NoWeightInsidePodAffinityTerm(t *testing.
 	}
 	if _, hasWeight := podTerm["weight"]; hasWeight {
 		t.Error("weight must not appear inside podAffinityTerm")
-	}
-}
-
-func TestBuildAffinity_PreferredInvalidWeight_ReturnsError(t *testing.T) {
-	a := &task.Affinity{
-		Policy:     "spread",
-		Constraint: "preferred",
-		Target:     "pod",
-		Rules: []task.AffinityRule{
-			{TopologyKey: "kubernetes.io/hostname", Weight: 0},
-		},
-	}
-	_, err := buildAffinity(a, "test-job")
-	if err == nil {
-		t.Fatal("expected error for invalid weight through buildAffinity, got nil")
-	}
-	if !strings.Contains(err.Error(), "must be 1-100") {
-		t.Errorf("error should mention valid range, got: %v", err)
 	}
 }
 
@@ -254,21 +235,19 @@ func TestBuildAffinity_NonePolicySkipsRules(t *testing.T) {
 			},
 		},
 	}
-	result, err := buildAffinity(a, "test-job")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	result := buildAffinity(a, "test-job")
 	if result != nil {
 		t.Errorf("expected nil for policy=none even with rules, got %v", result)
 	}
 }
 
-func TestBuildAffinity_NodeTargetSpreadNegatesOperators(t *testing.T) {
+func TestBuildAffinity_NodeTargetSpreadPreservesOperators(t *testing.T) {
 	a := &task.Affinity{
 		Target: "node",
 		Policy: "spread",
 		Rules: []task.AffinityRule{
 			{
+				Weight: 1,
 				MatchExpressions: []task.MatchExpression{
 					{Key: "gpu-type", Operator: "In", Values: []string{"A100"}},
 				},
@@ -276,13 +255,11 @@ func TestBuildAffinity_NodeTargetSpreadNegatesOperators(t *testing.T) {
 			},
 		},
 	}
-	result, err := buildAffinity(a, "test-job")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	result := buildAffinity(a, "test-job")
 	if result == nil {
 		t.Fatal("expected non-nil result")
 	}
+	assertK8sAffinityValid(t, result)
 
 	nodeAffinity, ok := result["nodeAffinity"].(map[string]interface{})
 	if !ok {
@@ -296,19 +273,32 @@ func TestBuildAffinity_NodeTargetSpreadNegatesOperators(t *testing.T) {
 	if !ok {
 		t.Fatal("expected term to be a map")
 	}
-	exprs, ok := term["matchExpressions"].([]interface{})
-	if !ok {
-		t.Fatal("expected matchExpressions")
+	if w, ok := term["weight"].(int64); !ok || w != 1 {
+		t.Errorf("expected weight=1, got %v", term["weight"])
 	}
+	pref, ok := term["preference"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected preference wrapper")
+	}
+	exprs, ok := pref["matchExpressions"].([]interface{})
+	if !ok {
+		t.Fatal("expected matchExpressions inside preference")
+	}
+	foundIn := false
 	for _, e := range exprs {
 		expr, ok := e.(map[string]interface{})
 		if !ok {
 			continue
 		}
-		op, _ := expr["operator"].(string)
-		if op == "In" {
-			t.Errorf("expected In to be negated to NotIn for spread policy, got In")
+		if op, _ := expr["operator"].(string); op == "In" {
+			foundIn = true
 		}
+		if op, _ := expr["operator"].(string); op == "NotIn" {
+			t.Error("expected In operator to be preserved for spread policy, got NotIn")
+		}
+	}
+	if !foundIn {
+		t.Error("expected to find In operator preserved for spread policy")
 	}
 }
 
@@ -318,19 +308,18 @@ func TestBuildAffinity_NodeTargetBinpackPreservesOperators(t *testing.T) {
 		Policy: "binpack",
 		Rules: []task.AffinityRule{
 			{
+				Weight: 1,
 				MatchExpressions: []task.MatchExpression{
 					{Key: "gpu-type", Operator: "In", Values: []string{"A100"}},
 				},
 			},
 		},
 	}
-	result, err := buildAffinity(a, "test-job")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	result := buildAffinity(a, "test-job")
 	if result == nil {
 		t.Fatal("expected non-nil result")
 	}
+	assertK8sAffinityValid(t, result)
 
 	nodeAffinity, ok := result["nodeAffinity"].(map[string]interface{})
 	if !ok {
@@ -344,9 +333,13 @@ func TestBuildAffinity_NodeTargetBinpackPreservesOperators(t *testing.T) {
 	if !ok {
 		t.Fatal("expected term to be a map")
 	}
-	exprs, ok := term["matchExpressions"].([]interface{})
+	pref, ok := term["preference"].(map[string]interface{})
 	if !ok {
-		t.Fatal("expected matchExpressions")
+		t.Fatal("expected preference wrapper")
+	}
+	exprs, ok := pref["matchExpressions"].([]interface{})
+	if !ok {
+		t.Fatal("expected matchExpressions inside preference")
 	}
 	found := false
 	for _, e := range exprs {
@@ -360,5 +353,441 @@ func TestBuildAffinity_NodeTargetBinpackPreservesOperators(t *testing.T) {
 	}
 	if !found {
 		t.Error("expected In operator to be preserved for binpack policy")
+	}
+}
+
+func TestBuildTopologySpreadConstraints_NilAffinity(t *testing.T) {
+	result := buildTopologySpreadConstraints(nil, "test-job")
+	if result != nil {
+		t.Errorf("expected nil for nil affinity, got %v", result)
+	}
+}
+
+func TestBuildTopologySpreadConstraints_NodeTargetSpread(t *testing.T) {
+	a := &task.Affinity{
+		Policy:     "spread",
+		Constraint: "preferred",
+		Target:     "node",
+		Rules: []task.AffinityRule{
+			{
+				Weight: 1,
+				MatchExpressions: []task.MatchExpression{
+					{Key: "gpu-type", Operator: "In", Values: []string{"A100"}},
+				},
+			},
+		},
+	}
+	result := buildTopologySpreadConstraints(a, "test-job")
+	if result == nil {
+		t.Fatal("expected non-nil result for node target spread")
+	}
+	if len(result) != 1 {
+		t.Fatalf("expected 1 constraint, got %d", len(result))
+	}
+	c, ok := result[0].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected map[string]interface{}")
+	}
+	if m, ok := c["maxSkew"].(int64); !ok || m != 1 {
+		t.Errorf("expected maxSkew=1, got %v", c["maxSkew"])
+	}
+	if tk, ok := c["topologyKey"].(string); !ok || tk != "kubernetes.io/hostname" {
+		t.Errorf("expected topologyKey=kubernetes.io/hostname, got %v", c["topologyKey"])
+	}
+	if wu, ok := c["whenUnsatisfiable"].(string); !ok || wu != "ScheduleAnyway" {
+		t.Errorf("expected whenUnsatisfiable=ScheduleAnyway for preferred, got %v", c["whenUnsatisfiable"])
+	}
+	ls, ok := c["labelSelector"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected labelSelector map")
+	}
+	ml, ok := ls["matchLabels"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected matchLabels map")
+	}
+	if v, ok := ml["training.kubeflow.org/job-name"].(string); !ok || v != "test-job" {
+		t.Errorf("expected labelSelector matchLabels job-name=test-job, got %v", ml)
+	}
+}
+
+func TestBuildTopologySpreadConstraints_NodeTargetSpreadRequired(t *testing.T) {
+	a := &task.Affinity{
+		Policy:     "spread",
+		Constraint: "required",
+		Target:     "node",
+		Rules: []task.AffinityRule{
+			{Weight: 1},
+		},
+	}
+	result := buildTopologySpreadConstraints(a, "test-job")
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	c := result[0].(map[string]interface{})
+	if wu, ok := c["whenUnsatisfiable"].(string); !ok || wu != "DoNotSchedule" {
+		t.Errorf("expected whenUnsatisfiable=DoNotSchedule for required, got %v", c["whenUnsatisfiable"])
+	}
+}
+
+func TestBuildTopologySpreadConstraints_NodeTargetSpreadCustomTopologyKey(t *testing.T) {
+	// topology_key is pod-only (task.Validate rejects it for node target);
+	// the builder tolerates it and TSC always uses kubernetes.io/hostname.
+	a := &task.Affinity{
+		Policy:     "spread",
+		Constraint: "preferred",
+		Target:     "node",
+		Rules: []task.AffinityRule{
+			{Weight: 1, TopologyKey: "topology.kubernetes.io/zone"},
+		},
+	}
+	result := buildTopologySpreadConstraints(a, "test-job")
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if len(result) != 1 {
+		t.Fatalf("expected 1 constraint, got %d", len(result))
+	}
+	c := result[0].(map[string]interface{})
+	if tk, ok := c["topologyKey"].(string); !ok || tk != "kubernetes.io/hostname" {
+		t.Errorf("expected topologyKey=kubernetes.io/hostname (hardcoded), got %v", c["topologyKey"])
+	}
+}
+
+func TestBuildTopologySpreadConstraints_NodeTargetBinpack(t *testing.T) {
+	a := &task.Affinity{
+		Policy: "binpack",
+		Target: "node",
+		Rules:  []task.AffinityRule{{Weight: 1}},
+	}
+	result := buildTopologySpreadConstraints(a, "test-job")
+	if result != nil {
+		t.Errorf("expected nil for binpack policy, got %v", result)
+	}
+}
+
+func TestBuildTopologySpreadConstraints_PodTarget(t *testing.T) {
+	a := &task.Affinity{
+		Policy: "spread",
+		Target: "pod",
+		Rules:  []task.AffinityRule{{Weight: 1}},
+	}
+	result := buildTopologySpreadConstraints(a, "test-job")
+	if result != nil {
+		t.Errorf("expected nil for pod target, got %v", result)
+	}
+}
+
+func TestBuildTopologySpreadConstraints_MultipleRules(t *testing.T) {
+	a := &task.Affinity{
+		Policy: "spread",
+		Target: "node",
+		Rules: []task.AffinityRule{
+			{Weight: 1, TopologyKey: "kubernetes.io/hostname"},
+			{Weight: 1, TopologyKey: "topology.kubernetes.io/zone"},
+		},
+	}
+	result := buildTopologySpreadConstraints(a, "test-job")
+	if len(result) != 1 {
+		t.Fatalf("expected 1 constraint (single TSC regardless of rule count), got %d", len(result))
+	}
+	c := result[0].(map[string]interface{})
+	if tk, ok := c["topologyKey"].(string); !ok || tk != "kubernetes.io/hostname" {
+		t.Errorf("expected topologyKey=kubernetes.io/hostname, got %v", c["topologyKey"])
+	}
+}
+
+func TestBuildPodSpec_NodeTargetSpreadHasTopologySpreadConstraints(t *testing.T) {
+	job := &task.Task{
+		Name:  "test-job",
+		Image: "test:latest",
+		Framework: task.Framework{
+			Name: "mpi",
+		},
+		Scheduling: task.Scheduling{
+			Affinity: &task.Affinity{
+				Policy:     "spread",
+				Constraint: "preferred",
+				Target:     "node",
+				Rules: []task.AffinityRule{
+					{
+						Weight: 1,
+						MatchExpressions: []task.MatchExpression{
+							{Key: "gpu-type", Operator: "In", Values: []string{"A100"}},
+						},
+					},
+				},
+			},
+		},
+	}
+	container := map[string]interface{}{
+		"name":  "mpi",
+		"image": "test:latest",
+	}
+	podSpec, err := buildPodSpec(job, container, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify nodeAffinity exists with positive (non-negated) operators
+	affinity, ok := podSpec["affinity"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected affinity in pod spec")
+	}
+	nodeAffinity, ok := affinity["nodeAffinity"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected nodeAffinity")
+	}
+	preferred, ok := nodeAffinity["preferredDuringSchedulingIgnoredDuringExecution"].([]interface{})
+	if !ok || len(preferred) != 1 {
+		t.Fatalf("expected 1 preferred term, got %v", nodeAffinity)
+	}
+	term := preferred[0].(map[string]interface{})
+	pref := term["preference"].(map[string]interface{})
+	exprs := pref["matchExpressions"].([]interface{})
+	for _, e := range exprs {
+		expr := e.(map[string]interface{})
+		if op, _ := expr["operator"].(string); op == "NotIn" {
+			t.Error("expected In operator to be preserved, got NotIn")
+		}
+	}
+
+	// Verify topologySpreadConstraints exists
+	tsc, ok := podSpec["topologySpreadConstraints"].([]interface{})
+	if !ok {
+		t.Fatal("expected topologySpreadConstraints in pod spec")
+	}
+	if len(tsc) != 1 {
+		t.Fatalf("expected 1 topology spread constraint, got %d", len(tsc))
+	}
+	c := tsc[0].(map[string]interface{})
+	if tk, ok := c["topologyKey"].(string); !ok || tk != "kubernetes.io/hostname" {
+		t.Errorf("expected topologyKey=kubernetes.io/hostname, got %v", c["topologyKey"])
+	}
+	if wu, ok := c["whenUnsatisfiable"].(string); !ok || wu != "ScheduleAnyway" {
+		t.Errorf("expected whenUnsatisfiable=ScheduleAnyway, got %v", c["whenUnsatisfiable"])
+	}
+	ls := c["labelSelector"].(map[string]interface{})
+	ml := ls["matchLabels"].(map[string]interface{})
+	if v, ok := ml["training.kubeflow.org/job-name"].(string); !ok || v != "test-job" {
+		t.Errorf("expected job-name=test-job, got %v", ml)
+	}
+}
+
+func TestBuildPodSpec_NodeTargetBinpackNoTopologySpreadConstraints(t *testing.T) {
+	job := &task.Task{
+		Name:  "test-job",
+		Image: "test:latest",
+		Framework: task.Framework{
+			Name: "mpi",
+		},
+		Scheduling: task.Scheduling{
+			Affinity: &task.Affinity{
+				Policy: "binpack",
+				Target: "node",
+				Rules: []task.AffinityRule{
+					{Weight: 1},
+				},
+			},
+		},
+	}
+	container := map[string]interface{}{
+		"name":  "mpi",
+		"image": "test:latest",
+	}
+	podSpec, err := buildPodSpec(job, container, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// affinity should exist with podAffinity (binpack packing)
+	affinity, ok := podSpec["affinity"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected affinity in pod spec for binpack")
+	}
+	if _, ok := affinity["podAffinity"].(map[string]interface{}); !ok {
+		t.Fatal("expected podAffinity for node binpack")
+	}
+
+	// topologySpreadConstraints should NOT exist
+	if _, ok := podSpec["topologySpreadConstraints"]; ok {
+		t.Error("expected no topologySpreadConstraints for binpack policy")
+	}
+}
+
+func TestBuildAffinity_DefaultTopologyKeyForPodTarget(t *testing.T) {
+	a := &task.Affinity{
+		Target: "pod",
+		Policy: "binpack",
+		Rules: []task.AffinityRule{
+			{
+				Weight:      50,
+				MatchLabels: map[string]string{"app": "test"},
+				// TopologyKey intentionally omitted — should default to kubernetes.io/hostname
+			},
+		},
+	}
+	result := buildAffinity(a, "test-job")
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	assertK8sAffinityValid(t, result)
+
+	// binpack → podAffinity; default constraint="" → preferred
+	podAff, ok := result["podAffinity"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected podAffinity, got keys: %v", mapKeys(result))
+	}
+	preferred, ok := podAff["preferredDuringSchedulingIgnoredDuringExecution"].([]interface{})
+	if !ok || len(preferred) != 1 {
+		t.Fatalf("expected 1 preferred term, got %v", podAff)
+	}
+	wTerm := preferred[0].(map[string]interface{})
+	term := wTerm["podAffinityTerm"].(map[string]interface{})
+	if tk, ok := term["topologyKey"].(string); !ok || tk != "kubernetes.io/hostname" {
+		t.Errorf("expected topologyKey=kubernetes.io/hostname (default), got %v", term["topologyKey"])
+	}
+}
+
+func mapKeys(m map[string]interface{}) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
+func TestBuildTopologySpreadConstraints_NoRules(t *testing.T) {
+	a := &task.Affinity{
+		Policy:     "spread",
+		Constraint: "preferred",
+		Target:     "node",
+		// No rules — should still generate 1 constraint
+	}
+	result := buildTopologySpreadConstraints(a, "test-job")
+	if result == nil {
+		t.Fatal("expected non-nil result for node spread without rules")
+	}
+	if len(result) != 1 {
+		t.Fatalf("expected 1 constraint without rules, got %d", len(result))
+	}
+	c := result[0].(map[string]interface{})
+	if tk, ok := c["topologyKey"].(string); !ok || tk != "kubernetes.io/hostname" {
+		t.Errorf("expected topologyKey=kubernetes.io/hostname, got %v", c["topologyKey"])
+	}
+}
+
+func TestBuildAffinity_NodeBinpackNoRules(t *testing.T) {
+	a := &task.Affinity{
+		Policy: "binpack",
+		Target: "node",
+		// No rules — should still generate podAffinity
+	}
+	result := buildAffinity(a, "test-job")
+	if result == nil {
+		t.Fatal("expected non-nil result for node binpack without rules")
+	}
+	assertK8sAffinityValid(t, result)
+
+	podAff, ok := result["podAffinity"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected podAffinity for node binpack")
+	}
+	preferred, ok := podAff["preferredDuringSchedulingIgnoredDuringExecution"].([]interface{})
+	if !ok || len(preferred) != 1 {
+		t.Fatalf("expected 1 preferred term, got %v", podAff)
+	}
+	wTerm := preferred[0].(map[string]interface{})
+	if w, ok := wTerm["weight"].(int64); !ok || w != 100 {
+		t.Errorf("expected default weight=100, got %v", wTerm["weight"])
+	}
+	term := wTerm["podAffinityTerm"].(map[string]interface{})
+	if tk, ok := term["topologyKey"].(string); !ok || tk != "kubernetes.io/hostname" {
+		t.Errorf("expected topologyKey=kubernetes.io/hostname, got %v", term["topologyKey"])
+	}
+	ls := term["labelSelector"].(map[string]interface{})
+	ml := ls["matchLabels"].(map[string]interface{})
+	if v, ok := ml["training.kubeflow.org/job-name"].(string); !ok || v != "test-job" {
+		t.Errorf("expected job-name=test-job, got %v", ml)
+	}
+}
+
+func TestBuildAffinity_NodeBinpackRequired(t *testing.T) {
+	a := &task.Affinity{
+		Policy:     "binpack",
+		Constraint: "required",
+		Target:     "node",
+	}
+	result := buildAffinity(a, "test-job")
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	assertK8sAffinityValid(t, result)
+
+	podAff, ok := result["podAffinity"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected podAffinity")
+	}
+	required, ok := podAff["requiredDuringSchedulingIgnoredDuringExecution"].([]interface{})
+	if !ok || len(required) != 1 {
+		t.Fatalf("expected 1 required term, got %v", podAff)
+	}
+	term := required[0].(map[string]interface{})
+	if tk, ok := term["topologyKey"].(string); !ok || tk != "kubernetes.io/hostname" {
+		t.Errorf("expected topologyKey=kubernetes.io/hostname, got %v", term["topologyKey"])
+	}
+}
+
+func TestBuildAffinity_NodeBinpackWithRules(t *testing.T) {
+	a := &task.Affinity{
+		Policy:     "binpack",
+		Constraint: "preferred",
+		Target:     "node",
+		Rules: []task.AffinityRule{
+			{
+				Weight:      50,
+				MatchLabels: map[string]string{"gpu": "a100"},
+			},
+		},
+	}
+	result := buildAffinity(a, "test-job")
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	assertK8sAffinityValid(t, result)
+
+	// Should have both podAffinity (packing) and nodeAffinity (node selection)
+	podAff, ok := result["podAffinity"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected podAffinity for binpack")
+	}
+	preferred := podAff["preferredDuringSchedulingIgnoredDuringExecution"].([]interface{})
+	wTerm := preferred[0].(map[string]interface{})
+	if w, ok := wTerm["weight"].(int64); !ok || w != 100 {
+		t.Errorf("expected self-affinity weight=100 (decoupled from rule weight), got %v", wTerm["weight"])
+	}
+
+	nodeAff, ok := result["nodeAffinity"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected nodeAffinity from rules")
+	}
+	nodePreferred := nodeAff["preferredDuringSchedulingIgnoredDuringExecution"].([]interface{})
+	if len(nodePreferred) != 1 {
+		t.Fatalf("expected 1 node preferred term, got %d", len(nodePreferred))
+	}
+	nodeTerm := nodePreferred[0].(map[string]interface{})
+	if w, ok := nodeTerm["weight"].(int64); !ok || w != 50 {
+		t.Errorf("expected node preference weight=50 from rule, got %v", nodeTerm["weight"])
+	}
+}
+
+func TestBuildAffinity_NodeSpreadNoRules(t *testing.T) {
+	a := &task.Affinity{
+		Policy: "spread",
+		Target: "node",
+		// No rules — buildAffinity returns nil (TSC generated separately in buildPodSpec)
+	}
+	result := buildAffinity(a, "test-job")
+	if result != nil {
+		t.Errorf("expected nil for node spread without rules (TSC generated separately), got %v", result)
 	}
 }

--- a/pkg/provider/interface.go
+++ b/pkg/provider/interface.go
@@ -427,43 +427,66 @@ func isMPIFamily(t *task.Task) bool {
 		t.Framework.Name == constants.FrameworkDeepSpeed
 }
 
+// toInterfaceSlice converts a []string to []interface{} for unstructured compatibility.
+// unstructured.DeepCopyJSONValue panics on []string; all slice values must be []interface{}.
+func toInterfaceSlice(s []string) []interface{} {
+	if len(s) == 0 {
+		return nil
+	}
+	result := make([]interface{}, len(s))
+	for i, v := range s {
+		result[i] = v
+	}
+	return result
+}
+
+// toInterfaceMap converts a map[string]string to map[string]interface{} for unstructured compatibility.
+func toInterfaceMap(m map[string]string) map[string]interface{} {
+	if len(m) == 0 {
+		return nil
+	}
+	result := make(map[string]interface{}, len(m))
+	for k, v := range m {
+		result[k] = v
+	}
+	return result
+}
+
 // buildAffinity creates a K8s Affinity map from the task's Affinity settings.
-// Supports two modes:
-// - Policy mode: policy×constraint generates podAffinity/podAntiAffinity or nodeAffinity (requires rules)
-// - Rules mode: custom rules applied to pod or node affinity based on target
-// Policy without rules is a no-op; task.Validate rejects that configuration.
-func buildAffinity(a *task.Affinity, _ string) (map[string]interface{}, error) {
+// An unset policy behaves like "none": nothing is generated and rules are
+// ignored (the CLI warns once per job in submitCRD).
+func buildAffinity(a *task.Affinity, jobName string) map[string]interface{} {
 	if a == nil {
-		return nil, nil
+		return nil
 	}
-	if a.Policy == "none" {
-		return nil, nil
-	}
-	if a.Policy == "" && len(a.Rules) == 0 {
-		return nil, nil
+	if a.Policy == "" || a.Policy == "none" {
+		return nil
 	}
 
 	affinity := map[string]interface{}{}
 
-	if len(a.Rules) > 0 {
-		switch a.Target {
-		case "pod":
-			if err := applyPodRules(affinity, a); err != nil {
-				return nil, err
-			}
-		case "node":
+	switch a.Target {
+	case "pod":
+		if len(a.Rules) > 0 {
+			applyPodRules(affinity, a)
+		}
+	case "node":
+		if a.Policy == "binpack" {
+			buildNodeBinpackAffinity(affinity, a, jobName)
+		}
+		if len(a.Rules) > 0 {
 			applyNodeRules(affinity, a)
 		}
 	}
 
 	if len(affinity) == 0 {
-		return nil, nil
+		return nil
 	}
-	return affinity, nil
+	return affinity
 }
 
 // applyPodRules applies affinity rules to podAffinity or podAntiAffinity based on policy.
-func applyPodRules(affinity map[string]interface{}, a *task.Affinity) error {
+func applyPodRules(affinity map[string]interface{}, a *task.Affinity) {
 	constraint := a.Constraint
 	if constraint == "" {
 		constraint = "preferred"
@@ -479,105 +502,124 @@ func applyPodRules(affinity map[string]interface{}, a *task.Affinity) error {
 		mode = "preferred"
 		fieldKey = "preferredDuringSchedulingIgnoredDuringExecution"
 	}
-	terms, err := buildPodAffinityTerms(a.Rules, mode)
-	if err != nil {
-		return err
-	}
+	terms := buildPodAffinityTerms(a.Rules, mode)
 	affinity[affinityType] = map[string]interface{}{fieldKey: terms}
-	return nil
 }
 
-// applyNodeRules applies affinity rules to nodeAffinity based on policy and constraint.
-// For binpack policy, rules attract pods to matching nodes (positive affinity).
-// For spread policy, operators are negated to repel pods from matching nodes.
+// applyNodeRules applies affinity rules to nodeAffinity based on constraint.
+// Both spread and binpack policies generate positive nodeAffinity (node selection).
+// For spread policy, topologySpreadConstraints (built separately by
+// buildTopologySpreadConstraints) handle the actual pod distribution.
 func applyNodeRules(affinity map[string]interface{}, a *task.Affinity) {
 	constraint := a.Constraint
 	if constraint == "" {
 		constraint = "preferred"
 	}
 
-	terms := buildNodeSelectorTerms(a.Rules)
-	if a.Policy == "spread" {
-		negateNodeSelectorTerms(terms)
-	}
-
 	if constraint == "preferred" {
+		preferredTerms := make([]interface{}, 0, len(a.Rules))
+		for _, rule := range a.Rules {
+			preferredTerms = append(preferredTerms, map[string]interface{}{
+				"weight":     int64(rule.Weight),
+				"preference": buildNodeSelectorTerm(rule),
+			})
+		}
 		affinity["nodeAffinity"] = map[string]interface{}{
-			"preferredDuringSchedulingIgnoredDuringExecution": terms,
+			"preferredDuringSchedulingIgnoredDuringExecution": preferredTerms,
 		}
 	} else { // required
 		affinity["nodeAffinity"] = map[string]interface{}{
 			"requiredDuringSchedulingIgnoredDuringExecution": map[string]interface{}{
-				"nodeSelectorTerms": terms,
+				"nodeSelectorTerms": buildNodeSelectorTerms(a.Rules),
 			},
 		}
 	}
 }
 
-// negateNodeSelectorTerms negates operators in node selector terms for spread policy.
-func negateNodeSelectorTerms(terms []interface{}) {
-	for _, term := range terms {
-		t, ok := term.(map[string]interface{})
-		if !ok {
-			continue
-		}
-		negateOperatorList(t, "matchExpressions")
-		negateOperatorList(t, "matchFields")
+// selfAffinityTerm builds a pod affinity term that selects pods of the same job
+// (via the training.kubeflow.org/job-name label) on the hostname topology.
+// Shared by buildNodeBinpackAffinity (as a podAffinityTerm) and
+// buildTopologySpreadConstraints (as the base for a TSC, which adds maxSkew/whenUnsatisfiable).
+func selfAffinityTerm(jobName string) map[string]interface{} {
+	return map[string]interface{}{
+		"topologyKey": constants.DefaultTopologyKey,
+		"labelSelector": map[string]interface{}{
+			"matchLabels": map[string]interface{}{
+				constants.LabelJobName: jobName,
+			},
+		},
 	}
 }
 
-func negateOperatorList(term map[string]interface{}, field string) {
-	exprs, ok := term[field].([]interface{})
-	if !ok {
-		return
+// buildNodeBinpackAffinity generates podAffinity for target:node + policy:binpack.
+// Uses selfAffinityTerm to co-locate pods from the same job on the same node.
+// In preferred mode, the self term always uses weight 100 (strongest binpack
+// preference); rule weights only apply to the nodeAffinity preferences built
+// by applyNodeRules.
+// Required self-affinity does not deadlock the first pod: since at least K8s 1.6
+// the scheduler admits a pod whose own labels satisfy its required affinity terms
+// when no matching pod exists cluster-wide (inter-pod-affinity self-match
+// exception). This relies on the operator injecting the
+// training.kubeflow.org/job-name label onto pods (training-operator >= v1.5 and
+// mpi-operator v2beta1 both do; the legacy standalone mpi-operator v1 labels
+// pods "mpi-job-name" instead, so the self-selector never matches there).
+// Later pods still go Pending if the co-located node runs out of capacity —
+// inherent to required binpack.
+func buildNodeBinpackAffinity(affinity map[string]interface{}, a *task.Affinity, jobName string) {
+	constraint := a.Constraint
+	if constraint == "" {
+		constraint = "preferred"
 	}
+
+	term := selfAffinityTerm(jobName)
+
+	if constraint == "preferred" {
+		affinity["podAffinity"] = map[string]interface{}{
+			"preferredDuringSchedulingIgnoredDuringExecution": []interface{}{
+				map[string]interface{}{
+					"weight":          int64(100),
+					"podAffinityTerm": term,
+				},
+			},
+		}
+	} else {
+		affinity["podAffinity"] = map[string]interface{}{
+			"requiredDuringSchedulingIgnoredDuringExecution": []interface{}{term},
+		}
+	}
+}
+
+// buildMatchExpressions converts MatchExpressions to their unstructured form.
+func buildMatchExpressions(exprs []task.MatchExpression) []interface{} {
+	result := make([]interface{}, 0, len(exprs))
 	for _, e := range exprs {
-		expr, ok := e.(map[string]interface{})
-		if !ok {
-			continue
+		expr := map[string]interface{}{
+			"key":      e.Key,
+			"operator": e.Operator,
 		}
-		if op, ok := expr["operator"].(string); ok {
-			expr["operator"] = negateNodeOperator(op)
+		if len(e.Values) > 0 {
+			expr["values"] = toInterfaceSlice(e.Values)
 		}
+		result = append(result, expr)
 	}
-}
-
-func negateNodeOperator(op string) string {
-	switch op {
-	case "In":
-		return "NotIn"
-	case "NotIn":
-		return "In"
-	case "Exists":
-		return "DoesNotExist"
-	case "DoesNotExist":
-		return "Exists"
-	case "Gt":
-		return "Lt"
-	case "Lt":
-		return "Gt"
-	default:
-		return op
-	}
+	return result
 }
 
 // buildAffinityTerm builds a single pod affinity term from an AffinityRule.
 // In preferred mode, the term is wrapped in a WeightedPodAffinityTerm (weight at outer level).
 // In required mode, the term is returned directly (no weight).
-// Returns an error if preferred mode rules have weight outside 1-100.
-func buildAffinityTerm(rule task.AffinityRule, mode string) (map[string]interface{}, error) {
-	if mode == "preferred" {
-		if rule.Weight < 1 || rule.Weight > 100 {
-			return nil, fmt.Errorf("invalid affinity rule weight: %d (must be 1-100 for preferred scheduling)", rule.Weight)
-		}
+// Weight validity (1-100 for preferred) is enforced by validateScheduling.
+func buildAffinityTerm(rule task.AffinityRule, mode string) map[string]interface{} {
+	topologyKey := rule.TopologyKey
+	if topologyKey == "" {
+		topologyKey = constants.DefaultTopologyKey
 	}
-
 	term := map[string]interface{}{
-		"topologyKey": rule.TopologyKey,
+		"topologyKey": topologyKey,
 	}
 	if len(rule.MatchLabels) > 0 {
 		term["labelSelector"] = map[string]interface{}{
-			"matchLabels": rule.MatchLabels,
+			"matchLabels": toInterfaceMap(rule.MatchLabels),
 		}
 	}
 	// matchExpressions
@@ -587,129 +629,111 @@ func buildAffinityTerm(rule task.AffinityRule, mode string) (map[string]interfac
 			labelSelector = map[string]interface{}{}
 			term["labelSelector"] = labelSelector
 		}
-		exprs := make([]interface{}, 0, len(rule.MatchExpressions))
-		for _, e := range rule.MatchExpressions {
-			expr := map[string]interface{}{
-				"key":      e.Key,
-				"operator": e.Operator,
-			}
-			if len(e.Values) > 0 {
-				expr["values"] = e.Values
-			}
-			exprs = append(exprs, expr)
-		}
-		labelSelector["matchExpressions"] = exprs
+		labelSelector["matchExpressions"] = buildMatchExpressions(rule.MatchExpressions)
 	}
 	// namespaces
 	if len(rule.Namespaces) > 0 {
-		term["namespaces"] = rule.Namespaces
+		term["namespaces"] = toInterfaceSlice(rule.Namespaces)
 	}
 	// namespaceSelector
 	if rule.NamespaceSelector != nil {
 		ns := map[string]interface{}{}
 		if len(rule.NamespaceSelector.MatchLabels) > 0 {
-			ns["matchLabels"] = rule.NamespaceSelector.MatchLabels
+			ns["matchLabels"] = toInterfaceMap(rule.NamespaceSelector.MatchLabels)
 		}
 		if len(rule.NamespaceSelector.MatchExpressions) > 0 {
-			exprs := make([]interface{}, 0, len(rule.NamespaceSelector.MatchExpressions))
-			for _, e := range rule.NamespaceSelector.MatchExpressions {
-				expr := map[string]interface{}{
-					"key":      e.Key,
-					"operator": e.Operator,
-				}
-				if len(e.Values) > 0 {
-					expr["values"] = e.Values
-				}
-				exprs = append(exprs, expr)
-			}
-			ns["matchExpressions"] = exprs
+			ns["matchExpressions"] = buildMatchExpressions(rule.NamespaceSelector.MatchExpressions)
 		}
 		term["namespaceSelector"] = ns
 	}
 
 	if mode == "preferred" {
 		return map[string]interface{}{
-			"weight":          rule.Weight,
+			"weight":          int64(rule.Weight),
 			"podAffinityTerm": term,
-		}, nil
+		}
 	}
-	return term, nil
+	return term
 }
 
 // buildPodAffinityTerms converts AffinityRules to pod affinity terms.
 // In preferred mode, returns WeightedPodAffinityTerm structures (weight at outer level).
 // In required mode, returns PodAffinityTerm structures directly (no weight).
-// Returns an error if preferred mode rules have weight outside 1-100.
-func buildPodAffinityTerms(rules []task.AffinityRule, mode string) ([]interface{}, error) {
+func buildPodAffinityTerms(rules []task.AffinityRule, mode string) []interface{} {
 	terms := make([]interface{}, 0, len(rules))
 	for _, rule := range rules {
-		term, err := buildAffinityTerm(rule, mode)
-		if err != nil {
-			return nil, err
-		}
-		terms = append(terms, term)
+		terms = append(terms, buildAffinityTerm(rule, mode))
 	}
-	return terms, nil
+	return terms
 }
 
 // buildNodeSelectorTerms converts AffinityRules to node selector terms.
 func buildNodeSelectorTerms(rules []task.AffinityRule) []interface{} {
 	terms := make([]interface{}, 0, len(rules))
 	for _, rule := range rules {
-		term := map[string]interface{}{}
-		// Convert MatchExpressions
-		if len(rule.MatchExpressions) > 0 {
-			exprs := make([]interface{}, 0, len(rule.MatchExpressions))
-			for _, e := range rule.MatchExpressions {
-				expr := map[string]interface{}{
-					"key":      e.Key,
-					"operator": e.Operator,
-				}
-				if len(e.Values) > 0 {
-					expr["values"] = e.Values
-				}
-				exprs = append(exprs, expr)
-			}
-			term["matchExpressions"] = exprs
+		terms = append(terms, buildNodeSelectorTerm(rule))
+	}
+	return terms
+}
+
+// buildNodeSelectorTerm converts a single AffinityRule to a node selector term.
+func buildNodeSelectorTerm(rule task.AffinityRule) map[string]interface{} {
+	term := map[string]interface{}{}
+	// Convert MatchExpressions
+	if len(rule.MatchExpressions) > 0 {
+		term["matchExpressions"] = buildMatchExpressions(rule.MatchExpressions)
+	}
+	// Convert MatchLabels to matchExpressions with In operator
+	if len(rule.MatchLabels) > 0 {
+		exprs := make([]interface{}, 0, len(rule.MatchLabels))
+		for k, v := range rule.MatchLabels {
+			exprs = append(exprs, map[string]interface{}{
+				"key":      k,
+				"operator": constants.AffinityOperatorIn,
+				"values":   []interface{}{v},
+			})
 		}
-		// Convert MatchLabels to matchExpressions with In operator
-		if len(rule.MatchLabels) > 0 {
-			exprs := make([]interface{}, 0, len(rule.MatchLabels))
-			for k, v := range rule.MatchLabels {
-				exprs = append(exprs, map[string]interface{}{
-					"key":      k,
-					"operator": constants.AffinityOperatorIn,
-					"values":   []string{v},
-				})
-			}
-			if existing, ok := term["matchExpressions"]; ok {
-				if existingArr, ok := existing.([]interface{}); ok {
-					term["matchExpressions"] = append(existingArr, exprs...)
-				} else {
-					term["matchExpressions"] = exprs
-				}
+		if existing, ok := term["matchExpressions"]; ok {
+			if existingArr, ok := existing.([]interface{}); ok {
+				term["matchExpressions"] = append(existingArr, exprs...)
 			} else {
 				term["matchExpressions"] = exprs
 			}
+		} else {
+			term["matchExpressions"] = exprs
 		}
-		// Convert MatchFields
-		if len(rule.MatchFields) > 0 {
-			fields := make([]interface{}, 0, len(rule.MatchFields))
-			for _, f := range rule.MatchFields {
-				field := map[string]interface{}{
-					"key":      f.Key,
-					"operator": f.Operator,
-				}
-				if len(f.Values) > 0 {
-					field["values"] = f.Values
-				}
-				fields = append(fields, field)
-			}
-			term["matchFields"] = fields
-		}
-		terms = append(terms, term)
 	}
-	return terms
+	// Convert MatchFields
+	if len(rule.MatchFields) > 0 {
+		term["matchFields"] = buildMatchExpressions(rule.MatchFields)
+	}
+	return term
+}
+
+// buildTopologySpreadConstraints generates a single TopologySpreadConstraint for
+// node-target spread policy. Returns nil for any other policy/target combination.
+// The constraint uses a hardcoded topologyKey (kubernetes.io/hostname) and a
+// self-referential labelSelector matching the job name (injected by the Kubeflow
+// Training Operator onto all pods it creates). Rules do not affect TSC — they
+// only control nodeAffinity (node selection) via applyNodeRules.
+func buildTopologySpreadConstraints(a *task.Affinity, jobName string) []interface{} {
+	if a == nil || a.Policy != "spread" || a.Target != "node" {
+		return nil
+	}
+	constraint := a.Constraint
+	if constraint == "" {
+		constraint = "preferred"
+	}
+	whenUnsatisfiable := "DoNotSchedule"
+	if constraint == "preferred" {
+		whenUnsatisfiable = "ScheduleAnyway"
+	}
+
+	tsc := selfAffinityTerm(jobName)
+	tsc["maxSkew"] = int64(1)
+	tsc["whenUnsatisfiable"] = whenUnsatisfiable
+
+	return []interface{}{tsc}
 }
 
 // buildInitContainers creates init containers from task.Init and task.Sync.
@@ -1063,12 +1087,13 @@ func buildPodSpec(t *task.Task, container map[string]interface{}, includeVolumes
 	buildScheduling(t, podSpec)
 
 	// Affinity
-	affinity, err := buildAffinity(t.Scheduling.Affinity, t.Name)
-	if err != nil {
-		return nil, fmt.Errorf("failed to build affinity: %w", err)
-	}
-	if affinity != nil {
+	if affinity := buildAffinity(t.Scheduling.Affinity, t.Name); affinity != nil {
 		podSpec["affinity"] = affinity
+	}
+
+	// Topology spread constraints (node target + spread policy only)
+	if tsc := buildTopologySpreadConstraints(t.Scheduling.Affinity, t.Name); len(tsc) > 0 {
+		podSpec["topologySpreadConstraints"] = tsc
 	}
 
 	return podSpec, nil

--- a/pkg/provider/interface_test.go
+++ b/pkg/provider/interface_test.go
@@ -387,10 +387,7 @@ func TestBuildPodAffinityTerms_MatchExpressions(t *testing.T) {
 			},
 		},
 	}
-	terms, err := buildPodAffinityTerms(rules, "preferred")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	terms := buildPodAffinityTerms(rules, "preferred")
 	if len(terms) != 1 {
 		t.Fatalf("expected 1 term, got %d", len(terms))
 	}
@@ -405,8 +402,8 @@ func TestBuildPodAffinityTerms_MatchExpressions(t *testing.T) {
 	if expr0["key"] != "app" || expr0["operator"] != "In" {
 		t.Errorf("unexpected first expression: %v", expr0)
 	}
-	vals := expr0["values"].([]string)
-	if len(vals) != 2 || vals[0] != "web" {
+	vals := expr0["values"].([]interface{})
+	if len(vals) != 2 || vals[0].(string) != "web" {
 		t.Errorf("unexpected values: %v", vals)
 	}
 }
@@ -419,14 +416,11 @@ func TestBuildPodAffinityTerms_Namespaces(t *testing.T) {
 			Namespaces:  []string{"ns1", "ns2"},
 		},
 	}
-	terms, err := buildPodAffinityTerms(rules, "preferred")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	terms := buildPodAffinityTerms(rules, "preferred")
 	wt := terms[0].(map[string]interface{})
 	podTerm := wt["podAffinityTerm"].(map[string]interface{})
-	ns := podTerm["namespaces"].([]string)
-	if len(ns) != 2 || ns[0] != "ns1" || ns[1] != "ns2" {
+	ns := podTerm["namespaces"].([]interface{})
+	if len(ns) != 2 || ns[0].(string) != "ns1" || ns[1].(string) != "ns2" {
 		t.Errorf("expected namespaces [ns1, ns2], got %v", ns)
 	}
 }
@@ -444,14 +438,11 @@ func TestBuildPodAffinityTerms_NamespaceSelector(t *testing.T) {
 			},
 		},
 	}
-	terms, err := buildPodAffinityTerms(rules, "required")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	terms := buildPodAffinityTerms(rules, "required")
 	term := terms[0].(map[string]interface{})
 	nsSel := term["namespaceSelector"].(map[string]interface{})
-	ml := nsSel["matchLabels"].(map[string]string)
-	if ml["env"] != "prod" {
+	ml := nsSel["matchLabels"].(map[string]interface{})
+	if ml["env"].(string) != "prod" {
 		t.Errorf("expected namespaceSelector matchLabels env=prod, got %v", ml)
 	}
 	exprs := nsSel["matchExpressions"].([]interface{})
@@ -485,8 +476,8 @@ func TestBuildNodeSelectorTerms_MatchFields(t *testing.T) {
 	if field["key"] != "metadata.name" || field["operator"] != "In" {
 		t.Errorf("unexpected matchField: %v", field)
 	}
-	vals := field["values"].([]string)
-	if len(vals) != 1 || vals[0] != "node-1" {
+	vals := field["values"].([]interface{})
+	if len(vals) != 1 || vals[0].(string) != "node-1" {
 		t.Errorf("unexpected matchField values: %v", vals)
 	}
 }

--- a/pkg/task/setter_test.go
+++ b/pkg/task/setter_test.go
@@ -1287,9 +1287,10 @@ worker:
 	result, err := ApplySetOverrides(yamlData, []string{
 		"scheduling.affinity.policy=spread",
 		"scheduling.affinity.constraint=preferred",
-		"scheduling.affinity.target=node",
+		"scheduling.affinity.target=pod",
 		"scheduling.affinity.rules[0].topology_key=kubernetes.io/hostname",
 		"scheduling.affinity.rules[0].weight=100",
+		"scheduling.affinity.rules[0].match_labels.app=web",
 	})
 	require.NoError(t, err)
 
@@ -1298,10 +1299,11 @@ worker:
 	require.NotNil(t, tk.Scheduling.Affinity)
 	assert.Equal(t, "spread", tk.Scheduling.Affinity.Policy)
 	assert.Equal(t, "preferred", tk.Scheduling.Affinity.Constraint)
-	assert.Equal(t, "node", tk.Scheduling.Affinity.Target)
+	assert.Equal(t, "pod", tk.Scheduling.Affinity.Target)
 	require.Len(t, tk.Scheduling.Affinity.Rules, 1)
 	assert.Equal(t, "kubernetes.io/hostname", tk.Scheduling.Affinity.Rules[0].TopologyKey)
 	assert.Equal(t, 100, tk.Scheduling.Affinity.Rules[0].Weight)
+	assert.Equal(t, map[string]string{"app": "web"}, tk.Scheduling.Affinity.Rules[0].MatchLabels)
 }
 
 func TestApplySetOverrides_NodeSelector(t *testing.T) {

--- a/pkg/task/types.go
+++ b/pkg/task/types.go
@@ -601,8 +601,9 @@ func validateScheduling(t *Task) error {
 			if !affinityPolicies[a.Policy] {
 				return fmt.Errorf("affinity.policy must be 'spread', 'binpack', or 'none', got %q", a.Policy)
 			}
-			if len(a.Rules) == 0 {
-				return fmt.Errorf("affinity.policy %q requires at least one rule", a.Policy)
+			// rules required for pod target; optional for node target (topology and labelSelector are fixed)
+			if len(a.Rules) == 0 && a.Target != "node" {
+				return fmt.Errorf("affinity.policy %q requires at least one rule (or set target to node)", a.Policy)
 			}
 		}
 		// constraint validation
@@ -611,8 +612,9 @@ func validateScheduling(t *Task) error {
 				return fmt.Errorf("affinity.constraint must be 'preferred' or 'required', got %q", a.Constraint)
 			}
 		}
-		// weight validation: preferred mode requires weight 1-100 (skip for 'none' policy)
-		if a.Policy != "none" {
+		// weight validation: preferred mode requires weight 1-100
+		// (skipped for none/unset policy — rules are ignored there)
+		if a.Policy != "" && a.Policy != "none" {
 			constraint := a.Constraint
 			if constraint == "" {
 				constraint = "preferred"
@@ -623,6 +625,54 @@ func validateScheduling(t *Task) error {
 						return fmt.Errorf("affinity rule[%d]: weight must be 1-100 for preferred scheduling, got %d", i, rule.Weight)
 					}
 				}
+			}
+		}
+		// per-target field applicability and match expression validation
+		for i, rule := range a.Rules {
+			if err := validateLabels(rule.MatchLabels, fmt.Sprintf("affinity rule[%d].match_labels", i)); err != nil {
+				return err
+			}
+			switch a.Target {
+			case "pod":
+				if len(rule.MatchFields) > 0 {
+					return fmt.Errorf("affinity rule[%d]: match_fields is only valid for target: node", i)
+				}
+				if rule.TopologyKey != "" {
+					if errs := validation.IsQualifiedName(rule.TopologyKey); len(errs) > 0 {
+						return fmt.Errorf("affinity rule[%d]: invalid topology_key %q: %s", i, rule.TopologyKey, strings.Join(errs, ", "))
+					}
+				}
+				for _, ns := range rule.Namespaces {
+					if errs := validation.IsDNS1123Label(ns); len(errs) > 0 {
+						return fmt.Errorf("affinity rule[%d]: invalid namespace %q: %s", i, ns, strings.Join(errs, ", "))
+					}
+				}
+				if err := validateMatchExpressions(rule.MatchExpressions, "pod", fmt.Sprintf("affinity rule[%d].match_expressions", i)); err != nil {
+					return err
+				}
+				if err := validateLabelSelector(rule.NamespaceSelector, fmt.Sprintf("affinity rule[%d].namespace_selector", i)); err != nil {
+					return err
+				}
+			case "node":
+				if rule.TopologyKey != "" {
+					return fmt.Errorf("affinity rule[%d]: topology_key is only valid for target: pod", i)
+				}
+				if len(rule.Namespaces) > 0 {
+					return fmt.Errorf("affinity rule[%d]: namespaces is only valid for target: pod", i)
+				}
+				if rule.NamespaceSelector != nil {
+					return fmt.Errorf("affinity rule[%d]: namespace_selector is only valid for target: pod", i)
+				}
+				if err := validateMatchExpressions(rule.MatchExpressions, "node", fmt.Sprintf("affinity rule[%d].match_expressions", i)); err != nil {
+					return err
+				}
+				if err := validateMatchFields(rule.MatchFields, fmt.Sprintf("affinity rule[%d].match_fields", i)); err != nil {
+					return err
+				}
+			}
+			// An empty selector matches nothing and silently makes the job unschedulable.
+			if len(rule.MatchLabels) == 0 && len(rule.MatchExpressions) == 0 && len(rule.MatchFields) == 0 {
+				return fmt.Errorf("affinity rule[%d]: at least one of match_labels, match_expressions, or match_fields is required", i)
 			}
 		}
 	}
@@ -636,6 +686,85 @@ func validateScheduling(t *Task) error {
 		}
 		if tol.Operator == "Exists" && tol.Value != "" {
 			return fmt.Errorf("toleration[%d]: Exists operator must not have a value", i)
+		}
+	}
+	return nil
+}
+
+// validateMatchExpressions checks operator enum, values cardinality, and key presence.
+// Node-target selectors additionally allow Gt/Lt operators.
+func validateMatchExpressions(exprs []MatchExpression, target, field string) error {
+	for j, e := range exprs {
+		loc := fmt.Sprintf("%s[%d]", field, j)
+		if e.Key == "" {
+			return fmt.Errorf("%s: key must not be empty", loc)
+		}
+		if errs := validation.IsQualifiedName(e.Key); len(errs) > 0 {
+			return fmt.Errorf("%s: invalid key %q: %s", loc, e.Key, strings.Join(errs, ", "))
+		}
+		switch e.Operator {
+		case "In", "NotIn":
+			if len(e.Values) == 0 {
+				return fmt.Errorf("%s: operator %q requires at least one value", loc, e.Operator)
+			}
+		case "Exists", "DoesNotExist":
+			if len(e.Values) > 0 {
+				return fmt.Errorf("%s: operator %q must not have values", loc, e.Operator)
+			}
+		case "Gt", "Lt":
+			if target != "node" {
+				return fmt.Errorf("%s: operator %q is only valid for target: node", loc, e.Operator)
+			}
+			if len(e.Values) != 1 {
+				return fmt.Errorf("%s: operator %q requires exactly one value", loc, e.Operator)
+			}
+			if _, err := strconv.Atoi(e.Values[0]); err != nil {
+				return fmt.Errorf("%s: operator %q requires an integer value, got %q", loc, e.Operator, e.Values[0])
+			}
+		default:
+			return fmt.Errorf("%s: invalid operator %q", loc, e.Operator)
+		}
+	}
+	return nil
+}
+
+// validateMatchFields enforces the K8s apiserver rules for nodeSelectorTerm
+// matchFields: key must be "metadata.name", operator In or NotIn, exactly one value.
+func validateMatchFields(fields []MatchExpression, field string) error {
+	for j, f := range fields {
+		loc := fmt.Sprintf("%s[%d]", field, j)
+		if f.Key != "metadata.name" {
+			return fmt.Errorf("%s: key must be \"metadata.name\", got %q", loc, f.Key)
+		}
+		if f.Operator != "In" && f.Operator != "NotIn" {
+			return fmt.Errorf("%s: operator must be In or NotIn, got %q", loc, f.Operator)
+		}
+		if len(f.Values) != 1 {
+			return fmt.Errorf("%s: exactly one value is required, got %d", loc, len(f.Values))
+		}
+	}
+	return nil
+}
+
+// validateLabelSelector validates match_labels and match_expressions inside a label selector.
+func validateLabelSelector(sel *LabelSelector, field string) error {
+	if sel == nil {
+		return nil
+	}
+	if err := validateLabels(sel.MatchLabels, field+".match_labels"); err != nil {
+		return err
+	}
+	return validateMatchExpressions(sel.MatchExpressions, "pod", field+".match_expressions")
+}
+
+// validateLabels checks that label keys and values follow K8s label syntax.
+func validateLabels(labels map[string]string, field string) error {
+	for k, v := range labels {
+		if errs := validation.IsQualifiedName(k); len(errs) > 0 {
+			return fmt.Errorf("%s: invalid label key %q: %s", field, k, strings.Join(errs, ", "))
+		}
+		if errs := validation.IsValidLabelValue(v); len(errs) > 0 {
+			return fmt.Errorf("%s: invalid label value %q for key %q: %s", field, v, k, strings.Join(errs, ", "))
 		}
 	}
 	return nil

--- a/pkg/task/types_test.go
+++ b/pkg/task/types_test.go
@@ -606,7 +606,8 @@ func TestValidateAffinityInvalidTarget(t *testing.T) {
 	assert.Contains(t, err.Error(), "affinity.target must be 'pod' or 'node'")
 }
 
-func TestValidateAffinityPolicyWithNodeRequiresRules(t *testing.T) {
+func TestValidateAffinityPolicyWithPodRequiresRules(t *testing.T) {
+	// pod target with policy but no rules should fail (rules required for pod)
 	task := &Task{
 		Name:      "t",
 		Image:     "x:1",
@@ -615,7 +616,7 @@ func TestValidateAffinityPolicyWithNodeRequiresRules(t *testing.T) {
 		Worker:    &Worker{Replicas: 1},
 		Scheduling: Scheduling{
 			Affinity: &Affinity{
-				Target: "node",
+				Target: "pod",
 				Policy: "spread",
 			},
 		},
@@ -623,6 +624,36 @@ func TestValidateAffinityPolicyWithNodeRequiresRules(t *testing.T) {
 	err := Validate(task)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "requires at least one rule")
+}
+
+func TestValidateAffinityNodeTargetWithoutRules(t *testing.T) {
+	// target: node with policy but no rules should be valid (rules optional for node)
+	tests := []struct {
+		name   string
+		policy string
+	}{
+		{"spread without rules", "spread"},
+		{"binpack without rules", "binpack"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			task := &Task{
+				Name:      "t",
+				Image:     "x:1",
+				Run:       "train",
+				Framework: Framework{Name: "pytorch"},
+				Worker:    &Worker{Replicas: 1},
+				Scheduling: Scheduling{
+					Affinity: &Affinity{
+						Target: "node",
+						Policy: tt.policy,
+					},
+				},
+			}
+			err := Validate(task)
+			require.NoError(t, err, "target:node with %s policy should be valid without rules", tt.policy)
+		})
+	}
 }
 
 func TestValidateAffinityInvalidPolicy(t *testing.T) {
@@ -675,7 +706,7 @@ func TestValidateAffinityValidConfigurations(t *testing.T) {
 			Affinity: &Affinity{
 				Target: "pod",
 				Policy: "spread",
-				Rules:  []AffinityRule{{TopologyKey: "kubernetes.io/hostname", Weight: 50}},
+				Rules:  []AffinityRule{{TopologyKey: "kubernetes.io/hostname", Weight: 50, MatchLabels: map[string]string{"app": "web"}}},
 			},
 		},
 	}
@@ -698,7 +729,7 @@ func TestValidateAffinityValidConfigurations(t *testing.T) {
 		Target:     "pod",
 		Policy:     "spread",
 		Constraint: "required",
-		Rules:      []AffinityRule{{TopologyKey: "kubernetes.io/hostname"}},
+		Rules:      []AffinityRule{{TopologyKey: "kubernetes.io/hostname", MatchLabels: map[string]string{"app": "web"}}},
 	}
 	err = Validate(task)
 	require.NoError(t, err)
@@ -707,7 +738,7 @@ func TestValidateAffinityValidConfigurations(t *testing.T) {
 	task.Scheduling.Affinity = &Affinity{
 		Target: "pod",
 		Policy: "none",
-		Rules:  []AffinityRule{{TopologyKey: "kubernetes.io/hostname"}},
+		Rules:  []AffinityRule{{TopologyKey: "kubernetes.io/hostname", MatchLabels: map[string]string{"app": "web"}}},
 	}
 	err = Validate(task)
 	require.NoError(t, err)
@@ -741,7 +772,7 @@ func TestValidateAffinityWeight(t *testing.T) {
 						Target:     "pod",
 						Policy:     "spread",
 						Constraint: tt.constraint,
-						Rules:      []AffinityRule{{TopologyKey: "kubernetes.io/hostname", Weight: tt.weight}},
+						Rules:      []AffinityRule{{TopologyKey: "kubernetes.io/hostname", Weight: tt.weight, MatchLabels: map[string]string{"app": "web"}}},
 					},
 				},
 			}
@@ -754,6 +785,254 @@ func TestValidateAffinityWeight(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestValidateAffinityTargetSpecificFields(t *testing.T) {
+	tests := []struct {
+		name      string
+		target    string
+		rule      AffinityRule
+		wantErr   bool
+		errSubstr string
+	}{
+		{"pod rule with match_fields rejected", "pod",
+			AffinityRule{TopologyKey: "kubernetes.io/hostname", Weight: 50,
+				MatchFields: []MatchExpression{{Key: "metadata.name", Operator: "In", Values: []string{"n1"}}}},
+			true, "match_fields is only valid for target: node"},
+		{"node rule with topology_key rejected", "node",
+			AffinityRule{TopologyKey: "kubernetes.io/hostname", Weight: 50},
+			true, "topology_key is only valid for target: pod"},
+		{"node rule with namespaces rejected", "node",
+			AffinityRule{Weight: 50, Namespaces: []string{"ns1"}},
+			true, "namespaces is only valid for target: pod"},
+		{"node rule with namespace_selector rejected", "node",
+			AffinityRule{Weight: 50, NamespaceSelector: &LabelSelector{MatchLabels: map[string]string{"env": "prod"}}},
+			true, "namespace_selector is only valid for target: pod"},
+		{"node rule with match_expressions valid", "node",
+			AffinityRule{Weight: 50, MatchExpressions: []MatchExpression{{Key: "gpu", Operator: "Exists"}}},
+			false, ""},
+		{"pod rule with namespaces valid", "pod",
+			AffinityRule{TopologyKey: "kubernetes.io/hostname", Weight: 50, Namespaces: []string{"ns1"},
+				MatchLabels: map[string]string{"app": "web"}},
+			false, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			task := &Task{
+				Name:      "t",
+				Image:     "x:1",
+				Run:       "train",
+				Framework: Framework{Name: "pytorch"},
+				Worker:    &Worker{Replicas: 1},
+				Scheduling: Scheduling{
+					Affinity: &Affinity{
+						Target:     tt.target,
+						Policy:     "spread",
+						Constraint: "preferred",
+						Rules:      []AffinityRule{tt.rule},
+					},
+				},
+			}
+			err := Validate(task)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errSubstr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateAffinityRuleSelectorsAndSyntax(t *testing.T) {
+	tests := []struct {
+		name      string
+		target    string
+		rule      AffinityRule
+		wantErr   bool
+		errSubstr string
+	}{
+		{"pod rule without any selector rejected", "pod",
+			AffinityRule{TopologyKey: "kubernetes.io/hostname", Weight: 50},
+			true, "at least one of match_labels, match_expressions, or match_fields"},
+		{"node rule without any selector rejected", "node",
+			AffinityRule{Weight: 50},
+			true, "at least one of match_labels, match_expressions, or match_fields"},
+		{"invalid label key rejected", "pod",
+			AffinityRule{Weight: 50, MatchLabels: map[string]string{"-bad key": "v"}},
+			true, "invalid label key"},
+		{"invalid label value rejected", "pod",
+			AffinityRule{Weight: 50, MatchLabels: map[string]string{"app": "bad value!"}},
+			true, "invalid label value"},
+		{"invalid topology_key rejected", "pod",
+			AffinityRule{TopologyKey: "bad//key", Weight: 50, MatchLabels: map[string]string{"app": "web"}},
+			true, "invalid topology_key"},
+		{"invalid namespace rejected", "pod",
+			AffinityRule{Weight: 50, MatchLabels: map[string]string{"app": "web"}, Namespaces: []string{"Bad_NS"}},
+			true, "invalid namespace"},
+		{"invalid expression key rejected", "node",
+			AffinityRule{Weight: 50, MatchExpressions: []MatchExpression{{Key: "bad key!", Operator: "Exists"}}},
+			true, "invalid key"},
+		{"namespace_selector invalid label key rejected", "pod",
+			AffinityRule{Weight: 50, MatchLabels: map[string]string{"app": "web"},
+				NamespaceSelector: &LabelSelector{MatchLabels: map[string]string{"bad key": "v"}}},
+			true, "namespace_selector.match_labels"},
+		{"valid dotted prefixed keys accepted", "pod",
+			AffinityRule{TopologyKey: "topology.kubernetes.io/zone", Weight: 50,
+				MatchLabels: map[string]string{"training.kubeflow.org/job-name": "my-job"}},
+			false, ""},
+		{"match_fields wrong key rejected", "node",
+			AffinityRule{Weight: 50, MatchFields: []MatchExpression{{Key: "spec.nodeName", Operator: "In", Values: []string{"n1"}}}},
+			true, `key must be "metadata.name"`},
+		{"match_fields Exists operator rejected", "node",
+			AffinityRule{Weight: 50, MatchFields: []MatchExpression{{Key: "metadata.name", Operator: "Exists"}}},
+			true, "operator must be In or NotIn"},
+		{"match_fields multiple values rejected", "node",
+			AffinityRule{Weight: 50, MatchFields: []MatchExpression{{Key: "metadata.name", Operator: "In", Values: []string{"n1", "n2"}}}},
+			true, "exactly one value is required"},
+		{"valid match_fields accepted", "node",
+			AffinityRule{Weight: 50, MatchFields: []MatchExpression{{Key: "metadata.name", Operator: "NotIn", Values: []string{"n1"}}}},
+			false, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			task := &Task{
+				Name:      "t",
+				Image:     "x:1",
+				Run:       "train",
+				Framework: Framework{Name: "pytorch"},
+				Worker:    &Worker{Replicas: 1},
+				Scheduling: Scheduling{
+					Affinity: &Affinity{
+						Target:     tt.target,
+						Policy:     "spread",
+						Constraint: "preferred",
+						Rules:      []AffinityRule{tt.rule},
+					},
+				},
+			}
+			err := Validate(task)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errSubstr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateAffinityWeightSkippedForInactivePolicy(t *testing.T) {
+	// Unset and "none" policy behave identically: rules are ignored,
+	// so the weight 1-100 requirement must not apply to either.
+	for _, policy := range []string{"", "none"} {
+		t.Run("policy_"+policy, func(t *testing.T) {
+			task := &Task{
+				Name:      "t",
+				Image:     "x:1",
+				Run:       "train",
+				Framework: Framework{Name: "pytorch"},
+				Worker:    &Worker{Replicas: 1},
+				Scheduling: Scheduling{
+					Affinity: &Affinity{
+						Target: "pod",
+						Policy: policy,
+						Rules:  []AffinityRule{{MatchLabels: map[string]string{"app": "web"}}}, // weight 0
+					},
+				},
+			}
+			require.NoError(t, Validate(task))
+		})
+	}
+}
+
+func TestValidateAffinityMatchExpressions(t *testing.T) {
+	tests := []struct {
+		name      string
+		target    string
+		exprs     []MatchExpression
+		wantErr   bool
+		errSubstr string
+	}{
+		{"valid In", "pod", []MatchExpression{{Key: "app", Operator: "In", Values: []string{"web"}}}, false, ""},
+		{"valid Exists", "node", []MatchExpression{{Key: "gpu", Operator: "Exists"}}, false, ""},
+		{"valid Gt on node", "node", []MatchExpression{{Key: "gpu-count", Operator: "Gt", Values: []string{"2"}}}, false, ""},
+		{"Gt rejected on pod", "pod", []MatchExpression{{Key: "gpu-count", Operator: "Gt", Values: []string{"2"}}},
+			true, "only valid for target: node"},
+		{"empty key rejected", "pod", []MatchExpression{{Operator: "In", Values: []string{"v"}}},
+			true, "key must not be empty"},
+		{"unknown operator rejected", "node", []MatchExpression{{Key: "k", Operator: "Contains", Values: []string{"v"}}},
+			true, "invalid operator"},
+		{"In without values rejected", "pod", []MatchExpression{{Key: "app", Operator: "In"}},
+			true, "requires at least one value"},
+		{"Exists with values rejected", "node", []MatchExpression{{Key: "gpu", Operator: "Exists", Values: []string{"1"}}},
+			true, "must not have values"},
+		{"Gt with multiple values rejected", "node", []MatchExpression{{Key: "gpu", Operator: "Gt", Values: []string{"1", "2"}}},
+			true, "requires exactly one value"},
+		{"Gt with non-integer rejected", "node", []MatchExpression{{Key: "gpu", Operator: "Gt", Values: []string{"many"}}},
+			true, "requires an integer value"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rule := AffinityRule{TopologyKey: "kubernetes.io/hostname", Weight: 50, MatchExpressions: tt.exprs}
+			if tt.target == "node" {
+				rule = AffinityRule{Weight: 50, MatchExpressions: tt.exprs}
+			}
+			task := &Task{
+				Name:      "t",
+				Image:     "x:1",
+				Run:       "train",
+				Framework: Framework{Name: "pytorch"},
+				Worker:    &Worker{Replicas: 1},
+				Scheduling: Scheduling{
+					Affinity: &Affinity{
+						Target:     tt.target,
+						Policy:     "spread",
+						Constraint: "preferred",
+						Rules:      []AffinityRule{rule},
+					},
+				},
+			}
+			err := Validate(task)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errSubstr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateAffinityNamespaceSelectorExpressions(t *testing.T) {
+	task := &Task{
+		Name:      "t",
+		Image:     "x:1",
+		Run:       "train",
+		Framework: Framework{Name: "pytorch"},
+		Worker:    &Worker{Replicas: 1},
+		Scheduling: Scheduling{
+			Affinity: &Affinity{
+				Target:     "pod",
+				Policy:     "spread",
+				Constraint: "preferred",
+				Rules: []AffinityRule{{
+					TopologyKey: "kubernetes.io/hostname",
+					Weight:      50,
+					NamespaceSelector: &LabelSelector{
+						MatchExpressions: []MatchExpression{{Key: "team", Operator: "In"}},
+					},
+				}},
+			},
+		},
+	}
+	err := Validate(task)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "namespace_selector.match_expressions[0]")
+	assert.Contains(t, err.Error(), "requires at least one value")
 }
 
 func TestValidateTolerations(t *testing.T) {


### PR DESCRIPTION
## Purpose

The affinity model previously used incorrect operator negation for node spread and was missing `preference` wrappers in nodeAffinity preferred terms. This PR redesigns it to use correct K8s mechanisms.

## Changes

- `target: node` + `spread` → `topologySpreadConstraints` (self-referential job-name labelSelector, hostname topologyKey)
- `target: node` + `binpack` → `podAffinity` with self-referential labelSelector
- Rules optional for `target: node`
- Fix `preference` wrapper nesting and `int`→`int64` weight type
- Add `DefaultTopologyKey` constant
- Update docs with K8s mechanism mapping table

## Checklist

- [x] `make v2-fmt` / `make v2-vet` / `make v2-lint`
- [x] `make v2-test`
- [x] `go mod tidy`
- [x] Conventional commits