### PR TITLE
feat(cli): align v1 flag compatibility for submit

### DIFF
--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -243,6 +243,8 @@ This is a single API call in v2, compared to v1's three-step delete process (rea
 
 The `sync` block generates init containers that run before the main training container. Use `git` for source code, `rsync` for remote files, and `hdfs` for HDFS-stored datasets. Each entry creates a named init container (`arena-sync-0`, `arena-sync-1`, ...).
 
+Sync write targets must be `tmp` or `shm` storages: a `local_path` that resolves to a `pvc`, `hostpath`, `configmap`, or `secret` storage is rejected at submit time. If the data already lives on a PVC, mount the PVC directly instead of pulling it per-pod with sync.
+
 ```yaml
 sync:
   - git: https://github.com/org/training-code.git
@@ -306,7 +308,7 @@ sync:
 
 ### Watch for local_path / mount mismatches
 
-If a sync entry's `local_path` does not match any resolved mount path, the synced data is written to the container's ephemeral storage and will be lost when the pod restarts. Arena prints a warning to stderr when this happens. Always ensure `local_path` matches a `mount_path` in the same entry's `mounts` list or in the referenced storage.
+If a sync entry's `local_path` is not equal to or under a resolved mount path, the synced data is written to the container's ephemeral storage and will be lost when the pod restarts. Arena prints a warning to stderr when this happens. Always ensure `local_path` matches a `mount_path` in the same entry's `mounts` list or in the referenced storage.
 
 ```yaml
 # Correct: local_path matches the mount_path
@@ -317,6 +319,19 @@ sync:
       - name: code
         mount_path: /code      # ← matches local_path
 ```
+
+### User-defined init containers are not validated
+
+The sync storage validation only covers `sync` entries. `init` entries run in
+every pod of the job too, but Arena does not validate what they write — an
+init container that mounts a `pvc` or `hostpath` storage and writes to it
+reintroduces exactly the concurrent-write hazard the sync validation rejects:
+multiple pods writing the same volume at once (git/rsync races on shared
+directories, RWO volumes sticking pods in `Pending` across nodes, silent
+corruption on RWX volumes). Arena cannot infer a container's write intent, so
+it does not block these configurations — you are responsible for ensuring
+your init containers write only to per-pod ephemeral storage, or coordinate
+shared-volume writes yourself.
 
 ## TensorBoard Integration
 
@@ -449,7 +464,7 @@ Instead of remembering 40+ CLI flags, define your job in YAML and use `--set` fo
 ```shell
 # v1 style (many flags)
 arena submit pytorchjob --name exp01 --workers 5 --gpus 2 --cpu 8 --memory 32Gi \
-  --data dataset:/data:training-pvc --tensorboard --tensorboard-logdir /logs \
+  --data dataset:/data:training-pvc --tensorboard --logdir /logs \
   "python train.py"
 
 # v2 equivalent (YAML + --set)

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -394,7 +394,9 @@ Output is identical to [`arena job get`](#arena-job-get).
 
 Submit a training job using CLI flags instead of a YAML file.
 
-> **Note:** `arena job run` with a YAML file is the preferred method for v2. The `submit` command is provided for backward compatibility with v1 workflows.
+> **Note:** `arena job run` with a YAML file is the preferred method for v2. The `submit` command keeps the v1 flag interface so existing scripts work unchanged.
+
+> **Note:** Per-framework subcommands are also available: `arena submit pytorchjob`, `tfjob`, `mpijob`, `horovodjob`, and `deepspeedjob`, plus v1 aliases like `pytorch`, `tf`, and `mpi`. Each subcommand's `--help` shows only that framework's flags; the generic `arena submit <type>` form keeps working unchanged.
 
 ### Syntax
 
@@ -426,42 +428,43 @@ Trailing arguments after `--` are used as the run command.
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
 | `--gpus` | int | `0` | Number of GPUs per worker |
-| `--cpus` | string | `""` | CPU request (e.g. `500m`, `2`) |
-| `--mem` | string | `""` | Memory request (e.g. `1Gi`, `512Mi`) |
+| `--cpu` | string | `""` | CPU request (e.g. `500m`, `2`) |
+| `--memory` | string | `""` | Memory request (e.g. `1Gi`, `512Mi`) |
 
 **Environment and data:**
 
 | Flag | Shorthand | Type | Default | Description |
 |------|-----------|------|---------|-------------|
-| `--env` | `-e` | stringSlice | `nil` | Environment variable (`key=value`, repeatable) |
-| `--data` | `-d` | stringSlice | `nil` | Data volume (`name:path:pvc`, repeatable) |
-| `--data-dir` | | stringSlice | `nil` | Host path volume (`name:path:hostpath`, repeatable) |
-| `--config-file` | | stringSlice | `nil` | ConfigMap volume (`name:path:configmap`, repeatable) |
-| `--label` | `-l` | stringSlice | `nil` | Label (`key=value`, repeatable) |
-| `--annotation` | `-a` | stringSlice | `nil` | Annotation (`key=value`, repeatable) |
+| `--env` | `-e` | stringArray | `nil` | Environment variable (`key=value`, repeatable) |
+| `--data` | `-d` | stringArray | `nil` | Data volume (`name:path:pvc`, repeatable); v1 form `<pvc>:<path>` also accepted (see migration guide) |
+| `--data-dir` | | stringArray | `nil` | Host path volume (`name:path:hostpath`, repeatable); v1 forms `<host_path>` / `<host_path>:<container_path>` also accepted (see migration guide) |
+| `--config-file` | | stringArray | `nil` | ConfigMap volume (`name:path:configmap`, repeatable); the v1 host-file form is rejected with guidance (see migration guide) |
+| `--label` | `-l` | stringArray | `nil` | Label (`key=value`, repeatable) |
+| `--annotation` | `-a` | stringArray | `nil` | Annotation (`key=value`, repeatable) |
 
 **Scheduling:**
 
-| Flag | Type | Default | Description |
-|------|------|---------|-------------|
-| `--selector` | stringSlice | `nil` | Node selector (`key=value`, repeatable) |
-| `--toleration` | stringSlice | `nil` | Toleration (`key=value:effect`, repeatable) |
-| `--priority` | int | `0` | Pod priority value |
-| `--priority-class-name` | string | `""` | Priority class name |
-| `--gang` | bool | `false` | Enable gang scheduling |
-| `--scheduler-name` | string | `""` | Custom scheduler name |
-| `--affinity-policy` | string | `""` | Affinity policy |
-| `--affinity-constraint` | string | `""` | Affinity constraint |
-| `--queue` | string | `""` | Scheduling queue name |
+| Flag | Shorthand | Type | Default | Description |
+|------|-----------|------|---------|-------------|
+| `--selector` | | stringArray | `nil` | Node selector (`key=value`, repeatable) |
+| `--toleration` | | stringArray | `nil` | Toleration (`key=value:effect`, repeatable) |
+| `--priority` | `-p` | string | `""` | Priority class name (v1 semantics) |
+| `--gang` | | bool | `false` | Enable gang scheduling |
+| `--scheduler` | | string | `""` | Custom scheduler name |
+| `--affinity-policy` | | string | `""` | Affinity policy |
+| `--affinity-constraint` | | string | `""` | Affinity constraint |
+| `--affinity-target` | | string | `""` | Affinity target (pod or node) |
+| `--queue` | | bool | `false` | Suspend the job so an external queue manager (e.g. [kube-queue](https://github.com/kube-queue/kube-queue)) can schedule it |
 
 **Lifecycle:**
 
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
-| `--clean-pod-policy` | string | `""` | Clean pod policy (`None`, `Running`, `All`) |
-| `--active-deadline` | string | `""` | Active deadline (e.g. `2h`, `7d`) |
+| `--clean-task-policy` | string | `Running` | Clean pod policy (`None`, `Running`, `All`); pass an empty value to use the operator default |
+| `--running-timeout` | string | `""` | Running timeout (e.g. `2h`, `7d`) |
 | `--ttl-after-finished` | string | `""` | TTL after finished (e.g. `7d`) |
-| `--backoff-limit` | int | `0` | Backoff limit for retries |
+| `--job-backoff-limit` | int | `0` | Max restart count for the job |
+| `--retry` | int | `0` | Times to retry the job (same as `--job-backoff-limit`) |
 | `--success-policy` | string | `""` | Success policy (`ChiefWorker`, `AllWorkers`, TF only) |
 
 **Runtime:**
@@ -469,12 +472,12 @@ Trailing arguments after `--` are used as the run command.
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
 | `--image-pull-policy` | string | `""` | Image pull policy (`Always`, `IfNotPresent`, `Never`) |
-| `--image-pull-secret` | stringSlice | `nil` | Image pull secret name (repeatable) |
+| `--image-pull-secret` | stringArray | `nil` | Image pull secret name (repeatable) |
 | `--service-account` | string | `""` | Service account name |
-| `--restart` | string | `""` | Restart policy (`Always`, `OnFailure`, `Never`) |
-| `--host-network` | bool | `false` | Use host network |
-| `--host-ipc` | bool | `false` | Use host IPC namespace |
-| `--host-pid` | bool | `false` | Use host PID namespace |
+| `--job-restart-policy` | string | `""` | Restart policy (`Always`, `OnFailure`, `Never`) |
+| `--hostNetwork` | bool | `false` | Use host network |
+| `--hostIPC` | bool | `false` | Use host IPC namespace |
+| `--hostPID` | bool | `false` | Use host PID namespace |
 
 **Task:**
 
@@ -482,8 +485,8 @@ Trailing arguments after `--` are used as the run command.
 |------|------|---------|-------------|
 | `--working-dir` | string | `""` | Working directory in container |
 | `--shell` | string | `""` | Shell to use (default `/bin/sh`) |
-| `--shm` | string | `""` | Shared memory size (e.g. `8Gi`) |
-| `--device` | stringSlice | `nil` | Extended resource (`name=count`, repeatable) |
+| `--share-memory` | string | `2Gi` | Shared memory size (e.g. `8Gi`); pass an empty value to skip the `/dev/shm` volume |
+| `--device` | stringArray | `nil` | Extended resource (`name=count`, repeatable) |
 | `--gpu-type` | string | `""` | GPU type (sets node selector `nvidia.com/gpu.product`) |
 
 **Logging / TensorBoard:**
@@ -491,7 +494,7 @@ Trailing arguments after `--` are used as the run command.
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
 | `--tensorboard` | bool | `false` | Enable TensorBoard sidecar |
-| `--tensorboard-logdir` | string | `""` | TensorBoard log directory |
+| `--logdir` | string | `/training_logs` | TensorBoard log directory; pass an empty value to opt out of the default |
 | `--tensorboard-image` | string | `""` | TensorBoard container image |
 
 **PyTorch-specific:**
@@ -504,7 +507,7 @@ Trailing arguments after `--` are used as the run command.
 
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
-| `--ps-count` | int | `0` | Number of parameter servers |
+| `--ps` | int | `0` | Number of parameter servers |
 | `--chief` | bool | `false` | Enable Chief worker |
 | `--evaluator` | bool | `false` | Enable Evaluator worker |
 
@@ -513,8 +516,48 @@ Trailing arguments after `--` are used as the run command.
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
 | `--slots-per-worker` | int | `0` | Slots per worker |
-| `--gpu-topology` | bool | `false` | Enable GPU topology annotation |
-| `--mounts-on-launcher` | bool | `false` | Mount volumes on launcher |
+| `--gputopology` | bool | `false` | Enable GPU topology (sets host networking, `gpu-topology` labels, and the MPI annotation) |
+| `--mounts-on-launcher` | bool | `false` | MPI: when false the launcher main container gets no volumeMounts; volumes stay declared in the pod spec so init containers keep their mounts. |
+
+**Code sync (v1 compatibility):**
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--sync-mode` | string | `""` | Code sync mode: `git`, `rsync`, or `hdfs` |
+| `--sync-source` | string | `""` | Sync source URL/path (required when `--sync-mode` is set) |
+| `--sync-image` | string | `""` | Image used by the sync init container (defaults per mode: git-sync, rsync, or HDFS image) |
+
+Synced code lands in `<working-dir>/code` (default `/root/code`) as an init container. The code is exchanged through a shared `code-sync` emptyDir volume mounted by both the sync init container and the main container (size limit 10Gi; v1 used an unlimited emptyDir). The `--sync-mode` path always uses this per-pod ephemeral `code-sync` emptyDir and never targets persistent storage, so it is unaffected by the sync write-target validation (see the YAML schema docs).
+
+**Per-role resources (TensorFlow):**
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--ps-cpu` | string | `""` | CPU for PS pods |
+| `--ps-memory` | string | `""` | Memory for PS pods |
+| `--ps-gpus` | int | `0` | GPUs for PS pods |
+| `--chief-cpu` | string | `""` | CPU for Chief pods |
+| `--chief-memory` | string | `""` | Memory for Chief pods |
+| `--evaluator-cpu` | string | `""` | CPU for Evaluator pods |
+| `--evaluator-memory` | string | `""` | Memory for Evaluator pods |
+| `--worker-cpu` | string | `""` | CPU for worker pods (overrides `--cpu`) |
+| `--worker-memory` | string | `""` | Memory for worker pods (overrides `--memory`) |
+
+Resource values are applied as both requests and limits (Guaranteed QoS). Role-specific flags win over the generic `--cpu`/`--memory`.
+
+The v1 `-limit` variants of the per-role flags (`--ps-cpu-limit`, `--worker-memory-limit`, etc.) are also accepted. A `-limit` flag overrides only the limit — requests stay at the request flag — so `--worker-cpu 1 --worker-cpu-limit 2` yields requests cpu=1 / limits cpu=2 (Burstable QoS). Without `-limit` flags, requests equal limits (Guaranteed QoS).
+
+**Deprecated v1 flags:**
+
+The remaining v1-only flags are accepted as deprecated compatibility flags so existing scripts do not break; most have no effect — see the table for exceptions. Using them prints a deprecation warning.
+
+| Flag | Behavior |
+|------|----------|
+| `--config <path>` | works (bound to `--kubeconfig`); deprecated |
+| `--loglevel <level>` | mapped to verbosity (`--verbose`): debug=2, info=1, warn/error=0 |
+| `--rdma` | ignored; request RDMA hardware with `--device <resource>=<count>` |
+| `--{ps,worker,chief,evaluator,launcher}-selector`, `--{worker,launcher}-annotation`, `--{ps,worker}-image`, `--{ps,worker,chief,ssh}-port`, `--{ps,worker}-affinity-{policy,constraint}` | accepted with a warning, ignored (needs per-role RoleConfig extension) |
+| `--pprof`, `--trace`, `--helm-binary`, `--arena-namespace`, `--model-name`, `--model-source`, `--starting-timeout`, `--role-sequence`, `--ssh-secret` | accepted with a warning, no effect |
 
 **Dry-run:**
 
@@ -534,7 +577,7 @@ $ arena submit pytorch --name my-job --image pytorch/pytorch:2.3.0-cuda12.1-cudn
 
 # Submit a TensorFlow job with chief and parameter server
 $ arena submit tensorflow --name tf-job --image tensorflow/tensorflow:2.16.1-gpu \
-    --workers 3 --gpus 1 --chief --ps-count 1 -- python -c "import tensorflow as tf; print('TF:', tf.__version__)"
+    --workers 3 --gpus 1 --chief --ps 1 -- python -c "import tensorflow as tf; print('TF:', tf.__version__)"
 
 # Submit an MPI job with deepspeed
 $ arena submit deepspeed --name ds-job --image deepspeed/deepspeed \
@@ -542,6 +585,12 @@ $ arena submit deepspeed --name ds-job --image deepspeed/deepspeed \
 
 # Dry-run to inspect the generated CRD
 $ arena submit pytorch --name my-job --image pytorch/pytorch --dry-run
+
+# Git code sync with a priority class and per-worker resources
+$ arena submit pytorch --name sync-job --image pytorch/pytorch:2.3.0-cuda12.1-cudnn8-runtime \
+    --workers 3 --gpus 1 --cpu 4 --memory 16Gi -p high \
+    --sync-mode git --sync-source https://github.com/example/repo.git \
+    -- python train.py --epochs 10
 ```
 
 ### Output

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -140,6 +140,55 @@ Helm Go SDK, no temp files, and no shell-outs to `kubectl`. This means:
 
 ---
 
+## Using v1 Commands with `arena submit`
+
+`arena-v2 submit` keeps the v1 flag interface. The v1 flag names are the
+registered flag names — no deprecation warnings, no renaming. Existing scripts
+work unchanged:
+
+```bash
+arena-v2 submit pytorch --name my-job --image pytorch:2.1 \
+  --workers 4 --gpus 1 --cpu 4 --memory 16Gi --share-memory 2Gi \
+  --sync-mode git --sync-source https://github.com/example/repo.git \
+  "python train.py"
+```
+
+**Fully supported:**
+
+- All renamed-in-v2-draft flags use their v1 names: `--cpu`, `--memory`,
+  `--scheduler`, `--logdir`, `--clean-task-policy`, `--running-timeout`,
+  `--share-memory`, `--job-restart-policy`, `--job-backoff-limit`, `--retry`,
+  `--ps`, `--gputopology`, `--hostNetwork`, `--hostIPC`, `--hostPID`.
+- Code sync: `--sync-mode`, `--sync-source`, `--sync-image`. Synced code lands
+  in `<working-dir>/code` (default `/root/code`) as an init container, matching
+  v1 behavior. The code is exchanged through a shared `code-sync` emptyDir
+  volume mounted by both the sync init container and the main container
+  (size limit 10Gi; v1 used an unlimited emptyDir). The v1 sync flags are applied
+  by `task.ApplyOverrides`, the same mechanism as every other submit flag.
+- Per-role resources (TFJob): `--ps-cpu`, `--ps-memory`, `--ps-gpus`,
+  `--chief-cpu`, `--chief-memory`, `--evaluator-cpu`, `--evaluator-memory`,
+  `--worker-cpu`, `--worker-memory` plus their v1 `-limit` variants
+  (`--ps-cpu-limit`, `--worker-memory-limit`, ...). A `-limit` flag overrides
+  only the limit — requests stay at the request flag — so `--worker-cpu 1
+  --worker-cpu-limit 2` yields requests cpu=1 / limits cpu=2. Role-specific
+  flags win over the generic `--cpu`/`--memory`.
+- `-p, --priority` takes a priority class name, as in v1.
+
+**Semantic differences from v1:**
+
+| Flag | v1 | v2 |
+|------|----|----|
+| `-p, --priority` | Priority class name (string) | Same in `arena submit`. The integer pod priority lives in YAML `scheduling.priority`. |
+| `--queue` | Boolean (suspend job for kube-queue) | Same in `arena submit` — sets `runPolicy.suspend`. The queue *name* (`scheduling.queue`) is YAML-only. |
+| `--workers N` (PyTorch) | N total processes (master included) | Same in `arena submit`; **differs in YAML** — see [worker.replicas Excludes Master](#workerreplicas-excludes-master) |
+| `--share-memory` | Default `"2Gi"` (PyTorch/TF) | Default `"2Gi"` on `submit`, uniform across job types; pass an empty value to skip the `/dev/shm` volume. |
+| `--logdir` | Default `"/training_logs"` | Default `"/training_logs"` on `submit`; pair it with `--tensorboard`. |
+
+See [arena submit (legacy)](cli-reference.md#arena-submit-legacy) in the CLI
+reference for the complete flag list.
+
+---
+
 ## Flag Mapping Table
 
 The following tables map v1 CLI flags to v2 YAML fields, organized by category.
@@ -168,13 +217,12 @@ Field names in v2 use `snake_case` per the schema specification.
 |---------|---------------|-------|
 | `--selector` | `scheduling.node_selector` | Array of `key=value` in v1; map in v2. |
 | `--toleration` | `scheduling.tolerations` | Array of toleration objects. |
-| `-p, --priority` | `scheduling.priority` | Integer. |
-| `--priority-class-name` | `scheduling.priority_class_name` | String. |
+| `-p, --priority` | `scheduling.priority_class_name` | v1 `--priority` took a **priority class name** (string), and `arena submit` preserves that. For an integer pod priority use `scheduling.priority` in YAML. |
 | `--gang` | `scheduling.gang.enabled` | Boolean. |
 | `--scheduler` | `scheduling.scheduler_name` | String. |
 | `--affinity-policy` | `scheduling.affinity.policy` | `none` / `spread` / `binpack`. |
 | `--affinity-constraint` | `scheduling.affinity.constraint` | `preferred` / `required`. |
-| `--queue` | `scheduling.queue` | String. |
+| `--queue` | `lifecycle.suspend` (flag) / `scheduling.queue` (YAML) | v1 boolean toggle suspends the job for kube-queue; the queue *name* is set via YAML only. |
 | `--rdma` | — | **Not planned.** |
 
 ### Data and Volumes
@@ -234,6 +282,9 @@ Each sync entry also supports `sync[].branch` (for Git), `sync[].local_path`
 (required — target path inside the container), and `sync[].mounts` for
 overriding storage mount points.
 
+These three flags are also accepted directly by `arena submit`, which fills in
+`local_path` as `<working-dir>/code` (default `/root/code`) to match v1.
+
 ### TensorBoard
 
 | v1 Flag | v2 YAML Field | Notes |
@@ -255,9 +306,9 @@ overriding storage mount points.
 | v1 Flag | v2 YAML Field | Notes |
 |---------|---------------|-------|
 | `--ps` (count) | `ps.replicas` | Integer. |
-| `--ps-cpu`, `--ps-cpu-limit` | `ps.resources.cpu` | |
-| `--ps-memory`, `--ps-memory-limit` | `ps.resources.memory` | |
-| `--ps-gpus` | `ps.resources.'nvidia.com/gpu'` | |
+| `--ps-cpu`, `--ps-cpu-limit` | `ps.resources.cpu` | Accepted by `arena submit`. |
+| `--ps-memory`, `--ps-memory-limit` | `ps.resources.memory` | Accepted by `arena submit`. |
+| `--ps-gpus` | `ps.resources.'nvidia.com/gpu'` | Accepted by `arena submit`. |
 | `--chief` (bool) | `chief` | Presence of `chief` block enables the role. |
 | `--chief-cpu`, `--chief-memory`, etc. | `chief.resources` | |
 | `--evaluator` (bool) | `evaluator` | Presence of `evaluator` block enables the role. |
@@ -282,7 +333,7 @@ overriding storage mount points.
 | `--cpu` | `worker.resources.cpu` | |
 | `--memory` | `worker.resources.memory` | |
 | `--gputopology` | `host_network` + `worker.resources` + `labels` | Sets `gpu-topology` / `gpu-topology-replica` labels. |
-| `--mounts-on-launcher` | `framework.options.mounts_on_launcher` | Boolean. |
+| `--mounts-on-launcher` | `framework.options.mounts_on_launcher` | When false, the launcher main container gets no volumeMounts; volumes stay declared so init containers keep their mounts. Unlike v1, non-PVC storages are no longer mounted on the launcher main container either. |
 | (no v1 flag) | `framework.options.run_launcher_as_worker` | v2-only field. |
 | (no v1 flag) | `framework.options.slots_per_worker` | v2-only field. |
 
@@ -305,6 +356,25 @@ overriding storage mount points.
 | `--ssh-secret` | — | **Not in schema.** MPI Operator handles SSH internally. |
 | `--launcher-annotation` | — | Not yet implemented. |
 | `--worker-annotation` | — | Not yet implemented. |
+
+### v1 flags accepted with changed or no effect
+
+| v1 flag | arena-v2 behavior |
+|---|---|
+| `--config <path>` | works (bound to `--kubeconfig`); deprecated |
+| `--loglevel <level>` | mapped to verbosity (`--verbose`): debug=2, info=1, warn/error=0 |
+| `--rdma` | ignored; request RDMA hardware with `--device <resource>=<count>` |
+| `--{ps,worker,chief,evaluator,launcher}-selector`, `--{worker,launcher}-annotation`, `--{ps,worker}-image`, `--{ps,worker,chief,ssh}-port`, `--{ps,worker}-affinity-{policy,constraint}` | accepted with a warning, ignored (needs per-role RoleConfig extension) |
+| `--pprof`, `--trace`, `--helm-binary`, `--arena-namespace`, `--model-name`, `--model-source`, `--starting-timeout`, `--role-sequence`, `--ssh-secret` | accepted with a warning, no effect |
+| `--data <pvc>:<path>` | supported (v1 form); v2 form is `--data <name>:<path>:<pvc>` |
+| `--data-dir <host>[:<container>]` | supported (v1 form); v2 form is `--data-dir <name>:<path>:<hostpath>` |
+| `--config-file <host>:<container>` | rejected with guidance — pre-create a configmap and use `--config-file <name>:<path>:<configmap>` |
+
+Defaults restored to v1 values on `submit`: `--share-memory 2Gi`, `--clean-task-policy Running`, `--logdir /training_logs` (uniform across job types; opt out by passing an empty value). Note: v1 `mpijob` defaulted `--clean-task-policy All` and had no `--share-memory`; v2 uses the uniform defaults.
+
+Repeatable flags (`--env`, `--data`, `--label`, ...) no longer split on commas — pass the flag once per value, as in v1.
+
+Per-role request/limit flags are independent again: `--worker-cpu 1 --worker-cpu-limit 2` produces requests=1/limits=2 (Burstable). Without `-limit` flags, requests equal limits (Guaranteed).
 
 ---
 
@@ -406,7 +476,6 @@ arena submit tfjob \
   --chief-cpu 2 \
   --chief-memory 4Gi \
   --evaluator \
-  --evaluator-gpus 1 \
   "python train.py"
 ```
 
@@ -508,10 +577,10 @@ launcher:
 - The `launcher` block is optional. If omitted, a default CPU-only launcher is
   used. When specified, it allows independent resource configuration for the
   launcher Pod.
-- v2-only fields `framework.options.mounts_on_launcher`,
-  `framework.options.run_launcher_as_worker`, and
+- v2-only fields `framework.options.run_launcher_as_worker` and
   `framework.options.slots_per_worker` are available for advanced MPI
-  configurations with no v1 equivalent.
+  configurations with no v1 equivalent. (`framework.options.mounts_on_launcher`
+  maps from the v1 `--mounts-on-launcher` flag; see the MPI flag table above.)
 
 ---
 

--- a/docs/yaml-schema.md
+++ b/docs/yaml-schema.md
@@ -100,6 +100,7 @@ Each replica block supports the same sub-fields:
 |---|---|---|---|
 | `replicas` | int | yes (for `worker` and `ps`) | Number of pods. Must be > 0 for `worker`. Fixed to 1 for `master`, `chief`, `launcher`, and `evaluator`. |
 | `resources` | map | no | Resource requests/limits (applied identically to both). Omit to leave pod resources unset. |
+| `limits` | map of resource name to quantity | no | Overrides individual limit entries derived from `resources`; requests are unaffected. Example: `limits: {cpu: "2"}` with `resources: {cpu: "1"}` yields requests cpu=1, limits cpu=2. |
 | `envs` | map | no | Per-role environment variables. Merged with top-level `envs`; role-level values override top-level. |
 
 **Role blocks:**
@@ -321,38 +322,53 @@ storages:
 
 Each entry in `mounts` references a storage by `name` and can override its `mount_path` and `sub_path`. The referenced storage must be defined in `storages`.
 
+#### Sync write targets
+
+`local_path` must resolve to a **`tmp` or `shm` storage**. Sync is a per-pod
+temporary pull — every pod of the job runs the sync init container — so
+persistent or read-only storages are rejected at submit time:
+
+| Storage type | Rejected because |
+|---|---|
+| `pvc` | Persistent and shared across pods: concurrent syncs race on the same volume (RWO sticks pods in `Pending`; RWX corrupts silently). Preload the data onto the PVC instead of syncing it per-pod. |
+| `hostpath` | Node-local, shared by same-node pods, and outlives the pod. |
+| `configmap` / `secret` | Mounted read-only by Kubernetes — sync writes fail immediately. |
+
+Matching is containment-based: a `local_path` equal to or *under* a mount
+path writes to that volume (the longest matching `mount_path` wins). When
+`mounts` is omitted, all storages are mounted into the sync init container,
+so the rule applies to every declared storage.
+
 ```yaml
 storages:
   - name: dataset
-    mount_path: /data              # Default mount path
+    mount_path: /data              # Main container reads the dataset from this PVC
     pvc: dataset-pvc
   - name: code
     mount_path: /workspace
     tmp: 1Gi                       # emptyDir for synced code
-  - name: checkpoints
+  - name: models
     mount_path: /models
-    pvc: ckpt-pvc
+    tmp: 2Gi                       # emptyDir for synced model files
 
 sync:
   - git: https://github.com/org/training-code.git
     branch: main
     local_path: /workspace
     mounts:
-      - name: code                 # References storages entry
+      - name: code                 # tmp storage — allowed sync target
         mount_path: /workspace
-
-  - rsync: 10.88.29.56::backup/data/dataset.zip
-    local_path: /dataset
-    mounts:
-      - name: dataset              # Overrides storages mount_path
-        mount_path: /dataset
 
   - hdfs: hdfs://namenode:8020/models/resnet
     local_path: /models
     mounts:
-      - name: checkpoints
+      - name: models               # tmp storage — allowed sync target
         mount_path: /models
 ```
+
+Data that must live on a PVC (like `dataset` above) is preloaded outside
+arena — for example with a one-off copy job — rather than pulled per-pod
+with `sync`.
 
 ### Init
 
@@ -563,7 +579,7 @@ See: [examples/v2/quickstart/tensorflow-simple.yaml](../examples/v2/quickstart/t
 | Option | Type | Default | Description |
 |---|---|---|---|
 | `slots_per_worker` | int | — | MPI slots per worker node. |
-| `mounts_on_launcher` | bool | `false` | Launcher also mounts PVCs. |
+| `mounts_on_launcher` | bool | `false` | When false the launcher main container gets no volumeMounts. Volumes stay declared in the pod spec (init containers keep their mounts); only the main container's mounts are cleared. |
 | `run_launcher_as_worker` | bool | `false` | Launcher also runs as a worker. |
 | `gpu_topology` | bool | `false` | Enable GPU topology awareness. |
 | `mpi_implementation` | string | — | `OpenMPI`, `Intel`, or `MPICH`. |

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.32.0
 	github.com/onsi/gomega v1.42.1
 	github.com/spf13/cobra v1.10.2
+	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.36.2
@@ -36,7 +37,6 @@ require (
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect

--- a/pkg/cli/completion_funcs.go
+++ b/pkg/cli/completion_funcs.go
@@ -30,9 +30,13 @@ func completeFrameworkType(cmd *cobra.Command, args []string, toComplete string)
 		"tf\tTensorFlow",
 		"mpi\tMPI",
 		"mpijob\tMPI",
+		"mj\tMPI",
 		"horovod\tHorovod",
+		"horovodjob\tHorovod",
+		"hj\tHorovod",
 		"deepspeed\tDeepSpeed",
-		"ray\tRay",
+		"deepspeedjob\tDeepSpeed",
+		"dp\tDeepSpeed",
 	}, cobra.ShellCompDirectiveNoFileComp
 }
 

--- a/pkg/cli/completion_funcs_test.go
+++ b/pkg/cli/completion_funcs_test.go
@@ -9,13 +9,14 @@ import (
 
 func TestCompleteFrameworkType(t *testing.T) {
 	completions, directive := completeFrameworkType(nil, nil, "")
-	assert.Len(t, completions, 10)
+	assert.Len(t, completions, 14)
 	assert.Equal(t, cobra.ShellCompDirectiveNoFileComp, directive)
 	expected := []string{
 		"pytorch\tPyTorch", "pytorchjob\tPyTorch",
 		"tensorflow\tTensorFlow", "tfjob\tTensorFlow", "tf\tTensorFlow",
-		"mpi\tMPI", "mpijob\tMPI",
-		"horovod\tHorovod", "deepspeed\tDeepSpeed", "ray\tRay",
+		"mpi\tMPI", "mpijob\tMPI", "mj\tMPI",
+		"horovod\tHorovod", "horovodjob\tHorovod", "hj\tHorovod",
+		"deepspeed\tDeepSpeed", "deepspeedjob\tDeepSpeed", "dp\tDeepSpeed",
 	}
 	assert.Equal(t, expected, completions)
 }

--- a/pkg/cli/framework_registry.go
+++ b/pkg/cli/framework_registry.go
@@ -6,54 +6,86 @@ import (
 	"github.com/kubeflow/arena/pkg/constants"
 )
 
+// frameworkDef describes one arena submit framework type: its v2 canonical
+// name, the label value preserving the user's original choice, the CRD kind
+// it renders, and every alias arena v1 accepted on the command line.
+type frameworkDef struct {
+	canonical string // v2 canonical framework name ("" when v2 does not support it)
+	original  string // label value for the user's original choice
+	kind      string // CRD kind ("" when none)
+	cmdName   string // v1 primary submit subcommand name ("" when v2 does not support it)
+	aliases   []string
+}
+
+// frameworkRegistry is the single source of truth for submit framework
+// types. Alias lists mirror `arena v0.15.4 submit <type> -h`.
+var frameworkRegistry = []frameworkDef{
+	{canonical: constants.FrameworkPyTorch, original: constants.FrameworkPyTorch, kind: constants.KindPyTorchJob,
+		cmdName: "pytorchjob",
+		aliases: []string{constants.FrameworkPyTorch, "pytorchjob"}},
+	{canonical: constants.FrameworkTensorFlow, original: constants.FrameworkTensorFlow, kind: constants.KindTFJob,
+		cmdName: "tfjob",
+		aliases: []string{constants.FrameworkTensorFlow, "tfjob", "tf"}},
+	{canonical: constants.FrameworkMPI, original: constants.FrameworkMPI, kind: constants.KindMPIJob,
+		cmdName: "mpijob",
+		aliases: []string{constants.FrameworkMPI, "mpijob", "mj"}},
+	{canonical: constants.FrameworkHorovod, original: constants.FrameworkHorovod, kind: constants.KindMPIJob,
+		cmdName: "horovodjob",
+		aliases: []string{constants.FrameworkHorovod, "horovodjob", "hj"}},
+	{canonical: constants.FrameworkDeepSpeed, original: constants.FrameworkDeepSpeed, kind: constants.KindMPIJob,
+		cmdName: "deepspeedjob",
+		aliases: []string{constants.FrameworkDeepSpeed, "deepspeedjob", "dp"}},
+	// arena v1 types with no v2 provider yet. They are recognized so submit
+	// can fail fast with a dedicated message instead of the generic
+	// unknown-type error.
+	{original: "ray", aliases: []string{"ray", "rayjob", "rj"}},
+	{original: "spark", aliases: []string{"spark", "sparkjob"}},
+	{original: "volcano", aliases: []string{"volcano", "volcanojob", "vj"}},
+	{original: "et", aliases: []string{"et", "etjob"}},
+}
+
+// lookupFramework resolves a user-supplied type string. It returns the v2
+// canonical framework name, and whether the string is a known arena v1 type
+// that v2 does not support yet.
+func lookupFramework(s string) (canonical string, v1TypeUnsupported bool) {
+	key := strings.ToLower(s)
+	for _, def := range frameworkRegistry {
+		for _, a := range def.aliases {
+			if a == key {
+				return def.canonical, def.canonical == ""
+			}
+		}
+	}
+	return "", false
+}
+
 // normalizeFramework maps framework aliases to canonical names.
 func normalizeFramework(s string) string {
-	switch strings.ToLower(s) {
-	case constants.FrameworkPyTorch, "pytorchjob":
-		return constants.FrameworkPyTorch
-	case constants.FrameworkTensorFlow, "tfjob", "tf":
-		return constants.FrameworkTensorFlow
-	case constants.FrameworkMPI, "mpijob", constants.FrameworkHorovod, constants.FrameworkDeepSpeed:
-		return constants.FrameworkMPI
-	case constants.FrameworkRay:
-		return constants.FrameworkRay
-	default:
-		return ""
-	}
+	canonical, _ := lookupFramework(s)
+	return canonical
 }
 
 // originalFramework preserves the user's original framework choice for labeling.
 func originalFramework(s string) string {
-	switch strings.ToLower(s) {
-	case constants.FrameworkPyTorch, "pytorchjob":
-		return constants.FrameworkPyTorch
-	case constants.FrameworkTensorFlow, "tfjob", "tf":
-		return constants.FrameworkTensorFlow
-	case constants.FrameworkHorovod:
-		return constants.FrameworkHorovod
-	case constants.FrameworkDeepSpeed:
-		return constants.FrameworkDeepSpeed
-	case constants.FrameworkMPI, "mpijob":
-		return constants.FrameworkMPI
-	case constants.FrameworkRay:
-		return constants.FrameworkRay
-	default:
-		return ""
+	key := strings.ToLower(s)
+	for _, def := range frameworkRegistry {
+		for _, a := range def.aliases {
+			if a == key {
+				return def.original
+			}
+		}
 	}
+	return ""
 }
 
 // frameworkToKind maps a canonical framework name to its CRD kind.
 func frameworkToKind(framework string) string {
-	switch framework {
-	case constants.FrameworkPyTorch:
-		return constants.KindPyTorchJob
-	case constants.FrameworkTensorFlow, "tf":
-		return constants.KindTFJob
-	case constants.FrameworkMPI, constants.FrameworkHorovod, constants.FrameworkDeepSpeed:
-		return constants.KindMPIJob
-	default:
-		return ""
+	for _, def := range frameworkRegistry {
+		if def.canonical == framework {
+			return def.kind
+		}
 	}
+	return ""
 }
 
 // kindToFramework maps a CRD kind to its canonical framework name.

--- a/pkg/cli/framework_registry_test.go
+++ b/pkg/cli/framework_registry_test.go
@@ -4,6 +4,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kubeflow/arena/pkg/constants"
 )
 
 func TestNormalizeFramework_Registry(t *testing.T) {
@@ -29,13 +32,13 @@ func TestNormalizeFramework_Registry(t *testing.T) {
 		{"MPI uppercase", "MPI", "mpi"},
 		{"mpijob", "mpijob", "mpi"},
 		{"MPIJob", "MPIJob", "mpi"},
-		{"horovod", "horovod", "mpi"},
-		{"Horovod", "Horovod", "mpi"},
-		{"deepspeed", "deepspeed", "mpi"},
-		{"DeepSpeed", "DeepSpeed", "mpi"},
+		{"horovod", "horovod", "horovod"},
+		{"Horovod", "Horovod", "horovod"},
+		{"deepspeed", "deepspeed", "deepspeed"},
+		{"DeepSpeed", "DeepSpeed", "deepspeed"},
 		// Ray
-		{"ray", "ray", "ray"},
-		{"Ray", "Ray", "ray"},
+		{"ray", "ray", ""},
+		{"Ray", "Ray", ""},
 		// Unknown/empty
 		{"unknown framework", "jax", ""},
 		{"empty string", "", ""},
@@ -147,4 +150,59 @@ func TestIsMPIFamily_Registry(t *testing.T) {
 			assert.Equal(t, tt.expected, isMPIFamily(tt.framework))
 		})
 	}
+}
+
+func TestLookupFramework_SupportedAliases(t *testing.T) {
+	tests := []struct{ input, want string }{
+		{"pytorch", constants.FrameworkPyTorch},
+		{"pytorchjob", constants.FrameworkPyTorch},
+		{"PyTorchJob", constants.FrameworkPyTorch},
+		{"tf", constants.FrameworkTensorFlow},
+		{"tfjob", constants.FrameworkTensorFlow},
+		{"tensorflow", constants.FrameworkTensorFlow},
+		{"mpi", constants.FrameworkMPI},
+		{"mpijob", constants.FrameworkMPI},
+		{"mj", constants.FrameworkMPI},
+		{"horovod", constants.FrameworkHorovod},
+		{"horovodjob", constants.FrameworkHorovod},
+		{"hj", constants.FrameworkHorovod},
+		{"deepspeed", constants.FrameworkDeepSpeed},
+		{"deepspeedjob", constants.FrameworkDeepSpeed},
+		{"dp", constants.FrameworkDeepSpeed},
+	}
+	for _, tt := range tests {
+		canonical, unsupported := lookupFramework(tt.input)
+		assert.Equal(t, tt.want, canonical, "input %q", tt.input)
+		assert.False(t, unsupported, "input %q should be supported", tt.input)
+	}
+}
+
+func TestLookupFramework_V1TypesUnsupported(t *testing.T) {
+	v1OnlyAliases := []string{
+		"ray", "rayjob", "rj",
+		"spark", "sparkjob",
+		"volcano", "volcanojob", "vj",
+		"et", "etjob",
+	}
+	for _, input := range v1OnlyAliases {
+		canonical, unsupported := lookupFramework(input)
+		assert.Empty(t, canonical, "input %q", input)
+		assert.True(t, unsupported, "input %q should be flagged as an unsupported v1 type", input)
+	}
+}
+
+func TestLookupFramework_Unknown(t *testing.T) {
+	canonical, unsupported := lookupFramework("bogus")
+	assert.Empty(t, canonical)
+	assert.False(t, unsupported)
+}
+
+func TestSubmitFrameworkTypeErrors(t *testing.T) {
+	err := submitCmd.RunE(submitCmd, []string{"rayjob"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not supported by arena-v2 yet")
+
+	err = submitCmd.RunE(submitCmd, []string{"bogus"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported framework type")
 }

--- a/pkg/cli/helpers.go
+++ b/pkg/cli/helpers.go
@@ -224,7 +224,6 @@ func submitCRD(ctx context.Context, k8sClient *client.Client, t *task.Task, fram
 	log.Debug("CRD built", "kind", crd.GetKind(), "name", crd.GetName(), "namespace", ns)
 
 	if dryRun {
-		log.Info("dry-run mode, not submitting")
 		return printDryRun(crd, t)
 	}
 

--- a/pkg/cli/logs_test.go
+++ b/pkg/cli/logs_test.go
@@ -390,7 +390,7 @@ func TestFrameworkToKind(t *testing.T) {
 		{constants.FrameworkMPI, constants.KindMPIJob},
 		{constants.FrameworkHorovod, constants.KindMPIJob},
 		{constants.FrameworkDeepSpeed, constants.KindMPIJob},
-		{"tf", constants.KindTFJob},
+		{"tf", ""},
 		{"unknown", ""},
 	}
 

--- a/pkg/cli/submit.go
+++ b/pkg/cli/submit.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"flag"
 	"fmt"
 	"strings"
 
@@ -8,128 +9,97 @@ import (
 
 	"github.com/kubeflow/arena/pkg/client"
 	"github.com/kubeflow/arena/pkg/constants"
-	outputpkg "github.com/kubeflow/arena/pkg/output"
+	"github.com/kubeflow/arena/pkg/log"
 	"github.com/kubeflow/arena/pkg/task"
 )
 
-var (
-	submitName               string
-	submitImage              string
-	submitWorkers            int
-	submitGPUs               int
-	submitCPUs               string
-	submitMem                string
-	submitEnvs               []string
-	submitData               []string
-	submitLabels             []string
-	submitAnnotations        []string
-	submitSelectors          []string
-	submitTolerations        []string
-	submitPriority           int
-	submitPriorityClass      string
-	submitGang               bool
-	submitSchedulerName      string
-	submitCleanPodPolicy     string
-	submitActiveDeadline     string
-	submitTTLAfterFinished   string
-	submitBackoffLimit       int
-	submitImagePullPolicy    string
-	submitImagePullSecret    []string
-	submitServiceAccount     string
-	submitRestart            string
-	submitHostNetwork        bool
-	submitHostIPC            bool
-	submitHostPID            bool
-	submitWorkingDir         string
-	submitShell              string
-	submitSHM                string
-	submitDevice             []string
-	submitGPUType            string
-	submitTensorBoard        bool
-	submitTBLogDir           string
-	submitTBImage            string
-	submitNprocPerNode       string
-	submitPSCount            int
-	submitChief              bool
-	submitEvaluator          bool
-	submitSlotsPerWorker     int
-	submitGPUTopology        bool
-	submitMountsOnLauncher   bool
-	submitAffinityPolicy     string
-	submitAffinityConstraint string
-	submitAffinityTarget     string
-	submitSuccessPolicy      string
-	submitDryRun             bool
-	submitQueue              string
-	submitDataDir            []string
-	submitConfigFile         []string
-)
-
 var submitCmd = &cobra.Command{
-	Use:   "submit <type>",
+	Use:   "submit",
 	Short: "Submit a training job",
-	Long: `Submit a training job using CLI flags.
-Supported types: pytorch, tensorflow, mpi, horovod, deepspeed (case-insensitive).
-Trailing arguments after -- are used as the run command.`,
-	Args: cobra.MinimumNArgs(1),
+	Long:  `Submit a training job using arena v1-compatible syntax`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		framework := normalizeFramework(args[0])
-		if framework == "" {
-			return fmt.Errorf("unsupported framework type: %q (must be pytorch, tensorflow, mpi, horovod, deepspeed, or ray)",
+		if len(args) == 0 {
+			return cmd.Help()
+		}
+		framework, v1TypeUnsupported := lookupFramework(args[0])
+		if v1TypeUnsupported {
+			return fmt.Errorf("framework type %q is an arena v1 type not supported by arena-v2 yet (supported: pytorch, tensorflow, mpi, horovod, deepspeed)",
 				args[0])
 		}
-
-		applyDryRunOutputDefault(cmd, submitDryRun)
-
-		// Trailing args after -- become the run command
-		trailingArgs := []string{}
-		if len(args) > 1 {
-			trailingArgs = args[1:]
+		if framework == "" {
+			return fmt.Errorf("unsupported framework type: %q (supported: pytorch/pytorchjob, tf/tfjob/tensorflow, mpi/mpijob/mj, horovod/horovodjob/hj, deepspeed/deepspeedjob/dp)",
+				args[0])
 		}
-
-		// Build the task with PyTorch N-1 conversion
-		t := buildSubmitTask(framework, trailingArgs)
-
-		// Build overrides map
-		flags := buildSubmitFlags()
-
-		// Apply overrides
-		if err := task.ApplyOverrides(t, flags); err != nil {
-			return fmt.Errorf("failed to apply overrides: %w", err)
+		// The parent cannot mark --name/--image required at registration
+		// (cobra would reject a bare `submit` before RunE prints help), so the
+		// fallback path validates them here, mirroring the subcommands' error.
+		if err := validateSubmitRequiredFlags(cmd); err != nil {
+			return err
 		}
-
-		// Validate
-		t.SetDefaults()
-		if err := task.Validate(t); err != nil {
-			return fmt.Errorf("validation failed: %w", err)
-		}
-
-		// Wire TensorBoard configuration from CLI flags
-		if submitTensorBoard {
-			if t.Logging.TensorBoard == nil {
-				t.Logging.TensorBoard = &task.TensorBoardConfig{}
-			}
-			t.Logging.TensorBoard.Enabled = true
-			if submitTBLogDir != "" {
-				t.Logging.TensorBoard.LogDir = submitTBLogDir
-			}
-			if submitTBImage != "" {
-				t.Logging.TensorBoard.Image = submitTBImage
-			}
-		}
-
-		var (
-			k8sClient *client.Client
-			err       error
-		)
-		if !submitDryRun {
-			k8sClient, err = client.NewClient(kubeconfig, kubeContext)
-			if err != nil {
-				return fmt.Errorf("failed to create K8s client: %w", err)
-			}
-		}
-		return submitCRD(cmdContext(cmd), k8sClient, t, originalFramework(args[0]), submitDryRun)
+		return runSubmit(cmd, framework, originalFramework(args[0]), args[1:])
 	},
+}
+
+// validateSubmitRequiredFlags reports unset --name/--image in the exact
+// format cobra's ValidateRequiredFlags uses (including the missing-only list
+// and lexical order), so fallback-path errors read identically to the
+// per-framework subcommands'. Unlike MarkFlagRequired it mutates no shared
+// command state, keeping a bare `submit` on the print-help path.
+func validateSubmitRequiredFlags(cmd *cobra.Command) error {
+	var missing []string
+	for _, name := range []string{"image", "name"} {
+		if f := cmd.Flags().Lookup(name); f != nil && !f.Changed {
+			missing = append(missing, name)
+		}
+	}
+	if len(missing) == 0 {
+		return nil
+	}
+	quoted := make([]string, 0, len(missing))
+	for _, name := range missing {
+		quoted = append(quoted, `"`+name+`"`)
+	}
+	return fmt.Errorf("required flag(s) %s not set", strings.Join(quoted, ", "))
+}
+
+// runSubmit is the shared submission core used by the parent submit command
+// (the fallback path for anything that is not a framework subcommand) and by
+// the per-framework subcommands. trailingArgs are the positional args that
+// follow the framework type; they become the run command.
+func runSubmit(cmd *cobra.Command, framework, originalFrameworkName string, trailingArgs []string) error {
+	if err := applyV1LogLevel(submitLogLevel); err != nil {
+		return err
+	}
+
+	applyDryRunOutputDefault(cmd, submitDryRun)
+
+	// Build the task with PyTorch N-1 conversion
+	t := buildSubmitTask(framework, trailingArgs)
+
+	// Apply overrides
+	flags := buildSubmitFlags()
+
+	if err := task.ApplyOverrides(t, flags); err != nil {
+		return fmt.Errorf("failed to apply overrides: %w", err)
+	}
+
+	// Validate
+	t.SetDefaults()
+	if err := task.Validate(t); err != nil {
+		return fmt.Errorf("validation failed: %w", err)
+	}
+
+	var (
+		k8sClient *client.Client
+		err       error
+	)
+	if !submitDryRun {
+		k8sClient, err = client.NewClient(kubeconfig, kubeContext)
+		if err != nil {
+			return fmt.Errorf("failed to create K8s client: %w", err)
+		}
+	}
+	return submitCRD(cmdContext(cmd), k8sClient, t, originalFrameworkName, submitDryRun)
 }
 
 // buildSubmitTask constructs a Task from submit CLI flags with framework-specific conversions.
@@ -163,293 +133,28 @@ func buildSubmitTask(framework string, trailingArgs []string) *task.Task {
 		t.Run = strings.Join(trailingArgs, " ")
 	}
 
-	// Map --chief/--evaluator/--ps-count to role sections
-	if submitChief {
-		t.Chief = &task.RoleConfig{} // nil resources → inherit from worker
-	}
-	if submitEvaluator {
-		t.Evaluator = &task.RoleConfig{}
-	}
-	if submitPSCount > 0 {
-		t.PS = &task.RoleConfig{Replicas: submitPSCount}
-	}
-
 	return t
 }
 
-// buildSubmitFlags builds the overrides map from all submit flag values.
-func buildSubmitFlags() map[string]interface{} {
-	flags := make(map[string]interface{})
-
-	// Identity
-	if submitName != "" {
-		flags["name"] = submitName
+// applyV1LogLevel maps the deprecated v1 --loglevel flag onto v2's klog
+// verbosity: debug->2, info->1, warn/error->0.
+func applyV1LogLevel(level string) error {
+	if level == "" {
+		return nil
 	}
-
-	// Resources
-	if submitGPUs > 0 {
-		flags["gpus"] = submitGPUs
+	var verbosity int32
+	switch strings.ToLower(level) {
+	case "debug":
+		verbosity = 2
+	case "info":
+		verbosity = 1
+	case "warn", "error":
+		verbosity = 0
+	default:
+		return fmt.Errorf("invalid --loglevel %q: must be debug, info, warn, or error", level)
 	}
-	if submitCPUs != "" {
-		flags["cpus"] = submitCPUs
+	if err := log.SetVerbosity(flag.CommandLine, verbosity); err != nil {
+		return fmt.Errorf("failed to set log level: %w", err)
 	}
-	if submitMem != "" {
-		flags["mem"] = submitMem
-	}
-
-	// Environment
-	if len(submitEnvs) > 0 {
-		flags["env"] = submitEnvs
-	}
-
-	// Data
-	if len(submitData) > 0 {
-		flags["data"] = submitData
-	}
-	if len(submitDataDir) > 0 {
-		flags["data-dir"] = submitDataDir
-	}
-	if len(submitConfigFile) > 0 {
-		flags["config-file"] = submitConfigFile
-	}
-
-	// Labels
-	if len(submitLabels) > 0 {
-		flags["label"] = submitLabels
-	}
-
-	// Annotations
-	if len(submitAnnotations) > 0 {
-		flags["annotation"] = submitAnnotations
-	}
-
-	// Scheduling
-	if len(submitSelectors) > 0 {
-		flags["selector"] = submitSelectors
-	}
-	if len(submitTolerations) > 0 {
-		flags["toleration"] = submitTolerations
-	}
-	if submitPriority > 0 {
-		flags["priority"] = submitPriority
-	}
-	if submitPriorityClass != "" {
-		flags["priority-class-name"] = submitPriorityClass
-	}
-	if submitGang {
-		flags["gang"] = submitGang
-	}
-	if submitSchedulerName != "" {
-		flags["scheduler-name"] = submitSchedulerName
-	}
-	if submitAffinityPolicy != "" {
-		flags["affinity-policy"] = submitAffinityPolicy
-	}
-	if submitAffinityConstraint != "" {
-		flags["affinity-constraint"] = submitAffinityConstraint
-	}
-	if submitAffinityTarget != "" {
-		flags["affinity-target"] = submitAffinityTarget
-	}
-	if submitQueue != "" {
-		flags["queue"] = submitQueue
-	}
-
-	// Lifecycle
-	if submitCleanPodPolicy != "" {
-		flags["clean-pod-policy"] = submitCleanPodPolicy
-	}
-	if submitActiveDeadline != "" {
-		flags["active-deadline"] = submitActiveDeadline
-	}
-	if submitTTLAfterFinished != "" {
-		flags["ttl-after-finished"] = submitTTLAfterFinished
-	}
-	if submitBackoffLimit > 0 {
-		flags["backoff-limit"] = submitBackoffLimit
-	}
-	if submitSuccessPolicy != "" {
-		flags["success-policy"] = submitSuccessPolicy
-	}
-
-	// Runtime
-	if submitImagePullPolicy != "" {
-		flags["image-pull-policy"] = submitImagePullPolicy
-	}
-	if len(submitImagePullSecret) > 0 {
-		flags["image-pull-secret"] = submitImagePullSecret
-	}
-	if submitServiceAccount != "" {
-		flags["service-account"] = submitServiceAccount
-	}
-	if submitRestart != "" {
-		flags["restart"] = submitRestart
-	}
-	if submitHostNetwork {
-		flags["host-network"] = submitHostNetwork
-	}
-	if submitHostIPC {
-		flags["host-ipc"] = submitHostIPC
-	}
-	if submitHostPID {
-		flags["host-pid"] = submitHostPID
-	}
-
-	// Task
-	if submitWorkingDir != "" {
-		flags["working-dir"] = submitWorkingDir
-	}
-	if submitShell != "" {
-		flags["shell"] = submitShell
-	}
-	if submitSHM != "" {
-		flags["shm"] = submitSHM
-	}
-	if len(submitDevice) > 0 {
-		flags["device"] = submitDevice
-	}
-	if submitGPUType != "" {
-		flags["gpu-type"] = submitGPUType
-	}
-
-	// Logging
-	if submitTensorBoard {
-		flags["tensorboard"] = submitTensorBoard
-	}
-	if submitTBLogDir != "" {
-		flags["tensorboard-logdir"] = submitTBLogDir
-	}
-	if submitTBImage != "" {
-		flags["tensorboard-image"] = submitTBImage
-	}
-
-	// Framework-specific
-	if submitNprocPerNode != "" {
-		flags["nproc-per-node"] = submitNprocPerNode
-	}
-	if submitPSCount > 0 {
-		flags["ps-count"] = submitPSCount
-	}
-	if submitChief {
-		flags["chief"] = submitChief
-	}
-	if submitEvaluator {
-		flags["evaluator"] = submitEvaluator
-	}
-	if submitSlotsPerWorker > 0 {
-		flags["slots-per-worker"] = submitSlotsPerWorker
-	}
-	if submitGPUTopology {
-		flags["gpu-topology"] = submitGPUTopology
-		flags["host-network"] = true
-		var labels []string
-		if existing, ok := flags["label"].([]string); ok {
-			labels = existing
-		} else {
-			labels = []string{}
-		}
-		flags["label"] = append(labels, "gpu-topology=true", "gpu-topology-replica=true")
-	}
-	if submitMountsOnLauncher {
-		flags["mounts-on-launcher"] = submitMountsOnLauncher
-	}
-
-	return flags
-}
-
-func init() {
-	// Required flags
-	submitCmd.Flags().StringVar(&submitName, "name", "", "job name")
-	submitCmd.Flags().StringVar(&submitImage, "image", "", "container image")
-
-	// Worker configuration
-	submitCmd.Flags().IntVar(&submitWorkers, "workers", 1, "number of worker replicas")
-
-	// Resource flags
-	submitCmd.Flags().IntVar(&submitGPUs, "gpus", 0, "number of GPUs per worker")
-	submitCmd.Flags().StringVar(&submitCPUs, "cpus", "", "CPU request (e.g. 500m, 2)")
-	submitCmd.Flags().StringVar(&submitMem, "mem", "", "memory request (e.g. 1Gi, 512Mi)")
-
-	// Environment and data
-	submitCmd.Flags().StringSliceVarP(&submitEnvs, "env", "e", nil, "environment variable (key=value, repeatable)")
-	submitCmd.Flags().StringSliceVarP(&submitData, "data", "d", nil, "data volume (name:path:pvc, repeatable)")
-	submitCmd.Flags().StringSliceVar(&submitDataDir, "data-dir", nil, "host path volume (name:path:hostpath, repeatable)")
-	submitCmd.Flags().StringSliceVar(&submitConfigFile, "config-file", nil, "configmap volume (name:path:configmap, repeatable)")
-	submitCmd.Flags().StringSliceVarP(&submitLabels, "label", "l", nil, "label (key=value, repeatable)")
-	submitCmd.Flags().StringSliceVarP(&submitAnnotations, "annotation", "a", nil, "annotation (key=value, repeatable)")
-
-	// Scheduling
-	submitCmd.Flags().StringSliceVar(&submitSelectors, "selector", nil, "node selector (key=value, repeatable)")
-	submitCmd.Flags().StringSliceVar(&submitTolerations, "toleration", nil, "toleration (key=value:effect, repeatable)")
-	submitCmd.Flags().IntVar(&submitPriority, "priority", 0, "pod priority value")
-	submitCmd.Flags().StringVar(&submitPriorityClass, "priority-class-name", "", "priority class name")
-	submitCmd.Flags().BoolVar(&submitGang, "gang", false, "enable gang scheduling")
-	submitCmd.Flags().StringVar(&submitSchedulerName, "scheduler-name", "", "custom scheduler name")
-	submitCmd.Flags().StringVar(&submitAffinityPolicy, "affinity-policy", "", "affinity policy")
-	submitCmd.Flags().StringVar(&submitAffinityConstraint, "affinity-constraint", "", "affinity constraint")
-	submitCmd.Flags().StringVar(&submitAffinityTarget, "affinity-target", "", "affinity target (pod or node)")
-	submitCmd.Flags().StringVar(&submitQueue, "queue", "", "scheduling queue name")
-
-	// Lifecycle
-	submitCmd.Flags().StringVar(&submitCleanPodPolicy, "clean-pod-policy", "", "clean pod policy (None, Running, All)")
-	submitCmd.Flags().StringVar(&submitActiveDeadline, "active-deadline", "", "active deadline (e.g. 2h, 7d)")
-	submitCmd.Flags().StringVar(&submitTTLAfterFinished, "ttl-after-finished", "", "TTL after finished (e.g. 7d)")
-	submitCmd.Flags().IntVar(&submitBackoffLimit, "backoff-limit", 0, "backoff limit for retries")
-	submitCmd.Flags().StringVar(&submitSuccessPolicy, "success-policy", "", "success policy (ChiefWorker, AllWorkers, TF only). ChiefWorker is an alias for the default \"\"")
-
-	// Runtime
-	submitCmd.Flags().StringVar(&submitImagePullPolicy, "image-pull-policy", "", "image pull policy (Always, IfNotPresent, Never)")
-	submitCmd.Flags().StringSliceVar(&submitImagePullSecret, "image-pull-secret", nil, "image pull secret name (repeatable)")
-	submitCmd.Flags().StringVar(&submitServiceAccount, "service-account", "", "service account name")
-	submitCmd.Flags().StringVar(&submitRestart, "restart", "", "restart policy (Always, OnFailure, Never)")
-	submitCmd.Flags().BoolVar(&submitHostNetwork, "host-network", false, "use host network")
-	submitCmd.Flags().BoolVar(&submitHostIPC, "host-ipc", false, "use host IPC namespace")
-	submitCmd.Flags().BoolVar(&submitHostPID, "host-pid", false, "use host PID namespace")
-
-	// Task
-	submitCmd.Flags().StringVar(&submitWorkingDir, "working-dir", "", "working directory in container")
-	submitCmd.Flags().StringVar(&submitShell, "shell", "", "shell to use (default /bin/sh)")
-	submitCmd.Flags().StringVar(&submitSHM, "shm", "", "shared memory size (e.g. 8Gi)")
-	submitCmd.Flags().StringSliceVar(&submitDevice, "device", nil, "extended resource (name=count, repeatable)")
-	submitCmd.Flags().StringVar(&submitGPUType, "gpu-type", "", "GPU type (sets node selector nvidia.com/gpu.product)")
-
-	// Logging / TensorBoard
-	submitCmd.Flags().BoolVar(&submitTensorBoard, "tensorboard", false, "enable TensorBoard sidecar (TensorBoard has no built-in authentication)")
-	submitCmd.Flags().StringVar(&submitTBLogDir, "tensorboard-logdir", "", "TensorBoard log directory")
-	submitCmd.Flags().StringVar(&submitTBImage, "tensorboard-image", "", "TensorBoard container image")
-
-	// Framework-specific: PyTorch
-	submitCmd.Flags().StringVar(&submitNprocPerNode, "nproc-per-node", "", "PyTorch: processes per node (auto, gpu, cpu, or int)")
-
-	// Framework-specific: TensorFlow
-	submitCmd.Flags().IntVar(&submitPSCount, "ps-count", 0, "TensorFlow: number of parameter servers")
-	submitCmd.Flags().BoolVar(&submitChief, "chief", false, "TensorFlow: enable Chief worker")
-	submitCmd.Flags().BoolVar(&submitEvaluator, "evaluator", false, "TensorFlow: enable Evaluator worker")
-
-	// Framework-specific: MPI
-	submitCmd.Flags().IntVar(&submitSlotsPerWorker, "slots-per-worker", 0, "MPI: slots per worker")
-	submitCmd.Flags().BoolVar(&submitGPUTopology, "gpu-topology", false, "MPI: enable GPU topology (sets host networking, gpu-topology/gpu-topology-replica labels, and MPI annotation)")
-	submitCmd.Flags().BoolVar(&submitMountsOnLauncher, "mounts-on-launcher", false, "MPI: mount volumes on launcher")
-
-	// Dry-run
-	submitCmd.Flags().BoolVar(&submitDryRun, "dry-run", false, "print CRD as JSON (default) or YAML (-o yaml) without submitting")
-	submitCmd.Flags().StringVarP(&outputFormat, "output", "o", string(outputpkg.DefaultFormat), outputpkg.FormatHelpText)
-	_ = submitCmd.RegisterFlagCompletionFunc("output", completeOutputFormat)
-
-	_ = submitCmd.MarkFlagRequired("name")
-	_ = submitCmd.MarkFlagRequired("image")
-
-	submitCmd.ValidArgsFunction = completeFrameworkType
-	_ = submitCmd.RegisterFlagCompletionFunc("clean-pod-policy", completeStaticChoices(
-		"None\tDo not clean pods", "Running\tClean running pods", "All\tClean all pods"))
-	_ = submitCmd.RegisterFlagCompletionFunc("image-pull-policy", completeStaticChoices(
-		"Always\tAlways pull", "IfNotPresent\tPull if not present", "Never\tNever pull"))
-	_ = submitCmd.RegisterFlagCompletionFunc("restart", completeStaticChoices(
-		"Always\tAlways restart", "OnFailure\tRestart on failure", "Never\tNever restart"))
-	_ = submitCmd.RegisterFlagCompletionFunc("success-policy", completeStaticChoices(
-		"ChiefWorker\tChief and worker succeed", "AllWorkers\tAll workers succeed"))
-	_ = submitCmd.RegisterFlagCompletionFunc("nproc-per-node", completeStaticChoices(
-		"auto\tAuto-detect", "gpu\tOne per GPU", "cpu\tOne per CPU"))
-
-	rootCmd.AddCommand(submitCmd)
+	return nil
 }

--- a/pkg/cli/submit_flags.go
+++ b/pkg/cli/submit_flags.go
@@ -1,0 +1,543 @@
+package cli
+
+// Flag registration and flag→overrides-map collection for the submit
+// command. All flag semantics (how a flag value lands in the Task) live in
+// pkg/task.ApplyOverrides; this file only declares the CLI surface.
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"github.com/kubeflow/arena/pkg/constants"
+	outputpkg "github.com/kubeflow/arena/pkg/output"
+)
+
+var (
+	submitName                 string
+	submitImage                string
+	submitWorkers              int
+	submitGPUs                 int
+	submitCPU                  string
+	submitMemory               string
+	submitEnvs                 []string
+	submitData                 []string
+	submitLabels               []string
+	submitAnnotations          []string
+	submitSelectors            []string
+	submitTolerations          []string
+	submitPriorityClass        string
+	submitGang                 bool
+	submitScheduler            string
+	submitCleanTaskPolicy      string
+	submitRunningTimeout       string
+	submitTTLAfterFinished     string
+	submitJobBackoffLimit      int
+	submitImagePullPolicy      string
+	submitImagePullSecret      []string
+	submitServiceAccount       string
+	submitJobRestartPolicy     string
+	submitHostNetwork          bool
+	submitHostIPC              bool
+	submitHostPID              bool
+	submitWorkingDir           string
+	submitShell                string
+	submitShareMemory          string
+	submitDevice               []string
+	submitGPUType              string
+	submitTensorBoard          bool
+	submitLogDir               string
+	submitTBImage              string
+	submitNprocPerNode         string
+	submitPS                   int
+	submitChief                bool
+	submitEvaluator            bool
+	submitSlotsPerWorker       int
+	submitGPUTopology          bool
+	submitMountsOnLauncher     bool
+	submitAffinityPolicy       string
+	submitAffinityConstraint   string
+	submitAffinityTarget       string
+	submitSuccessPolicy        string
+	submitDryRun               bool
+	submitQueue                bool
+	submitDataDir              []string
+	submitConfigFile           []string
+	submitSyncMode             string
+	submitSyncSource           string
+	submitSyncImage            string
+	submitPSCPU                string
+	submitPSMemory             string
+	submitPSGPUs               int
+	submitChiefCPU             string
+	submitChiefMemory          string
+	submitEvaluatorCPU         string
+	submitEvaluatorMemory      string
+	submitWorkerCPU            string
+	submitWorkerMemory         string
+	submitPSCPULimit           string
+	submitPSMemoryLimit        string
+	submitChiefCPULimit        string
+	submitChiefMemoryLimit     string
+	submitEvaluatorCPULimit    string
+	submitEvaluatorMemoryLimit string
+	submitWorkerCPULimit       string
+	submitWorkerMemoryLimit    string
+	submitLogLevel             string
+	submitIgnoredString        string
+	submitIgnoredBool          bool
+)
+
+func init() {
+	registerSubmitCommonFlags(submitCmd)
+	registerPyTorchSubmitFlags(submitCmd)
+	registerTFSubmitFlags(submitCmd)
+	registerMPISubmitFlags(submitCmd)
+	registerSubmitCompatFlags(submitCmd)
+
+	submitCmd.ValidArgsFunction = completeFrameworkType
+
+	// The parent keeps the full flag set — the fallback path and the test
+	// suite parse it — but hides it from help: `submit -h` lists only the
+	// framework subcommands, matching arena v1.
+	submitCmd.Flags().VisitAll(func(f *pflag.Flag) { f.Hidden = true })
+
+	rootCmd.AddCommand(submitCmd)
+}
+
+// registerSubmitCommonFlags registers the framework-agnostic submit flags on
+// cmd. Required marking of --name/--image is left to the caller: only the
+// per-framework subcommands enforce them at cobra level, the parent's flag
+// set is the v1-compat fallback parser and defers missing values to task
+// validation.
+func registerSubmitCommonFlags(cmd *cobra.Command) {
+	f := cmd.Flags()
+
+	// Required flags
+	f.StringVar(&submitName, "name", "", "job name")
+	f.StringVar(&submitImage, "image", "", "container image")
+
+	// Worker configuration
+	f.IntVar(&submitWorkers, "workers", 1, "number of worker replicas")
+
+	// Resource flags
+	f.IntVar(&submitGPUs, "gpus", 0, "number of GPUs per worker")
+	f.StringVar(&submitCPU, "cpu", "", "CPU request (e.g. 500m, 2)")
+	f.StringVar(&submitMemory, "memory", "", "memory request (e.g. 1Gi, 512Mi)")
+
+	// Environment and data
+	f.StringArrayVarP(&submitEnvs, "env", "e", nil, "environment variable (key=value, repeatable)")
+	f.StringArrayVarP(&submitData, "data", "d", nil, "data volume (name:path:pvc, repeatable)")
+	f.StringArrayVar(&submitDataDir, "data-dir", nil, "host path volume (name:path:hostpath, repeatable)")
+	f.StringArrayVar(&submitConfigFile, "config-file", nil, "configmap volume (name:path:configmap, repeatable)")
+	f.StringArrayVarP(&submitLabels, "label", "l", nil, "label (key=value, repeatable)")
+	f.StringArrayVarP(&submitAnnotations, "annotation", "a", nil, "annotation (key=value, repeatable)")
+
+	// Scheduling
+	f.StringArrayVar(&submitSelectors, "selector", nil, "node selector (key=value, repeatable)")
+	f.StringArrayVar(&submitTolerations, "toleration", nil, "toleration (key=value:effect, repeatable)")
+	f.StringVarP(&submitPriorityClass, "priority", "p", "", "priority class name")
+	f.BoolVar(&submitGang, "gang", false, "enable gang scheduling")
+	f.StringVar(&submitScheduler, "scheduler", "", "custom scheduler name")
+	f.StringVar(&submitAffinityPolicy, "affinity-policy", "", "affinity policy")
+	f.StringVar(&submitAffinityConstraint, "affinity-constraint", "", "affinity constraint")
+	f.StringVar(&submitAffinityTarget, "affinity-target", "", "affinity target (pod or node)")
+	f.BoolVar(&submitQueue, "queue", false, "enables the feature to queue jobs after they are scheduled (Kube-queue needs to be pre-installed https://github.com/kube-queue/kube-queue)")
+
+	// Lifecycle
+	f.StringVar(&submitCleanTaskPolicy, "clean-task-policy", "Running", "clean pod policy (None, Running, All); pass \"\" to use the operator default")
+	f.StringVar(&submitRunningTimeout, "running-timeout", "", "running timeout (e.g. 2h, 7d)")
+	f.StringVar(&submitTTLAfterFinished, "ttl-after-finished", "", "TTL after finished (e.g. 7d)")
+	f.IntVar(&submitJobBackoffLimit, "job-backoff-limit", 0, "max restart count for the job")
+	f.IntVar(&submitJobBackoffLimit, "retry", 0, "times to retry the job (same as --job-backoff-limit)")
+
+	// Runtime
+	f.StringVar(&submitImagePullPolicy, "image-pull-policy", "", "image pull policy (Always, IfNotPresent, Never)")
+	f.StringArrayVar(&submitImagePullSecret, "image-pull-secret", nil, "image pull secret name (repeatable)")
+	f.StringVar(&submitServiceAccount, "service-account", "", "service account name")
+	f.StringVar(&submitJobRestartPolicy, "job-restart-policy", "", "restart policy (Always, OnFailure, Never)")
+	f.BoolVar(&submitHostNetwork, "hostNetwork", false, "use host network")
+	f.BoolVar(&submitHostIPC, "hostIPC", false, "use host IPC namespace")
+	f.BoolVar(&submitHostPID, "hostPID", false, "use host PID namespace")
+
+	// Task
+	f.StringVar(&submitWorkingDir, "working-dir", "", "working directory in container")
+	f.StringVar(&submitShell, "shell", "", "shell to use (default /bin/sh)")
+	f.StringVar(&submitShareMemory, "share-memory", "2Gi", "shared memory size (default 2Gi like v1; pass \"\" to disable)")
+	f.StringArrayVar(&submitDevice, "device", nil, "extended resource (name=count, repeatable)")
+	f.StringVar(&submitGPUType, "gpu-type", "", "GPU type (sets node selector nvidia.com/gpu.product)")
+
+	// Logging / TensorBoard
+	f.BoolVar(&submitTensorBoard, "tensorboard", false, "enable TensorBoard sidecar (TensorBoard has no built-in authentication)")
+	f.StringVar(&submitLogDir, "logdir", "/training_logs", "TensorBoard log directory (default /training_logs like v1)")
+	f.StringVar(&submitTBImage, "tensorboard-image", "", "TensorBoard container image")
+
+	// Dry-run
+	f.BoolVar(&submitDryRun, "dry-run", false, "print CRD as JSON (default) or YAML (-o yaml) without submitting")
+	f.StringVarP(&outputFormat, "output", "o", string(outputpkg.DefaultFormat), outputpkg.FormatHelpText)
+
+	_ = cmd.RegisterFlagCompletionFunc("output", completeOutputFormat)
+	_ = cmd.RegisterFlagCompletionFunc("clean-task-policy", completeStaticChoices(
+		"None\tDo not clean pods", "Running\tClean running pods", "All\tClean all pods"))
+	_ = cmd.RegisterFlagCompletionFunc("image-pull-policy", completeStaticChoices(
+		"Always\tAlways pull", "IfNotPresent\tPull if not present", "Never\tNever pull"))
+	_ = cmd.RegisterFlagCompletionFunc("job-restart-policy", completeStaticChoices(
+		"Always\tAlways restart", "OnFailure\tRestart on failure", "Never\tNever restart"))
+}
+
+// registerPyTorchSubmitFlags registers the PyTorch-only submit flags on cmd.
+func registerPyTorchSubmitFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&submitNprocPerNode, "nproc-per-node", "", "PyTorch: processes per node (auto, gpu, cpu, or int)")
+	_ = cmd.RegisterFlagCompletionFunc("nproc-per-node", completeStaticChoices(
+		"auto\tAuto-detect", "gpu\tOne per GPU", "cpu\tOne per CPU"))
+}
+
+// registerTFSubmitFlags registers the TensorFlow-only submit flags on cmd:
+// role toggles, success policy, and the v1 per-role resource flags.
+func registerTFSubmitFlags(cmd *cobra.Command) {
+	f := cmd.Flags()
+
+	f.IntVar(&submitPS, "ps", 0, "TensorFlow: number of parameter servers")
+	f.BoolVar(&submitChief, "chief", false, "TensorFlow: enable Chief worker")
+	f.BoolVar(&submitEvaluator, "evaluator", false, "TensorFlow: enable Evaluator worker")
+	f.StringVar(&submitSuccessPolicy, "success-policy", "", "success policy (ChiefWorker, AllWorkers, TF only). ChiefWorker is an alias for the default \"\"")
+	_ = cmd.RegisterFlagCompletionFunc("success-policy", completeStaticChoices(
+		"ChiefWorker\tChief and worker succeed", "AllWorkers\tAll workers succeed"))
+
+	f.StringVar(&submitPSCPU, "ps-cpu", "", "TensorFlow: CPU for parameter servers (e.g. 500m, 2)")
+	f.StringVar(&submitPSMemory, "ps-memory", "", "TensorFlow: memory for parameter servers (e.g. 1Gi)")
+	f.IntVar(&submitPSGPUs, "ps-gpus", 0, "TensorFlow: GPUs per parameter server")
+	f.StringVar(&submitChiefCPU, "chief-cpu", "", "TensorFlow: CPU for the Chief role (e.g. 500m, 2)")
+	f.StringVar(&submitChiefMemory, "chief-memory", "", "TensorFlow: memory for the Chief role (e.g. 1Gi)")
+	f.StringVar(&submitEvaluatorCPU, "evaluator-cpu", "", "TensorFlow: CPU for the Evaluator role (e.g. 500m, 2)")
+	f.StringVar(&submitEvaluatorMemory, "evaluator-memory", "", "TensorFlow: memory for the Evaluator role (e.g. 1Gi)")
+
+	// v1 TFJob -limit variants. v2 defaults to Guaranteed QoS (one value for
+	// requests and limits); an explicit -limit value overrides only the limit,
+	// reproducing v1's independent request/limit flags.
+	f.StringVar(&submitPSCPULimit, "ps-cpu-limit", "", "TensorFlow: CPU limit for parameter servers (requests stay at --ps-cpu)")
+	f.StringVar(&submitPSMemoryLimit, "ps-memory-limit", "", "TensorFlow: memory limit for parameter servers (requests stay at --ps-memory)")
+	f.StringVar(&submitChiefCPULimit, "chief-cpu-limit", "", "TensorFlow: CPU limit for the Chief role (requests stay at --chief-cpu)")
+	f.StringVar(&submitChiefMemoryLimit, "chief-memory-limit", "", "TensorFlow: memory limit for the Chief role (requests stay at --chief-memory)")
+	f.StringVar(&submitEvaluatorCPULimit, "evaluator-cpu-limit", "", "TensorFlow: CPU limit for the Evaluator role (requests stay at --evaluator-cpu)")
+	f.StringVar(&submitEvaluatorMemoryLimit, "evaluator-memory-limit", "", "TensorFlow: memory limit for the Evaluator role (requests stay at --evaluator-memory)")
+}
+
+// registerMPISubmitFlags registers the MPI-family-only submit flags on cmd
+// (mpi, horovod and deepspeed all render the MPIJob CRD).
+func registerMPISubmitFlags(cmd *cobra.Command) {
+	f := cmd.Flags()
+	f.IntVar(&submitSlotsPerWorker, "slots-per-worker", 0, "MPI: slots per worker")
+	f.BoolVar(&submitGPUTopology, "gputopology", false, "MPI: enable GPU topology (sets host networking, gpu-topology/gpu-topology-replica labels, and MPI annotation)")
+	f.BoolVar(&submitMountsOnLauncher, "mounts-on-launcher", false, "MPI: mount volumes on launcher")
+}
+
+// registerSubmitFrameworkFlags registers the framework-specific submit flags
+// on cmd: PyTorch flags for pytorch, TensorFlow flags for tensorflow, and
+// the MPI-family flags for mpi/horovod/deepspeed (all three render MPIJob).
+func registerSubmitFrameworkFlags(cmd *cobra.Command, framework string) {
+	switch {
+	case framework == constants.FrameworkPyTorch:
+		registerPyTorchSubmitFlags(cmd)
+	case framework == constants.FrameworkTensorFlow:
+		registerTFSubmitFlags(cmd)
+	case isMPIFamily(framework):
+		registerMPISubmitFlags(cmd)
+	}
+}
+
+// buildSubmitFlags builds the overrides map from all submit flag values.
+func buildSubmitFlags() map[string]interface{} {
+	flags := make(map[string]interface{})
+
+	// Identity
+	if submitName != "" {
+		flags["name"] = submitName
+	}
+
+	// Resources
+	if submitGPUs > 0 {
+		flags["gpus"] = submitGPUs
+	}
+	if submitCPU != "" {
+		flags["cpu"] = submitCPU
+	}
+	if submitMemory != "" {
+		flags["memory"] = submitMemory
+	}
+
+	// Environment
+	if len(submitEnvs) > 0 {
+		flags["env"] = submitEnvs
+	}
+
+	// Data
+	if len(submitData) > 0 {
+		flags["data"] = submitData
+	}
+	if len(submitDataDir) > 0 {
+		flags["data-dir"] = submitDataDir
+	}
+	if len(submitConfigFile) > 0 {
+		flags["config-file"] = submitConfigFile
+	}
+
+	// Labels
+	if len(submitLabels) > 0 {
+		flags["label"] = submitLabels
+	}
+
+	// Annotations
+	if len(submitAnnotations) > 0 {
+		flags["annotation"] = submitAnnotations
+	}
+
+	// Scheduling
+	if len(submitSelectors) > 0 {
+		flags["selector"] = submitSelectors
+	}
+	if len(submitTolerations) > 0 {
+		flags["toleration"] = submitTolerations
+	}
+	if submitPriorityClass != "" {
+		flags["priority"] = submitPriorityClass
+	}
+	if submitGang {
+		flags["gang"] = submitGang
+	}
+	if submitScheduler != "" {
+		flags["scheduler"] = submitScheduler
+	}
+	if submitAffinityPolicy != "" {
+		flags["affinity-policy"] = submitAffinityPolicy
+	}
+	if submitAffinityConstraint != "" {
+		flags["affinity-constraint"] = submitAffinityConstraint
+	}
+	if submitAffinityTarget != "" {
+		flags["affinity-target"] = submitAffinityTarget
+	}
+	if submitQueue {
+		flags["queue"] = submitQueue
+	}
+
+	// Lifecycle
+	if submitCleanTaskPolicy != "" {
+		flags["clean-task-policy"] = submitCleanTaskPolicy
+	}
+	if submitRunningTimeout != "" {
+		flags["running-timeout"] = submitRunningTimeout
+	}
+	if submitTTLAfterFinished != "" {
+		flags["ttl-after-finished"] = submitTTLAfterFinished
+	}
+	if submitJobBackoffLimit > 0 {
+		flags["job-backoff-limit"] = submitJobBackoffLimit
+	}
+	if submitSuccessPolicy != "" {
+		flags["success-policy"] = submitSuccessPolicy
+	}
+
+	// Runtime
+	if submitImagePullPolicy != "" {
+		flags["image-pull-policy"] = submitImagePullPolicy
+	}
+	if len(submitImagePullSecret) > 0 {
+		flags["image-pull-secret"] = submitImagePullSecret
+	}
+	if submitServiceAccount != "" {
+		flags["service-account"] = submitServiceAccount
+	}
+	if submitJobRestartPolicy != "" {
+		flags["job-restart-policy"] = submitJobRestartPolicy
+	}
+	if submitHostNetwork {
+		flags["hostNetwork"] = submitHostNetwork
+	}
+	if submitHostIPC {
+		flags["hostIPC"] = submitHostIPC
+	}
+	if submitHostPID {
+		flags["hostPID"] = submitHostPID
+	}
+
+	// Task
+	if submitWorkingDir != "" {
+		flags["working-dir"] = submitWorkingDir
+	}
+	if submitShell != "" {
+		flags["shell"] = submitShell
+	}
+	if submitShareMemory != "" {
+		flags["share-memory"] = submitShareMemory
+	}
+	if len(submitDevice) > 0 {
+		flags["device"] = submitDevice
+	}
+	if submitGPUType != "" {
+		flags["gpu-type"] = submitGPUType
+	}
+
+	// Logging
+	if submitTensorBoard {
+		flags["tensorboard"] = submitTensorBoard
+	}
+	if submitLogDir != "" {
+		flags["logdir"] = submitLogDir
+	}
+	if submitTBImage != "" {
+		flags["tensorboard-image"] = submitTBImage
+	}
+
+	// v1 code sync (applied by task.ApplyOverrides)
+	if submitSyncMode != "" {
+		flags["sync-mode"] = submitSyncMode
+	}
+	if submitSyncSource != "" {
+		flags["sync-source"] = submitSyncSource
+	}
+	if submitSyncImage != "" {
+		flags["sync-image"] = submitSyncImage
+	}
+
+	// Framework-specific
+	if submitNprocPerNode != "" {
+		flags["nproc-per-node"] = submitNprocPerNode
+	}
+	if submitPS > 0 {
+		flags["ps"] = submitPS
+	}
+	if submitChief {
+		flags["chief"] = submitChief
+	}
+	if submitEvaluator {
+		flags["evaluator"] = submitEvaluator
+	}
+	if submitSlotsPerWorker > 0 {
+		flags["slots-per-worker"] = submitSlotsPerWorker
+	}
+	if submitGPUTopology {
+		flags["gputopology"] = submitGPUTopology
+	}
+	if submitMountsOnLauncher {
+		flags["mounts-on-launcher"] = submitMountsOnLauncher
+	}
+
+	// v1 per-role resources (applied by task.ApplyOverrides after the roles
+	// are created, so they override the generic --cpu/--memory)
+	if submitPSCPU != "" {
+		flags["ps-cpu"] = submitPSCPU
+	}
+	if submitPSMemory != "" {
+		flags["ps-memory"] = submitPSMemory
+	}
+	if submitPSGPUs > 0 {
+		flags["ps-gpus"] = submitPSGPUs
+	}
+	if submitChiefCPU != "" {
+		flags["chief-cpu"] = submitChiefCPU
+	}
+	if submitChiefMemory != "" {
+		flags["chief-memory"] = submitChiefMemory
+	}
+	if submitEvaluatorCPU != "" {
+		flags["evaluator-cpu"] = submitEvaluatorCPU
+	}
+	if submitEvaluatorMemory != "" {
+		flags["evaluator-memory"] = submitEvaluatorMemory
+	}
+	if submitWorkerCPU != "" {
+		flags["worker-cpu"] = submitWorkerCPU
+	}
+	if submitWorkerMemory != "" {
+		flags["worker-memory"] = submitWorkerMemory
+	}
+	if submitPSCPULimit != "" {
+		flags["ps-cpu-limit"] = submitPSCPULimit
+	}
+	if submitPSMemoryLimit != "" {
+		flags["ps-memory-limit"] = submitPSMemoryLimit
+	}
+	if submitChiefCPULimit != "" {
+		flags["chief-cpu-limit"] = submitChiefCPULimit
+	}
+	if submitChiefMemoryLimit != "" {
+		flags["chief-memory-limit"] = submitChiefMemoryLimit
+	}
+	if submitEvaluatorCPULimit != "" {
+		flags["evaluator-cpu-limit"] = submitEvaluatorCPULimit
+	}
+	if submitEvaluatorMemoryLimit != "" {
+		flags["evaluator-memory-limit"] = submitEvaluatorMemoryLimit
+	}
+	if submitWorkerCPULimit != "" {
+		flags["worker-cpu-limit"] = submitWorkerCPULimit
+	}
+	if submitWorkerMemoryLimit != "" {
+		flags["worker-memory-limit"] = submitWorkerMemoryLimit
+	}
+
+	return flags
+}
+
+// registerSubmitCompatFlags registers the v1 flags that need custom wiring:
+// sync, per-role worker resources, and the deprecated no-op compat flags.
+func registerSubmitCompatFlags(cmd *cobra.Command) {
+	f := cmd.Flags()
+
+	// v1 -limit variants for the worker role (the TF per-role -limit variants
+	// live in registerTFSubmitFlags).
+	f.StringVar(&submitWorkerCPULimit, "worker-cpu-limit", "", "CPU limit for workers (requests stay at --worker-cpu)")
+	f.StringVar(&submitWorkerMemoryLimit, "worker-memory-limit", "", "memory limit for workers (requests stay at --worker-memory)")
+
+	// Sync code (v1 --sync-mode/--sync-source/--sync-image).
+	f.StringVar(&submitSyncMode, "sync-mode", "", "sync mode: git, rsync, or hdfs")
+	f.StringVar(&submitSyncSource, "sync-source", "", "sync source (repo URL for git, host::path for rsync, URI for hdfs)")
+	f.StringVar(&submitSyncImage, "sync-image", "", "container image used by the sync init container")
+
+	// Per-role worker resources (v1 flags mapped to v2 role blocks).
+	f.StringVar(&submitWorkerCPU, "worker-cpu", "", "CPU for workers, overrides the generic resource flags (e.g. 500m, 2)")
+	f.StringVar(&submitWorkerMemory, "worker-memory", "", "memory for workers, overrides the generic resource flags (e.g. 1Gi)")
+
+	// --config: v1 name for the kubeconfig path; v2's global --kubeconfig is
+	// the equivalent, so this binds the same variable and still works.
+	f.StringVar(&kubeconfig, "config", "", "path to kubeconfig file (v1 compat)")
+	_ = f.MarkDeprecated("config", "please use --kubeconfig instead")
+
+	// --loglevel: v1 log level mapped onto v2 verbosity (debug->2, info->1,
+	// warn/error->0) in runSubmit via applyV1LogLevel.
+	f.StringVar(&submitLogLevel, "loglevel", "", "log level: debug, info, warn, or error (v1 compat)")
+	_ = f.MarkDeprecated("loglevel", "please use --verbose instead")
+
+	f.BoolVar(&submitIgnoredBool, "rdma", false, "enable RDMA (v1 compat)")
+	_ = f.MarkDeprecated("rdma", "arena-v2 requests RDMA hardware via --device <resource>=<count>, e.g. --device rdma/hca=1")
+
+	// TODO(role-config): bind these per-role flags to real RoleConfig fields
+	// once it grows selector/annotation/image/port support. They are accepted
+	// so v1 scripts do not hard-fail, and warn that they are ignored.
+	for _, name := range []string{
+		"ps-selector", "worker-selector", "chief-selector", "evaluator-selector", "launcher-selector",
+		"worker-annotation", "launcher-annotation",
+		"ps-image", "worker-image",
+		"ps-port", "worker-port", "chief-port", "ssh-port",
+		"ps-affinity-policy", "ps-affinity-constraint",
+		"worker-affinity-policy", "worker-affinity-constraint",
+	} {
+		f.StringVar(&submitIgnoredString, name, "", "per-role setting (v1 compat)")
+		_ = f.MarkDeprecated(name, "not compatible with arena-v2 yet (requires per-role RoleConfig extension); ignored")
+	}
+
+	// v1 flags with no v2 equivalent and no behavioral effect.
+	f.BoolVar(&submitIgnoredBool, "pprof", false, "enable cpu profile (v1 compat)")
+	_ = f.MarkDeprecated("pprof", "has no effect in arena-v2")
+	f.BoolVar(&submitIgnoredBool, "trace", false, "enable trace (v1 compat)")
+	_ = f.MarkDeprecated("trace", "has no effect in arena-v2")
+	f.BoolVar(&submitIgnoredBool, "helm-binary", false, "use helm binary to submit job (v1 compat)")
+	_ = f.MarkDeprecated("helm-binary", "has no effect in arena-v2")
+	for _, name := range []string{
+		"arena-namespace", "model-name", "model-source",
+		"starting-timeout", "role-sequence", "ssh-secret",
+	} {
+		f.StringVar(&submitIgnoredString, name, "", "(v1 compat)")
+		_ = f.MarkDeprecated(name, "has no effect in arena-v2")
+	}
+}

--- a/pkg/cli/submit_flags_test.go
+++ b/pkg/cli/submit_flags_test.go
@@ -1,0 +1,400 @@
+package cli
+
+import (
+	"flag"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kubeflow/arena/pkg/log"
+	"github.com/kubeflow/arena/pkg/task"
+)
+
+// resetSubmitCompatFlags resets v1-compat flag variables to their defaults.
+func resetSubmitCompatFlags() {
+	submitSyncMode = ""
+	submitSyncSource = ""
+	submitSyncImage = ""
+	submitPSCPU = ""
+	submitPSMemory = ""
+	submitPSGPUs = 0
+	submitChiefCPU = ""
+	submitChiefMemory = ""
+	submitEvaluatorCPU = ""
+	submitEvaluatorMemory = ""
+	submitWorkerCPU = ""
+	submitWorkerMemory = ""
+	submitPSCPULimit = ""
+	submitPSMemoryLimit = ""
+	submitChiefCPULimit = ""
+	submitChiefMemoryLimit = ""
+	submitEvaluatorCPULimit = ""
+	submitEvaluatorMemoryLimit = ""
+	submitWorkerCPULimit = ""
+	submitWorkerMemoryLimit = ""
+	submitLogLevel = ""
+	submitIgnoredString = ""
+	submitIgnoredBool = false
+}
+
+// v1RenamedFlags are v1 flag names that must be registered on the submit
+// command.
+var v1RenamedFlags = []string{
+	"cpu",
+	"memory",
+	"scheduler",
+	"logdir",
+	"clean-task-policy",
+	"running-timeout",
+	"share-memory",
+	"job-restart-policy",
+	"job-backoff-limit",
+	"retry",
+	"ps",
+	"gputopology",
+	"hostNetwork",
+	"hostIPC",
+	"hostPID",
+}
+
+// wrongV2Names are v2-invented flag names that diverged from v1 and must not
+// exist on the submit command.
+var wrongV2Names = []string{
+	"cpus",
+	"mem",
+	"scheduler-name",
+	"tensorboard-logdir",
+	"clean-pod-policy",
+	"active-deadline",
+	"shm",
+	"restart",
+	"backoff-limit",
+	"ps-count",
+	"gpu-topology",
+	"host-network",
+	"host-ipc",
+	"host-pid",
+	"priority-class-name",
+	// -limit variants that never existed in v1
+	"cpu-limit",
+	"memory-limit",
+	"gpus-limit",
+	"ps-gpus-limit",
+}
+
+func TestSubmitCompat_V1FlagNamesRegistered(t *testing.T) {
+	for _, name := range v1RenamedFlags {
+		f := submitCmd.Flags().Lookup(name)
+		require.NotNil(t, f, "v1 flag --%s should be registered", name)
+	}
+}
+
+func TestSubmitCompat_WrongV2FlagNamesRemoved(t *testing.T) {
+	for _, name := range wrongV2Names {
+		assert.Nil(t, submitCmd.Flags().Lookup(name),
+			"--%s must not be registered; the v1 name is the correct name", name)
+	}
+}
+
+func TestSubmitCompat_V1LimitVariantsRegistered(t *testing.T) {
+	// v1 TFJob exposed -limit variants for per-role resources. They bind to their own variables and override only limits; requests come from the request flag.
+	limits := map[string]string{
+		"ps-cpu-limit":           "ps-cpu",
+		"ps-memory-limit":        "ps-memory",
+		"chief-cpu-limit":        "chief-cpu",
+		"chief-memory-limit":     "chief-memory",
+		"evaluator-cpu-limit":    "evaluator-cpu",
+		"evaluator-memory-limit": "evaluator-memory",
+		"worker-cpu-limit":       "worker-cpu",
+		"worker-memory-limit":    "worker-memory",
+	}
+	for limit, base := range limits {
+		f := submitCmd.Flags().Lookup(limit)
+		require.NotNil(t, f, "v1 flag --%s should be registered", limit)
+		assert.NotNil(t, submitCmd.Flags().Lookup(base), "--%s should also be registered", base)
+	}
+}
+
+func TestSubmitCompat_V1FlagsBindToVariables(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		parseErr bool
+		check    func(t *testing.T)
+	}{
+		{
+			name:  "--cpu sets the cpu variable",
+			args:  []string{"--cpu", "4"},
+			check: func(t *testing.T) { assert.Equal(t, "4", submitCPU) },
+		},
+		{
+			name:  "--memory sets the memory variable",
+			args:  []string{"--memory", "8Gi"},
+			check: func(t *testing.T) { assert.Equal(t, "8Gi", submitMemory) },
+		},
+		{
+			name:  "--scheduler sets the scheduler variable",
+			args:  []string{"--scheduler", "volcano"},
+			check: func(t *testing.T) { assert.Equal(t, "volcano", submitScheduler) },
+		},
+		{
+			// Distinct from the resetSubmitFlags default (/training_logs) so the
+			// subtest proves parsing, not the pre-loaded default.
+			name:  "--logdir sets the logdir variable",
+			args:  []string{"--logdir", "/custom/logs"},
+			check: func(t *testing.T) { assert.Equal(t, "/custom/logs", submitLogDir) },
+		},
+		{
+			name:  "--clean-task-policy sets the clean task policy variable",
+			args:  []string{"--clean-task-policy", "None"},
+			check: func(t *testing.T) { assert.Equal(t, "None", submitCleanTaskPolicy) },
+		},
+		{
+			name:  "--running-timeout sets the running timeout variable",
+			args:  []string{"--running-timeout", "2h22m"},
+			check: func(t *testing.T) { assert.Equal(t, "2h22m", submitRunningTimeout) },
+		},
+		{
+			name:  "--job-backoff-limit sets the backoff variable",
+			args:  []string{"--job-backoff-limit", "3"},
+			check: func(t *testing.T) { assert.Equal(t, 3, submitJobBackoffLimit) },
+		},
+		{
+			name:  "--retry sets the backoff variable",
+			args:  []string{"--retry", "5"},
+			check: func(t *testing.T) { assert.Equal(t, 5, submitJobBackoffLimit) },
+		},
+		{
+			name:  "retry and job-backoff-limit share one variable (last wins)",
+			args:  []string{"--retry", "5", "--job-backoff-limit", "2"},
+			check: func(t *testing.T) { assert.Equal(t, 2, submitJobBackoffLimit) },
+		},
+		{
+			// Distinct from the resetSubmitFlags default (2Gi) so the subtest
+			// proves parsing, not the pre-loaded default.
+			name:  "--share-memory sets the share memory variable",
+			args:  []string{"--share-memory", "4Gi"},
+			check: func(t *testing.T) { assert.Equal(t, "4Gi", submitShareMemory) },
+		},
+		{
+			name:  "--ps sets the ps count variable",
+			args:  []string{"--ps", "2"},
+			check: func(t *testing.T) { assert.Equal(t, 2, submitPS) },
+		},
+		{
+			name:  "--gputopology sets the gpu topology variable",
+			args:  []string{"--gputopology"},
+			check: func(t *testing.T) { assert.True(t, submitGPUTopology) },
+		},
+		{
+			name:  "--hostNetwork sets the host network variable",
+			args:  []string{"--hostNetwork"},
+			check: func(t *testing.T) { assert.True(t, submitHostNetwork) },
+		},
+		{
+			name:  "--hostIPC sets the host ipc variable",
+			args:  []string{"--hostIPC"},
+			check: func(t *testing.T) { assert.True(t, submitHostIPC) },
+		},
+		{
+			name:  "--hostPID sets the host pid variable",
+			args:  []string{"--hostPID"},
+			check: func(t *testing.T) { assert.True(t, submitHostPID) },
+		},
+		{
+			name:  "--job-restart-policy sets the restart variable",
+			args:  []string{"--job-restart-policy", "OnFailure"},
+			check: func(t *testing.T) { assert.Equal(t, "OnFailure", submitJobRestartPolicy) },
+		},
+		{
+			name:  "--ps-cpu-limit sets the ps cpu limit variable",
+			args:  []string{"--ps-cpu-limit", "2"},
+			check: func(t *testing.T) { assert.Equal(t, "2", submitPSCPULimit) },
+		},
+		{
+			name:  "--worker-memory-limit sets the worker memory limit variable",
+			args:  []string{"--worker-memory-limit", "16Gi"},
+			check: func(t *testing.T) { assert.Equal(t, "16Gi", submitWorkerMemoryLimit) },
+		},
+		{
+			name:     "--cpu-limit is not a v1 flag and must not parse",
+			args:     []string{"--cpu-limit", "2"},
+			check:    func(t *testing.T) { t.Error("should not reach here") },
+			parseErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetSubmitFlags(t)
+			err := submitCmd.Flags().Parse(tt.args)
+			if tt.parseErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			tt.check(t)
+		})
+	}
+}
+
+func TestSubmitCompat_PriorityIsV1ClassName(t *testing.T) {
+	t.Run("--priority takes a class name like v1", func(t *testing.T) {
+		resetSubmitFlags(t)
+		require.NoError(t, submitCmd.Flags().Parse([]string{"--priority", "high-priority"}))
+		assert.Equal(t, "high-priority", submitPriorityClass)
+	})
+
+	t.Run("-p shorthand is preserved", func(t *testing.T) {
+		resetSubmitFlags(t)
+		require.NoError(t, submitCmd.Flags().Parse([]string{"-p", "high"}))
+		assert.Equal(t, "high", submitPriorityClass)
+	})
+
+	t.Run("--priority is a string flag", func(t *testing.T) {
+		f := submitCmd.Flags().Lookup("priority")
+		require.NotNil(t, f)
+		assert.Equal(t, "string", f.Value.Type())
+	})
+}
+
+func TestSubmitCompat_QueueIsV1Bool(t *testing.T) {
+	t.Run("--queue is a bool flag like v1", func(t *testing.T) {
+		f := submitCmd.Flags().Lookup("queue")
+		require.NotNil(t, f)
+		assert.Equal(t, "bool", f.Value.Type())
+	})
+
+	t.Run("bare --queue parses like a v1 invocation", func(t *testing.T) {
+		resetSubmitFlags(t)
+		require.NoError(t, submitCmd.Flags().Parse([]string{"--queue"}))
+		assert.True(t, submitQueue)
+	})
+
+	t.Run("--queue suspends the job for kube-queue", func(t *testing.T) {
+		resetSubmitFlags(t)
+		require.NoError(t, submitCmd.Flags().Parse([]string{"--queue"}))
+
+		tk := buildSubmitTask("pytorch", nil)
+		flags := buildSubmitFlags()
+		require.NoError(t, task.ApplyOverrides(tk, flags))
+
+		require.NotNil(t, tk.Lifecycle.Suspend, "--queue should set suspend")
+		assert.True(t, *tk.Lifecycle.Suspend)
+	})
+}
+
+func TestSubmitCompat_RepeatableFlagsAreStringArrays(t *testing.T) {
+	names := []string{
+		"env", "data", "data-dir", "config-file",
+		"label", "annotation", "selector", "toleration",
+		"device", "image-pull-secret",
+	}
+	for _, name := range names {
+		f := submitCmd.Flags().Lookup(name)
+		require.NotNil(t, f, "--%s should be registered", name)
+		assert.Equal(t, "stringArray", f.Value.Type(),
+			"--%s must be a stringArray flag (v1 semantics, no comma splitting)", name)
+	}
+}
+
+func TestSubmitCompat_CommaValuesNotSplit(t *testing.T) {
+	resetSubmitFlags(t)
+	require.NoError(t, submitCmd.Flags().Parse([]string{
+		"--env", "A=1,2",
+		"--data", "ds:/data",
+	}))
+
+	assert.Equal(t, []string{"A=1,2"}, submitEnvs,
+		"--env value with a comma must stay one entry like v1")
+	assert.Equal(t, []string{"ds:/data"}, submitData)
+}
+
+func TestSubmitCompat_LimitFlagsHaveOwnVariables(t *testing.T) {
+	resetSubmitFlags(t)
+	resetSubmitCompatFlags()
+	require.NoError(t, submitCmd.Flags().Parse([]string{
+		"--ps-cpu", "1", "--ps-cpu-limit", "2",
+		"--worker-cpu", "1", "--worker-cpu-limit", "3",
+	}))
+	assert.Equal(t, "1", submitPSCPU)
+	assert.Equal(t, "2", submitPSCPULimit)
+	assert.Equal(t, "1", submitWorkerCPU)
+	assert.Equal(t, "3", submitWorkerCPULimit)
+}
+
+// v1OfficialMissingFlags are the v1-official submit flags (visible in
+// `arena v0.15.4 submit <type> -h`) that arena-v2 had not registered.
+var v1OfficialMissingFlags = []string{
+	"config", "loglevel", "rdma",
+	// per-role flags: accepted, warned, ignored until RoleConfig grows
+	// selector/annotation/image/port fields
+	"ps-selector", "worker-selector", "chief-selector", "evaluator-selector", "launcher-selector",
+	"worker-annotation", "launcher-annotation",
+	"ps-image", "worker-image",
+	"ps-port", "worker-port", "chief-port", "ssh-port",
+	"ps-affinity-policy", "ps-affinity-constraint",
+	"worker-affinity-policy", "worker-affinity-constraint",
+	// flags with no v2 equivalent
+	"pprof", "trace", "helm-binary", "arena-namespace",
+	"model-name", "model-source", "starting-timeout", "role-sequence", "ssh-secret",
+}
+
+func TestSubmitCompat_V1OfficialFlagsRegistered(t *testing.T) {
+	for _, name := range v1OfficialMissingFlags {
+		f := submitCmd.Flags().Lookup(name)
+		require.NotNil(t, f, "v1 official flag --%s should be registered", name)
+		assert.True(t, f.Hidden, "--%s is deprecated and must be hidden from help", name)
+	}
+}
+
+func TestSubmitCompat_ConfigBindsKubeconfig(t *testing.T) {
+	oldKubeconfig := kubeconfig
+	t.Cleanup(func() { kubeconfig = oldKubeconfig })
+
+	resetSubmitFlags(t)
+	require.NoError(t, submitCmd.Flags().Parse([]string{"--config", "/tmp/kube-config"}))
+	assert.Equal(t, "/tmp/kube-config", kubeconfig)
+}
+
+func TestSubmitCompat_DeprecatedFlagsParse(t *testing.T) {
+	resetSubmitFlags(t)
+	resetSubmitCompatFlags()
+	require.NoError(t, submitCmd.Flags().Parse([]string{
+		"--rdma",
+		"--ps-selector", "gpu=a100",
+		"--worker-image", "tf:2.15",
+		"--model-name", "my-model",
+	}))
+	// Deprecated no-op flags must not disturb the task build path.
+	tk := buildSubmitTask("pytorch", nil)
+	flags := buildSubmitFlags()
+	require.NoError(t, task.ApplyOverrides(tk, flags))
+	assert.Empty(t, tk.Annotations, "no-op flags must not leak into the task")
+}
+
+func TestApplyV1LogLevel(t *testing.T) {
+	// applyV1LogLevel mutates klog verbosity on flag.CommandLine; restore the
+	// default afterwards so a mid-test failure cannot leak state.
+	t.Cleanup(func() {
+		if err := log.SetVerbosity(flag.CommandLine, 0); err != nil {
+			t.Errorf("failed to restore verbosity to 0: %v", err)
+		}
+	})
+	vFlag := flag.CommandLine.Lookup("v")
+	require.NotNil(t, vFlag, "klog -v flag should be registered on flag.CommandLine")
+
+	require.NoError(t, applyV1LogLevel(""))
+	require.NoError(t, applyV1LogLevel("debug"))
+	assert.Equal(t, "2", vFlag.Value.String(), "debug should map to verbosity 2")
+	require.NoError(t, applyV1LogLevel("info"))
+	assert.Equal(t, "1", vFlag.Value.String(), "info should map to verbosity 1")
+	require.NoError(t, applyV1LogLevel("warn"))
+	assert.Equal(t, "0", vFlag.Value.String(), "warn should map to verbosity 0")
+	require.NoError(t, applyV1LogLevel("error"))
+	assert.Equal(t, "0", vFlag.Value.String(), "error should map to verbosity 0")
+	err := applyV1LogLevel("bogus")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must be debug, info, warn, or error")
+}

--- a/pkg/cli/submit_subcommands.go
+++ b/pkg/cli/submit_subcommands.go
@@ -1,0 +1,54 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// newSubmitFrameworkSubcommand builds the per-framework submit subcommand
+// (submit pytorchjob, submit tfjob, …) for a supported registry entry. Each
+// subcommand carries only the common flags plus its framework-specific
+// subset, so --help stays focused and flags foreign to the framework fail
+// with "unknown flag". Anything that does not match a subcommand name or
+// alias (unknown types, v1-only types, case variants) falls back to the
+// parent submit command unchanged.
+func newSubmitFrameworkSubcommand(def frameworkDef) *cobra.Command {
+	aliases := make([]string, 0, len(def.aliases))
+	for _, a := range def.aliases {
+		if a != def.cmdName {
+			aliases = append(aliases, a)
+		}
+	}
+	cmd := &cobra.Command{
+		Use:     def.cmdName,
+		Aliases: aliases,
+		Short:   fmt.Sprintf("Submit a %s training job", def.original),
+		Args:    cobra.ArbitraryArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// The label uses originalFramework(typed alias) exactly like the
+			// parent path, so submit tf and submit tfjob both label
+			// "tensorflow" (the canonical name, not the typed alias).
+			return runSubmit(cmd, def.canonical, originalFramework(cmd.CalledAs()), args)
+		},
+	}
+	registerSubmitCommonFlags(cmd)
+	// Required only on subcommands: the parent's copy stays unmarked so a
+	// bare `submit` reaches RunE and prints help instead of failing cobra's
+	// required-flag validation; the parent path defers missing --name/--image
+	// to task validation.
+	_ = cmd.MarkFlagRequired("name")
+	_ = cmd.MarkFlagRequired("image")
+	registerSubmitFrameworkFlags(cmd, def.canonical)
+	registerSubmitCompatFlags(cmd)
+	return cmd
+}
+
+func init() {
+	for _, def := range frameworkRegistry {
+		if def.canonical == "" {
+			continue
+		}
+		submitCmd.AddCommand(newSubmitFrameworkSubcommand(def))
+	}
+}

--- a/pkg/cli/submit_subcommands_test.go
+++ b/pkg/cli/submit_subcommands_test.go
@@ -1,0 +1,362 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// resetSubmitCommandState restores the cobra-side flag state of the submit
+// command tree (the parent and every framework subcommand) after earlier
+// ExecuteWithArgs calls in the same process. pflag never clears a flag's
+// Changed bit — nor the implicit --help flag's value — between Parse calls,
+// so a subcommand that once saw --name/--image would skip cobra's
+// required-flag validation forever, and a command whose --help ran once
+// would print help on every later execution. resetSubmitFlags covers the
+// bound package variables; this covers the state pflag keeps on the shared
+// command objects.
+//
+// The flags are reached through Lookup on each command's flag set: the
+// leaked state lives on per-command pflag.Flag objects — every command in
+// the tree registers its own --name and --image, plus cobra's implicit
+// --help — so each of the three flags is looked up by name on every
+// command, and Lookup's nil return lets the loop skip commands that have
+// not (yet) defined one.
+func resetSubmitCommandState(t *testing.T) {
+	t.Helper()
+	cmds := append([]*cobra.Command{submitCmd}, submitCmd.Commands()...)
+	for _, cmd := range cmds {
+		for _, name := range []string{"name", "image", "help"} {
+			f := cmd.Flags().Lookup(name)
+			if f == nil {
+				continue
+			}
+			if name == "help" {
+				// Cobra checks the help flag's value, not its Changed bit, so
+				// resetting the value through the flag's Value is enough.
+				_ = f.Value.Set("false")
+			}
+			f.Changed = false
+		}
+	}
+}
+
+// executeSubmitForJSON runs the CLI with the given args, captures stdout, and
+// unmarshals the CRD JSON printed by a --dry-run submit.
+func executeSubmitForJSON(t *testing.T, args ...string) map[string]interface{} {
+	t.Helper()
+	resetSubmitCommandState(t)
+
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	err := ExecuteWithArgs(args)
+	w.Close()
+	os.Stdout = oldStdout
+
+	var buf bytes.Buffer
+	_, _ = io.Copy(&buf, r)
+
+	require.NoError(t, err, "submit should succeed, stdout: %s", buf.String())
+
+	var crd map[string]interface{}
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &crd),
+		"dry-run output should be valid JSON, got: %s", buf.String())
+	return crd
+}
+
+// executeSubmitCaptureStdout runs the CLI with the given args and returns
+// everything written to stdout (used for --help output).
+func executeSubmitCaptureStdout(t *testing.T, args ...string) string {
+	t.Helper()
+	resetSubmitCommandState(t)
+
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	err := ExecuteWithArgs(args)
+	w.Close()
+	os.Stdout = oldStdout
+
+	var buf bytes.Buffer
+	_, _ = io.Copy(&buf, r)
+
+	require.NoError(t, err)
+	return buf.String()
+}
+
+func TestSubmitSubcommands_DispatchDryRun(t *testing.T) {
+	tests := []struct {
+		subcommand string
+		kind       string
+	}{
+		{"pytorchjob", "PyTorchJob"},
+		{"tfjob", "TFJob"},
+		{"mpijob", "MPIJob"},
+		{"horovodjob", "MPIJob"},
+		{"deepspeedjob", "MPIJob"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.subcommand, func(t *testing.T) {
+			resetSubmitFlags(t)
+			crd := executeSubmitForJSON(t, "submit", tt.subcommand,
+				"--name", "subcmd-test", "--image", "test:latest",
+				"--workers", "2", "--dry-run", "echo", "hi")
+			assert.Equal(t, tt.kind, crd["kind"])
+		})
+	}
+}
+
+// TestSubmitSubcommands_SubcommandPathCarriesRunConfig goes one level deeper
+// than the kind-only dispatch assertions: a subcommand-path dry-run must
+// carry the run command (trailing args) and the parsed --workers flag through
+// the shared runSubmit core into the CRD.
+func TestSubmitSubcommands_SubcommandPathCarriesRunConfig(t *testing.T) {
+	resetSubmitFlags(t)
+	crd := executeSubmitForJSON(t, "submit", "pytorchjob",
+		"--name", "cfg-test", "--image", "test:latest",
+		"--workers", "2", "--dry-run", "python", "train.py")
+
+	replicaSpecs := crd["spec"].(map[string]interface{})["pytorchReplicaSpecs"].(map[string]interface{})
+	master, ok := replicaSpecs["Master"].(map[string]interface{})
+	require.True(t, ok, "dry-run CRD should carry a Master replica spec: %v", replicaSpecs)
+	worker, ok := replicaSpecs["Worker"].(map[string]interface{})
+	require.True(t, ok, "--workers 2 should produce a Worker replica spec: %v", replicaSpecs)
+
+	// v1 PyTorch semantics: --workers N means N total processes (1 master +
+	// N-1 workers), so --workers 2 yields one worker replica next to the
+	// master. The Worker spec existing at all proves the flag reached the
+	// shared core (--workers <= 1 would build a master-only CRD).
+	assert.Equal(t, float64(1), master["replicas"])
+	assert.Equal(t, float64(1), worker["replicas"])
+
+	// The trailing args "python" "train.py" are joined into the run command
+	// on the container (run+shell model: command [shell, -c], args [run]).
+	masterPodSpec := master["template"].(map[string]interface{})["spec"].(map[string]interface{})
+	masterContainer := masterPodSpec["containers"].([]interface{})[0].(map[string]interface{})
+	assert.Equal(t, []interface{}{"/bin/sh", "-c"}, masterContainer["command"])
+	assert.Equal(t, []interface{}{"python train.py"}, masterContainer["args"])
+}
+
+func TestSubmitSubcommands_RejectForeignFlags(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "pytorch rejects TF --ps",
+			args: []string{"submit", "pytorch", "--name", "x", "--image", "y", "--dry-run", "--ps", "2", "python", "train.py"},
+		},
+		{
+			name: "pytorch rejects MPI --slots-per-worker",
+			args: []string{"submit", "pytorch", "--name", "x", "--image", "y", "--dry-run", "--slots-per-worker", "2", "python", "train.py"},
+		},
+		{
+			name: "tfjob rejects PyTorch --nproc-per-node",
+			args: []string{"submit", "tfjob", "--name", "x", "--image", "y", "--dry-run", "--nproc-per-node", "auto", "python", "train.py"},
+		},
+		{
+			name: "mpijob rejects TF --chief",
+			args: []string{"submit", "mpijob", "--name", "x", "--image", "y", "--dry-run", "--chief", "python", "train.py"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetSubmitFlags(t)
+			err := ExecuteWithArgs(tt.args)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "unknown flag")
+		})
+	}
+}
+
+func TestSubmitSubcommands_HelpShowsOnlyRelevantFlags(t *testing.T) {
+	tests := []struct {
+		subcommand string
+		contains   []string
+		omits      []string
+	}{
+		{
+			subcommand: "pytorchjob",
+			contains:   []string{"--nproc-per-node", "--name", "--workers"},
+			omits:      []string{"--ps", "--chief", "--slots-per-worker", "--gputopology"},
+		},
+		{
+			subcommand: "tfjob",
+			contains:   []string{"--ps", "--chief", "--success-policy"},
+			omits:      []string{"--nproc-per-node", "--slots-per-worker"},
+		},
+		{
+			subcommand: "mpijob",
+			contains:   []string{"--slots-per-worker", "--gputopology", "--mounts-on-launcher"},
+			omits:      []string{"--ps", "--chief", "--nproc-per-node"},
+		},
+		{
+			subcommand: "horovodjob",
+			contains:   []string{"--slots-per-worker"},
+			omits:      []string{"--ps", "--nproc-per-node"},
+		},
+		{
+			subcommand: "deepspeedjob",
+			contains:   []string{"--slots-per-worker"},
+			omits:      []string{"--ps", "--nproc-per-node"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.subcommand, func(t *testing.T) {
+			resetSubmitFlags(t)
+			help := executeSubmitCaptureStdout(t, "submit", tt.subcommand, "--help")
+			for _, want := range tt.contains {
+				assert.Contains(t, help, want)
+			}
+			for _, notWant := range tt.omits {
+				assert.NotContains(t, help, notWant)
+			}
+		})
+	}
+}
+
+func TestSubmitSubcommands_AliasMatrixDispatch(t *testing.T) {
+	tests := []struct {
+		alias string
+		kind  string
+	}{
+		{"pytorch", "PyTorchJob"},
+		{"pytorchjob", "PyTorchJob"},
+		{"tensorflow", "TFJob"},
+		{"tfjob", "TFJob"},
+		{"tf", "TFJob"},
+		{"mpi", "MPIJob"},
+		{"mpijob", "MPIJob"},
+		{"mj", "MPIJob"},
+		{"horovod", "MPIJob"},
+		{"horovodjob", "MPIJob"},
+		{"hj", "MPIJob"},
+		{"deepspeed", "MPIJob"},
+		{"deepspeedjob", "MPIJob"},
+		{"dp", "MPIJob"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.alias, func(t *testing.T) {
+			resetSubmitFlags(t)
+			crd := executeSubmitForJSON(t, "submit", tt.alias,
+				"--name", "alias-test", "--image", "test:latest", "--dry-run", "echo", "hi")
+			assert.Equal(t, tt.kind, crd["kind"])
+		})
+	}
+}
+
+func TestSubmitSubcommands_FrameworkLabelIsCanonical(t *testing.T) {
+	tests := []struct {
+		typed string
+		want  string
+	}{
+		{"pytorch", "pytorch"},
+		{"pytorchjob", "pytorch"},
+		{"tensorflow", "tensorflow"},
+		{"tf", "tensorflow"},
+		{"tfjob", "tensorflow"},
+		{"mpi", "mpi"},
+		{"mpijob", "mpi"},
+		{"horovod", "horovod"},
+		{"deepspeed", "deepspeed"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.typed, func(t *testing.T) {
+			resetSubmitFlags(t)
+			crd := executeSubmitForJSON(t, "submit", tt.typed,
+				"--name", "label-test", "--image", "test:latest", "--dry-run", "echo", "hi")
+			labels, ok := crd["metadata"].(map[string]interface{})["labels"].(map[string]interface{})
+			require.True(t, ok, "dry-run CRD should carry labels: %v", crd["metadata"])
+			assert.Equal(t, tt.want, labels["arena.io/framework"])
+		})
+	}
+}
+
+func TestSubmitSubcommands_ParentFallbackBehaviors(t *testing.T) {
+	t.Run("v1-only type with flags still gets the dedicated error", func(t *testing.T) {
+		resetSubmitFlags(t)
+		err := ExecuteWithArgs([]string{"submit", "ray", "--name", "x", "--image", "y", "python", "train.py"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not supported by arena-v2 yet")
+	})
+
+	t.Run("unknown type still gets the unsupported error", func(t *testing.T) {
+		resetSubmitFlags(t)
+		err := ExecuteWithArgs([]string{"submit", "bogus", "--name", "x", "--image", "y", "python", "train.py"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unsupported framework type")
+	})
+
+	t.Run("case variant falls back to the parent and still submits", func(t *testing.T) {
+		resetSubmitFlags(t)
+		crd := executeSubmitForJSON(t, "submit", "PyTorch",
+			"--name", "case-test", "--image", "test:latest", "--dry-run", "echo", "hi")
+		assert.Equal(t, "PyTorchJob", crd["kind"])
+	})
+
+	t.Run("fallback path missing required flags matches the subcommand error", func(t *testing.T) {
+		resetSubmitCommandState(t)
+		resetSubmitFlags(t)
+		err := ExecuteWithArgs([]string{"submit", "PyTorch", "python", "train.py"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `required flag(s) "image", "name" not set`)
+	})
+
+	t.Run("bare submit prints help instead of erroring", func(t *testing.T) {
+		resetSubmitFlags(t)
+		help := executeSubmitCaptureStdout(t, "submit")
+		for _, sub := range []string{"pytorchjob", "tfjob", "mpijob", "horovodjob", "deepspeedjob"} {
+			assert.Contains(t, help, sub, "bare submit help should list the %s subcommand", sub)
+		}
+	})
+
+	t.Run("flags but no framework prints help instead of erroring", func(t *testing.T) {
+		resetSubmitFlags(t)
+		help := executeSubmitCaptureStdout(t, "submit", "--name", "x", "--image", "y")
+		assert.Contains(t, help, "Available Commands:")
+	})
+
+	t.Run("missing required flags still fails before RunE", func(t *testing.T) {
+		// Cobra-level required-flag validation is a subcommand contract
+		// (--name/--image are marked required on each subcommand, not on the
+		// parent fallback parser). Earlier subtests parse --name/--image and
+		// pflag never clears the Changed bit, so validation would be skipped
+		// if that state leaked in. Reset it so this subtest passes regardless
+		// of ordering. (Parent-path missing --name is covered by
+		// TestSubmitCmd_NameAndImageRequired via task validation.)
+		resetSubmitCommandState(t)
+		resetSubmitFlags(t)
+		err := ExecuteWithArgs([]string{"submit", "pytorchjob", "python", "train.py"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "required flag")
+	})
+
+	t.Run("flags before the type still route to the subcommand", func(t *testing.T) {
+		resetSubmitFlags(t)
+		crd := executeSubmitForJSON(t, "submit",
+			"--name", "order-test", "--image", "test:latest",
+			"pytorchjob", "--dry-run", "echo", "hi")
+		assert.Equal(t, "PyTorchJob", crd["kind"])
+	})
+}
+
+func TestSubmitParentHelp_ListsSubcommandsOnly(t *testing.T) {
+	resetSubmitFlags(t)
+	help := executeSubmitCaptureStdout(t, "submit", "--help")
+
+	for _, sub := range []string{"pytorchjob", "tfjob", "mpijob", "horovodjob", "deepspeedjob"} {
+		assert.Contains(t, help, sub, "submit --help should list the %s subcommand", sub)
+	}
+	// The parent's flag wall must not appear; global (root persistent) flags
+	// like --namespace still do, which is fine.
+	for _, notWant := range []string{"--nproc-per-node", "--slots-per-worker", "--ps ", "--clean-task-policy", "--share-memory"} {
+		assert.NotContains(t, help, notWant)
+	}
+}

--- a/pkg/cli/submit_test.go
+++ b/pkg/cli/submit_test.go
@@ -16,13 +16,11 @@ import (
 	"github.com/kubeflow/arena/pkg/task"
 )
 
-func TestSubmitCmd_RequiresFrameworkArg(t *testing.T) {
-	err := submitCmd.Args(submitCmd, nil)
-	assert.Error(t, err)
-}
-
-func TestSubmitCmd_AcceptsSingleArg(t *testing.T) {
-	err := submitCmd.Args(submitCmd, []string{"pytorch"})
+func TestSubmitCmd_NoFrameworkArgPrintsHelp(t *testing.T) {
+	// RunE guards the empty-args case with help (the framework is the first
+	// positional argument); full stdout coverage lives in
+	// TestSubmitSubcommands_ParentFallbackBehaviors.
+	err := submitCmd.RunE(submitCmd, nil)
 	assert.NoError(t, err)
 }
 
@@ -38,7 +36,7 @@ func TestSubmitCmd_RegisteredWithRootCmd(t *testing.T) {
 }
 
 func TestSubmitCmd_HasRequiredFlags(t *testing.T) {
-	flagNames := []string{"name", "image", "workers", "gpus", "cpus", "mem"}
+	flagNames := []string{"name", "image", "workers", "gpus", "cpu", "memory"}
 	for _, name := range flagNames {
 		f := submitCmd.Flags().Lookup(name)
 		require.NotNil(t, f, "flag %q should be registered", name)
@@ -49,8 +47,8 @@ func TestSubmitCmd_HasFrameworkFlags(t *testing.T) {
 	f := submitCmd.Flags().Lookup("nproc-per-node")
 	assert.NotNil(t, f, "nproc-per-node flag should be registered")
 
-	f = submitCmd.Flags().Lookup("ps-count")
-	assert.NotNil(t, f, "ps-count flag should be registered")
+	f = submitCmd.Flags().Lookup("ps")
+	assert.NotNil(t, f, "ps flag should be registered")
 
 	f = submitCmd.Flags().Lookup("slots-per-worker")
 	assert.NotNil(t, f, "slots-per-worker flag should be registered")
@@ -63,13 +61,12 @@ func TestSubmitCmd_HasDryRunFlag(t *testing.T) {
 }
 
 func TestSubmitCmd_NameAndImageRequired(t *testing.T) {
+	resetSubmitCommandState(t)
 	resetSubmitFlags(t)
 
-	submitName = ""
-	submitImage = ""
 	err := submitCmd.RunE(submitCmd, []string{"pytorch"})
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "validation failed")
+	assert.Contains(t, err.Error(), "required flag")
 }
 
 func TestSubmitCmd_UnsupportedFramework(t *testing.T) {
@@ -84,27 +81,25 @@ func TestSubmitCmd_UnsupportedFramework(t *testing.T) {
 }
 
 func TestSubmitCmd_ValidationFailsWithoutName(t *testing.T) {
+	resetSubmitCommandState(t)
 	resetSubmitFlags(t)
 
-	submitName = ""
-	submitImage = "some-image:latest"
+	require.NoError(t, submitCmd.Flags().Parse([]string{"--image", "some-image:latest"}))
 
 	err := submitCmd.RunE(submitCmd, []string{"pytorch"})
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "validation failed")
-	assert.Contains(t, err.Error(), "name is required")
+	assert.Contains(t, err.Error(), `required flag(s) "name" not set`)
 }
 
 func TestSubmitCmd_ValidationFailsWithoutImage(t *testing.T) {
+	resetSubmitCommandState(t)
 	resetSubmitFlags(t)
 
-	submitName = "my-job"
-	submitImage = ""
+	require.NoError(t, submitCmd.Flags().Parse([]string{"--name", "my-job"}))
 
 	err := submitCmd.RunE(submitCmd, []string{"pytorch"})
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "validation failed")
-	assert.Contains(t, err.Error(), "image is required")
+	assert.Contains(t, err.Error(), `required flag(s) "image" not set`)
 }
 
 func TestBuildSubmitTask_PyTorchWorkersNMinusOne(t *testing.T) {
@@ -177,14 +172,45 @@ func TestBuildSubmitTask_ChiefEvaluatorPS(t *testing.T) {
 	submitWorkers = 2
 	submitChief = true
 	submitEvaluator = true
-	submitPSCount = 3
+	submitPS = 3
 
-	task := buildSubmitTask("tensorflow", nil)
+	// v1 per-role resource flags. These must flow through buildSubmitFlags
+	// into task.ApplyOverrides and land on each role's Resources — a dropped
+	// or misnamed flag key would silently break the v1 compat interface.
+	submitCPU = "2"
+	submitMemory = "4Gi"
+	submitPSCPU = "500m"
+	submitPSMemory = "1Gi"
+	submitPSGPUs = 1
+	submitChiefCPU = "1"
+	submitChiefMemory = "2Gi"
+	submitEvaluatorCPU = "250m"
+	submitEvaluatorMemory = "512Mi"
+	submitWorkerCPU = "8"
+	submitWorkerMemory = "32Gi"
 
-	require.NotNil(t, task.Chief, "chief should be set")
-	require.NotNil(t, task.Evaluator, "evaluator should be set")
-	require.NotNil(t, task.PS, "ps should be set")
-	assert.Equal(t, 3, task.PS.Replicas)
+	// Role sections are created by task.ApplyOverrides from the
+	// chief/evaluator/ps flag keys, not by buildSubmitTask.
+	tk := buildSubmitTask("tensorflow", nil)
+	require.NoError(t, task.ApplyOverrides(tk, buildSubmitFlags()))
+
+	require.NotNil(t, tk.Chief, "chief should be set")
+	require.NotNil(t, tk.Evaluator, "evaluator should be set")
+	require.NotNil(t, tk.PS, "ps should be set")
+	require.NotNil(t, tk.Worker, "worker should be set")
+	assert.Equal(t, 3, tk.PS.Replicas)
+
+	// Per-role resources land on their role and beat the generic
+	// --cpu/--memory (v1 precedence).
+	assert.Equal(t, "500m", tk.PS.Resources["cpu"])
+	assert.Equal(t, "1Gi", tk.PS.Resources["memory"])
+	assert.Equal(t, "1", tk.PS.Resources["nvidia.com/gpu"])
+	assert.Equal(t, "1", tk.Chief.Resources["cpu"])
+	assert.Equal(t, "2Gi", tk.Chief.Resources["memory"])
+	assert.Equal(t, "250m", tk.Evaluator.Resources["cpu"])
+	assert.Equal(t, "512Mi", tk.Evaluator.Resources["memory"])
+	assert.Equal(t, "8", tk.Worker.Resources["cpu"])
+	assert.Equal(t, "32Gi", tk.Worker.Resources["memory"])
 }
 
 func TestBuildSubmitTask_TrailingArgs(t *testing.T) {
@@ -217,8 +243,8 @@ func TestNormalizeFramework(t *testing.T) {
 		{"MPI", "mpi"},
 		{"mpijob", "mpi"},
 		{"MPIJob", "mpi"},
-		{"horovod", "mpi"},
-		{"Horovod", "mpi"},
+		{"horovod", "horovod"},
+		{"Horovod", "horovod"},
 		{"jax", ""},
 		{"", ""},
 	}
@@ -255,8 +281,8 @@ func TestBuildSubmitFlags(t *testing.T) {
 	submitName = "test-job"
 	submitImage = "test:latest"
 	submitGPUs = 2
-	submitCPUs = "4"
-	submitMem = "8Gi"
+	submitCPU = "4"
+	submitMemory = "8Gi"
 	submitEnvs = []string{"FOO=bar"}
 	submitWorkers = 3
 
@@ -264,15 +290,15 @@ func TestBuildSubmitFlags(t *testing.T) {
 
 	assert.Equal(t, "test-job", flags["name"])
 	assert.Equal(t, 2, flags["gpus"])
-	assert.Equal(t, "4", flags["cpus"])
-	assert.Equal(t, "8Gi", flags["mem"])
+	assert.Equal(t, "4", flags["cpu"])
+	assert.Equal(t, "8Gi", flags["memory"])
 	assert.Equal(t, []string{"FOO=bar"}, flags["env"])
 }
 
 func TestSubmitDeepSpeed(t *testing.T) {
 	fw := normalizeFramework("deepspeed")
-	if fw != "mpi" {
-		t.Errorf("expected mpi, got %s", fw)
+	if fw != "deepspeed" {
+		t.Errorf("expected deepspeed, got %s", fw)
 	}
 }
 
@@ -373,7 +399,7 @@ func TestSubmitCmd_MPIVersionIntegration_DeepSpeed(t *testing.T) {
 	submitWorkers = 2
 
 	framework := normalizeFramework("deepspeed")
-	require.Equal(t, "mpi", framework)
+	require.Equal(t, "deepspeed", framework)
 	assert.True(t, isMPIFamily(framework))
 
 	tk := buildSubmitTask(framework, []string{"deepspeed", "train.py"})
@@ -400,7 +426,7 @@ func TestSubmitCmd_MPIVersionIntegration_Horovod(t *testing.T) {
 	submitWorkers = 3
 
 	framework := normalizeFramework("horovod")
-	require.Equal(t, "mpi", framework)
+	require.Equal(t, "horovod", framework)
 
 	tk := buildSubmitTask(framework, []string{"mpirun", "train"})
 
@@ -424,39 +450,38 @@ func resetSubmitFlags(t *testing.T) {
 	submitImage = ""
 	submitWorkers = 1
 	submitGPUs = 0
-	submitCPUs = ""
-	submitMem = ""
+	submitCPU = ""
+	submitMemory = ""
 	submitEnvs = nil
 	submitData = nil
 	submitLabels = nil
 	submitAnnotations = nil
 	submitSelectors = nil
 	submitTolerations = nil
-	submitPriority = 0
 	submitPriorityClass = ""
 	submitGang = false
-	submitSchedulerName = ""
-	submitCleanPodPolicy = ""
-	submitActiveDeadline = ""
+	submitScheduler = ""
+	submitCleanTaskPolicy = "Running"
+	submitRunningTimeout = ""
 	submitTTLAfterFinished = ""
-	submitBackoffLimit = 0
+	submitJobBackoffLimit = 0
 	submitImagePullPolicy = ""
 	submitImagePullSecret = nil
 	submitServiceAccount = ""
-	submitRestart = ""
+	submitJobRestartPolicy = ""
 	submitHostNetwork = false
 	submitHostIPC = false
 	submitHostPID = false
 	submitWorkingDir = ""
 	submitShell = ""
-	submitSHM = ""
+	submitShareMemory = "2Gi"
 	submitDevice = nil
 	submitGPUType = ""
 	submitTensorBoard = false
-	submitTBLogDir = ""
+	submitLogDir = "/training_logs"
 	submitTBImage = ""
 	submitNprocPerNode = ""
-	submitPSCount = 0
+	submitPS = 0
 	submitChief = false
 	submitEvaluator = false
 	submitSlotsPerWorker = 0
@@ -467,9 +492,10 @@ func resetSubmitFlags(t *testing.T) {
 	submitAffinityTarget = ""
 	submitSuccessPolicy = ""
 	submitDryRun = false
-	submitQueue = ""
+	submitQueue = false
 	submitDataDir = nil
 	submitConfigFile = nil
+	resetSubmitCompatFlags()
 }
 
 func TestCRDReplicaSpecs_PyTorch(t *testing.T) {
@@ -582,8 +608,8 @@ func TestApplyOverrides_Flags(t *testing.T) {
 		"run":            "python train.py --lr 0.001",
 		"workers":        4,
 		"gpus":           2,
-		"cpus":           "4",
-		"mem":            "16Gi",
+		"cpu":            "4",
+		"memory":         "16Gi",
 		"framework":      "pytorch",
 		"nproc-per-node": "auto",
 	}
@@ -735,13 +761,16 @@ func TestProviderRejectsWrongFramework(t *testing.T) {
 }
 
 func TestSubmitCmd_DryRunCapturesOutput(t *testing.T) {
+	resetSubmitCommandState(t)
 	resetSubmitFlags(t)
 
-	submitName = "dryrun-test"
-	submitImage = "pytorch:2.1"
-	submitWorkers = 2
-	submitGPUs = 1
-	submitDryRun = true
+	require.NoError(t, submitCmd.Flags().Parse([]string{
+		"--name", "dryrun-test",
+		"--image", "pytorch:2.1",
+		"--workers", "2",
+		"--gpus", "1",
+		"--dry-run",
+	}))
 
 	// Capture stdout — printCRD uses fmt.Println which writes to os.Stdout.
 	// klog-based log output goes to stderr, so stdout should contain only the CRD JSON.
@@ -767,4 +796,169 @@ func TestSubmitCmd_DryRunCapturesOutput(t *testing.T) {
 		"output should be valid JSON")
 	assert.Equal(t, "PyTorchJob", crd["kind"])
 	assert.Equal(t, "dryrun-test", crd["metadata"].(map[string]interface{})["name"])
+}
+
+// The generated CRD must wire the shared volume into both containers: the
+// sync init container (writer) and the main container (reader).
+func TestSubmitCompat_SyncVolumeSharedWithMainContainer(t *testing.T) {
+	resetSubmitFlags(t)
+
+	v1Args := []string{
+		"--name", "sync-volume-e2e",
+		"--image", "pytorch:2.1",
+		"--sync-mode", "git",
+		"--sync-source", "https://github.com/kubeflow/arena.git",
+		"--dry-run",
+	}
+	require.NoError(t, submitCmd.Flags().Parse(v1Args))
+
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	err := submitCmd.RunE(submitCmd, []string{"pytorch", "python", "train.py"})
+
+	w.Close()
+	os.Stdout = oldStdout
+
+	var buf bytes.Buffer
+	_, _ = io.Copy(&buf, r)
+	output := buf.String()
+
+	require.NoError(t, err, "sync invocation should succeed in dry-run mode")
+
+	var crd map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(output), &crd), "dry-run should print valid JSON, got: %s", output)
+
+	spec := crd["spec"].(map[string]interface{})
+	replicaSpecs := spec["pytorchReplicaSpecs"].(map[string]interface{})
+	master := replicaSpecs["Master"].(map[string]interface{})
+	podSpec := master["template"].(map[string]interface{})["spec"].(map[string]interface{})
+
+	mountPaths := func(container map[string]interface{}) map[string]string {
+		result := map[string]string{}
+		for _, m := range container["volumeMounts"].([]interface{}) {
+			mm := m.(map[string]interface{})
+			result[mm["name"].(string)] = mm["mountPath"].(string)
+		}
+		return result
+	}
+
+	containers := podSpec["containers"].([]interface{})
+	mainMounts := mountPaths(containers[0].(map[string]interface{}))
+	assert.Equal(t, "/root/code", mainMounts["code-sync"],
+		"main container should mount the shared code-sync volume at $workingDir/code")
+
+	initContainers := podSpec["initContainers"].([]interface{})
+	require.Len(t, initContainers, 1)
+	initMounts := mountPaths(initContainers[0].(map[string]interface{}))
+	assert.Equal(t, "/root/code", initMounts["code-sync"],
+		"sync init container should write into the shared code-sync volume")
+}
+
+func TestSubmitCompat_V1CommandEndToEndDryRun(t *testing.T) {
+	resetSubmitFlags(t)
+
+	// A representative v1 invocation using only v1 flag names.
+	v1Args := []string{
+		"--name", "v1-compat-job",
+		"--image", "pytorch:2.1",
+		"--workers", "2",
+		"--cpu", "4",
+		"--memory", "8Gi",
+		"-p", "high",
+		"--share-memory", "2Gi",
+		"--running-timeout", "2h",
+		"--retry", "3",
+		"--sync-mode", "git",
+		"--sync-source", "https://github.com/kubeflow/arena.git",
+		"--dry-run",
+	}
+	require.NoError(t, submitCmd.Flags().Parse(v1Args))
+
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	err := submitCmd.RunE(submitCmd, []string{"pytorch", "python", "train.py"})
+
+	w.Close()
+	os.Stdout = oldStdout
+
+	var buf bytes.Buffer
+	_, _ = io.Copy(&buf, r)
+	output := buf.String()
+
+	require.NoError(t, err, "v1-style invocation should succeed in dry-run mode")
+
+	var crd map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(output), &crd), "dry-run should print valid JSON, got: %s", output)
+	assert.Equal(t, "PyTorchJob", crd["kind"])
+
+	spec := crd["spec"].(map[string]interface{})
+	runPolicy := spec["runPolicy"].(map[string]interface{})
+	assert.Equal(t, float64(7200), runPolicy["activeDeadlineSeconds"],
+		"--running-timeout 2h should map to runPolicy.activeDeadlineSeconds")
+	assert.Equal(t, float64(3), runPolicy["backoffLimit"],
+		"--retry 3 should map to runPolicy.backoffLimit")
+
+	replicaSpecs := spec["pytorchReplicaSpecs"].(map[string]interface{})
+	master := replicaSpecs["Master"].(map[string]interface{})
+	podSpec := master["template"].(map[string]interface{})["spec"].(map[string]interface{})
+
+	assert.Equal(t, "high", podSpec["priorityClassName"],
+		"-p should set the priority class name (v1 semantics)")
+
+	containers := podSpec["containers"].([]interface{})
+	container := containers[0].(map[string]interface{})
+	resources := container["resources"].(map[string]interface{})
+	requests := resources["requests"].(map[string]interface{})
+	assert.Equal(t, "4", requests["cpu"], "--cpu should map to the CPU request")
+	assert.Equal(t, "8Gi", requests["memory"], "--memory should map to the memory request")
+
+	initContainers := podSpec["initContainers"].([]interface{})
+	require.Len(t, initContainers, 1, "git sync should produce one init container")
+	init := initContainers[0].(map[string]interface{})
+	assert.Contains(t, init["name"], "arena-sync")
+}
+
+func TestSubmitCompat_UniformV1Defaults(t *testing.T) {
+	f := submitCmd.Flags().Lookup("share-memory")
+	require.NotNil(t, f)
+	assert.Equal(t, "2Gi", f.DefValue)
+	f = submitCmd.Flags().Lookup("clean-task-policy")
+	require.NotNil(t, f)
+	assert.Equal(t, "Running", f.DefValue)
+	f = submitCmd.Flags().Lookup("logdir")
+	require.NotNil(t, f)
+	assert.Equal(t, "/training_logs", f.DefValue)
+}
+
+func TestSubmitCompat_DefaultsReachTheTask(t *testing.T) {
+	resetSubmitFlags(t)
+	tk := buildSubmitTask("pytorch", nil)
+	flags := buildSubmitFlags()
+	require.NoError(t, task.ApplyOverrides(tk, flags))
+
+	assert.Equal(t, "Running", tk.Lifecycle.CleanPodPolicy)
+	require.NotNil(t, tk.Logging.TensorBoard)
+	assert.Equal(t, "/training_logs", tk.Logging.TensorBoard.LogDir)
+
+	foundSHM := false
+	for _, s := range tk.Storages {
+		if s.SHM != "" {
+			assert.Equal(t, "2Gi", s.SHM)
+			foundSHM = true
+		}
+	}
+	assert.True(t, foundSHM, "default 2Gi shm storage should be applied")
+}
+
+func TestSubmitCompat_DefaultsOptOutViaEmptyValue(t *testing.T) {
+	resetSubmitFlags(t)
+	require.NoError(t, submitCmd.Flags().Parse([]string{"--share-memory", "", "--clean-task-policy", "", "--logdir", ""}))
+	flags := buildSubmitFlags()
+	assert.NotContains(t, flags, "share-memory")
+	assert.NotContains(t, flags, "clean-task-policy")
+	assert.NotContains(t, flags, "logdir")
 }

--- a/pkg/provider/affinity_test.go
+++ b/pkg/provider/affinity_test.go
@@ -523,7 +523,7 @@ func TestBuildPodSpec_NodeTargetSpreadHasTopologySpreadConstraints(t *testing.T)
 		"name":  "mpi",
 		"image": "test:latest",
 	}
-	podSpec, err := buildPodSpec(job, container, false)
+	podSpec, err := buildPodSpec(job, container)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -594,7 +594,7 @@ func TestBuildPodSpec_NodeTargetBinpackNoTopologySpreadConstraints(t *testing.T)
 		"name":  "mpi",
 		"image": "test:latest",
 	}
-	podSpec, err := buildPodSpec(job, container, false)
+	podSpec, err := buildPodSpec(job, container)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/pkg/provider/interface.go
+++ b/pkg/provider/interface.go
@@ -737,9 +737,12 @@ func buildTopologySpreadConstraints(a *task.Affinity, jobName string) []interfac
 }
 
 // buildInitContainers creates init containers from task.Init and task.Sync.
-// Sync-generated init containers (arena-sync-N) are added first, followed by user-defined init containers.
-func buildInitContainers(t *task.Task) []map[string]interface{} {
-	containers := make([]map[string]interface{}, 0, len(t.Init)+len(t.Sync))
+// Sync-generated init containers (arena-sync-N) are added first, followed by
+// user-defined init containers. All slices embedded in an unstructured object
+// must be []interface{} — typed Go slices make apimachinery helpers (e.g.
+// NestedMap) panic on deep copy.
+func buildInitContainers(t *task.Task) []interface{} {
+	containers := make([]interface{}, 0, len(t.Init)+len(t.Sync))
 
 	if syncInits := buildSyncInitContainers(t); len(syncInits) > 0 {
 		containers = append(containers, syncInits...)
@@ -774,17 +777,32 @@ func buildInitContainers(t *task.Task) []map[string]interface{} {
 	return containers
 }
 
+// syncWritesToEphemeral reports whether the sync entry's local_path misses
+// every resolved mount, meaning the data lands on ephemeral container
+// storage. Containment follows task.ResolveSyncWriteTarget: a local_path
+// under a mount path (not just equal to it) writes to that volume.
+func syncWritesToEphemeral(s task.SyncEntry, t *task.Task) bool {
+	if s.LocalPath == "" {
+		return false
+	}
+	if len(ResolveContainerMounts(s.Mounts, t)) == 0 {
+		return false
+	}
+	st, _ := task.ResolveSyncWriteTarget(s, t.Storages)
+	return st == nil
+}
+
 // buildSyncInitContainers generates system init containers from all sync entries.
 // Supports git-sync, rsync, and hdfs modes. Each sync entry gets its own init container
 // named arena-sync-N. Volume mounts are resolved from storages via ResolveContainerMounts.
 // The sync command target path is always local_path; a warning is printed to stderr
 // when local_path does not match any resolved mount path.
-func buildSyncInitContainers(t *task.Task) []map[string]interface{} {
+func buildSyncInitContainers(t *task.Task) []interface{} {
 	if len(t.Sync) == 0 {
 		return nil
 	}
 
-	containers := make([]map[string]interface{}, 0, len(t.Sync))
+	containers := make([]interface{}, 0, len(t.Sync))
 	for i, s := range t.Sync {
 		containerName := "arena-sync-" + strconv.Itoa(i)
 
@@ -800,21 +818,9 @@ func buildSyncInitContainers(t *task.Task) []map[string]interface{} {
 			containers = append(containers, buildHDFSSyncContainer(s, containerName, volumeMounts))
 		}
 
-		// Warn when local_path does not match any resolved mount path
-		if s.LocalPath != "" && len(volumeMounts) > 0 {
-			matched := false
-			for _, vm := range volumeMounts {
-				if m, ok := vm.(map[string]interface{}); ok {
-					if mp, ok := m["mountPath"].(string); ok && mp == s.LocalPath {
-						matched = true
-						break
-					}
-				}
-			}
-			if !matched {
-				log.Warning("sync local_path does not match any mount path; data will be written to ephemeral storage",
-					"index", i, "local_path", s.LocalPath)
-			}
+		if syncWritesToEphemeral(s, t) {
+			log.Warning("sync local_path does not match any mount path; data will be written to ephemeral storage",
+				"index", i, "local_path", s.LocalPath)
 		}
 	}
 
@@ -897,7 +903,8 @@ func buildHDFSSyncContainer(sync task.SyncEntry, name string, volumeMounts []int
 // buildEnvWithOverrides merges default envs with user envs.
 // User envs with the same key override default values.
 // User envs with secret/configmap refs are appended.
-func buildEnvWithOverrides(defaults map[string]string, userEnvs map[string]task.EnvValue) []map[string]interface{} {
+// Returns JSON-native []interface{} for embedding in unstructured objects.
+func buildEnvWithOverrides(defaults map[string]string, userEnvs map[string]task.EnvValue) []interface{} {
 	// Start with defaults, userEnvs with same key override default value
 	merged := make(map[string]string, len(defaults))
 	for k, v := range defaults {
@@ -905,7 +912,7 @@ func buildEnvWithOverrides(defaults map[string]string, userEnvs map[string]task.
 	}
 
 	// Track which keys are handled by user envs with refs
-	refEnvs := make([]map[string]interface{}, 0, len(userEnvs))
+	refEnvs := make([]interface{}, 0, len(userEnvs))
 	for k, e := range userEnvs {
 		if e.Secret != nil || e.ConfigMap != nil {
 			// Env with secret/configmap ref - add to ref list
@@ -935,7 +942,7 @@ func buildEnvWithOverrides(defaults map[string]string, userEnvs map[string]task.
 	}
 
 	// Output: merged plain values (sorted for deterministic output) + ref envs (sorted by name)
-	result := make([]map[string]interface{}, 0, len(merged)+len(refEnvs))
+	result := make([]interface{}, 0, len(merged)+len(refEnvs))
 	mergedKeys := make([]string, 0, len(merged))
 	for k := range merged {
 		mergedKeys = append(mergedKeys, k)
@@ -947,8 +954,8 @@ func buildEnvWithOverrides(defaults map[string]string, userEnvs map[string]task.
 		})
 	}
 	sort.Slice(refEnvs, func(i, j int) bool {
-		nameI, _ := refEnvs[i]["name"].(string)
-		nameJ, _ := refEnvs[j]["name"].(string)
+		nameI, _ := refEnvs[i].(map[string]interface{})["name"].(string)
+		nameJ, _ := refEnvs[j].(map[string]interface{})["name"].(string)
 		return nameI < nameJ
 	})
 	result = append(result, refEnvs...)
@@ -986,23 +993,30 @@ func buildMetadata(t *task.Task) map[string]interface{} {
 	return meta
 }
 
-// buildResources creates a Guaranteed QoS resource block (requests == limits).
-func buildResources(r task.Resources) map[string]interface{} {
-	if len(r) == 0 {
+// buildResources creates a resource block with the limits overlay semantics:
+// requests come from r; limits are r overlaid with limits (limits entries win
+// on key conflicts). Returns nil when both maps are empty (no resources block).
+func buildResources(r, limits task.Resources) map[string]interface{} {
+	if len(r) == 0 && len(limits) == 0 {
 		return nil
 	}
-	reqs := make(map[string]interface{}, len(r))
-	for k, v := range r {
-		reqs[k] = v
+	res := map[string]interface{}{}
+	if len(r) > 0 {
+		reqs := make(map[string]interface{}, len(r))
+		for k, v := range r {
+			reqs[k] = v
+		}
+		res["requests"] = reqs
 	}
-	lims := make(map[string]interface{}, len(r))
+	lims := make(map[string]interface{}, len(r)+len(limits))
 	for k, v := range r {
 		lims[k] = v
 	}
-	return map[string]interface{}{
-		"requests": reqs,
-		"limits":   lims,
+	for k, v := range limits {
+		lims[k] = v
 	}
+	res["limits"] = lims
+	return res
 }
 
 // containerOptions holds parameters for buildContainer.
@@ -1011,6 +1025,7 @@ type containerOptions struct {
 	Image     string
 	Task      *task.Task
 	Resources task.Resources
+	Limits    task.Resources
 	RoleEnvs  map[string]task.EnvValue
 	Run       string
 	Mounts    []task.Mount
@@ -1024,7 +1039,7 @@ func buildContainer(opts containerOptions) map[string]interface{} {
 	}
 
 	// Resources
-	res := buildResources(opts.Resources)
+	res := buildResources(opts.Resources, opts.Limits)
 	if res != nil {
 		container["resources"] = res
 	}
@@ -1062,19 +1077,15 @@ func buildContainer(opts containerOptions) map[string]interface{} {
 }
 
 // buildPodSpec creates a pod spec with container, volumes, scheduling, affinity, and init containers.
-func buildPodSpec(t *task.Task, container map[string]interface{}, includeVolumes bool) (map[string]interface{}, error) {
+func buildPodSpec(t *task.Task, container map[string]interface{}) (map[string]interface{}, error) {
 	podSpec := map[string]interface{}{
 		"containers": []interface{}{container},
 	}
 
 	// Volumes from storages only (sync references storages, no separate sync volumes)
-	volumes := []interface{}{}
-	if includeVolumes {
-		storageVols, _ := BuildVolumes(t)
-		volumes = append(volumes, storageVols...)
-	}
-	if len(volumes) > 0 {
-		podSpec["volumes"] = volumes
+	storageVols, _ := BuildVolumes(t)
+	if len(storageVols) > 0 {
+		podSpec["volumes"] = storageVols
 	}
 
 	// Init containers (sync init + user-defined)
@@ -1101,14 +1112,14 @@ func buildPodSpec(t *task.Task, container map[string]interface{}, includeVolumes
 
 // replicaSpecOptions holds parameters for buildRoleReplicaSpec.
 type replicaSpecOptions struct {
-	ContainerName  string
-	Task           *task.Task
-	Resources      task.Resources
-	Envs           map[string]task.EnvValue
-	Replicas       int64
-	RestartPolicy  string
-	IncludeVolumes bool
-	Run            string
+	ContainerName string
+	Task          *task.Task
+	Resources     task.Resources
+	Limits        task.Resources
+	Envs          map[string]task.EnvValue
+	Replicas      int64
+	RestartPolicy string
+	Run           string
 }
 
 // buildRoleReplicaSpec creates a replica spec with custom container name, resources, envs, and replicas.
@@ -1119,7 +1130,7 @@ func buildRoleReplicaSpec(opts replicaSpecOptions) (map[string]interface{}, erro
 		"image": opts.Task.Image,
 	}
 
-	if res := buildResources(opts.Resources); res != nil {
+	if res := buildResources(opts.Resources, opts.Limits); res != nil {
 		container["resources"] = res
 	}
 
@@ -1134,13 +1145,9 @@ func buildRoleReplicaSpec(opts replicaSpecOptions) (map[string]interface{}, erro
 	}
 
 	// Volume mounts (from storages only — sync volumes live in storages now)
-	mounts := []interface{}{}
-	if opts.IncludeVolumes {
-		_, storageMounts := BuildVolumes(opts.Task)
-		mounts = append(mounts, storageMounts...)
-	}
-	if len(mounts) > 0 {
-		container["volumeMounts"] = mounts
+	_, storageMounts := BuildVolumes(opts.Task)
+	if len(storageMounts) > 0 {
+		container["volumeMounts"] = storageMounts
 	}
 
 	if opts.Task.ImagePullPolicy != "" {
@@ -1150,7 +1157,7 @@ func buildRoleReplicaSpec(opts replicaSpecOptions) (map[string]interface{}, erro
 		container["workingDir"] = opts.Task.WorkingDir
 	}
 
-	podSpec, err := buildPodSpec(opts.Task, container, opts.IncludeVolumes)
+	podSpec, err := buildPodSpec(opts.Task, container)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build replica spec for %s: %w", opts.ContainerName, err)
 	}

--- a/pkg/provider/interface_test.go
+++ b/pkg/provider/interface_test.go
@@ -9,6 +9,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// mustGetInitContainer returns the container at index i of an init-container
+// slice as a map, failing the test if the entry is not a map.
+func mustGetInitContainer(t *testing.T, result []interface{}, i int) map[string]interface{} {
+	t.Helper()
+	c, ok := result[i].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected init container %d to be map[string]interface{}, got %T", i, result[i])
+	}
+	return c
+}
+
 func TestBuildSchedulingPolicy_WithQueue(t *testing.T) {
 	tt := &task.Task{
 		Scheduling: task.Scheduling{
@@ -152,11 +163,11 @@ func TestBuildInitContainers_SingleUserDefined(t *testing.T) {
 	if len(result) != 1 {
 		t.Fatalf("expected 1 init container, got %d", len(result))
 	}
-	if result[0]["name"] != "setup" {
-		t.Errorf("expected name=setup, got %v", result[0]["name"])
+	if mustGetInitContainer(t, result, 0)["name"] != "setup" {
+		t.Errorf("expected name=setup, got %v", mustGetInitContainer(t, result, 0)["name"])
 	}
-	if result[0]["image"] != "busybox" {
-		t.Errorf("expected image=busybox, got %v", result[0]["image"])
+	if mustGetInitContainer(t, result, 0)["image"] != "busybox" {
+		t.Errorf("expected image=busybox, got %v", mustGetInitContainer(t, result, 0)["image"])
 	}
 }
 
@@ -169,7 +180,7 @@ func TestBuildInitContainers_ShellFallback(t *testing.T) {
 		Sync: []task.SyncEntry{},
 	}
 	result := buildInitContainers(tt)
-	cmd := result[0]["command"].([]interface{})
+	cmd := mustGetInitContainer(t, result, 0)["command"].([]interface{})
 	if cmd[0] != "/bin/bash" {
 		t.Errorf("expected shell=/bin/bash from init, got %v", cmd[0])
 	}
@@ -183,7 +194,7 @@ func TestBuildInitContainers_ShellFallback(t *testing.T) {
 		Sync: []task.SyncEntry{},
 	}
 	result = buildInitContainers(tt)
-	cmd = result[0]["command"].([]interface{})
+	cmd = mustGetInitContainer(t, result, 0)["command"].([]interface{})
 	if cmd[0] != "/bin/zsh" {
 		t.Errorf("expected shell=/bin/zsh from task, got %v", cmd[0])
 	}
@@ -196,7 +207,7 @@ func TestBuildInitContainers_ShellFallback(t *testing.T) {
 		Sync: []task.SyncEntry{},
 	}
 	result = buildInitContainers(tt)
-	cmd = result[0]["command"].([]interface{})
+	cmd = mustGetInitContainer(t, result, 0)["command"].([]interface{})
 	if cmd[0] != "/bin/sh" {
 		t.Errorf("expected shell=/bin/sh default, got %v", cmd[0])
 	}
@@ -214,11 +225,11 @@ func TestBuildInitContainers_Multiple(t *testing.T) {
 	if len(result) != 2 {
 		t.Fatalf("expected 2 init containers, got %d", len(result))
 	}
-	if result[0]["name"] != "init1" {
-		t.Errorf("expected first init name=init1, got %v", result[0]["name"])
+	if mustGetInitContainer(t, result, 0)["name"] != "init1" {
+		t.Errorf("expected first init name=init1, got %v", mustGetInitContainer(t, result, 0)["name"])
 	}
-	if result[1]["name"] != "init2" {
-		t.Errorf("expected second init name=init2, got %v", result[1]["name"])
+	if mustGetInitContainer(t, result, 1)["name"] != "init2" {
+		t.Errorf("expected second init name=init2, got %v", mustGetInitContainer(t, result, 1)["name"])
 	}
 }
 
@@ -253,13 +264,14 @@ func TestBuildSyncInitContainers_Git(t *testing.T) {
 	if len(result) != 1 {
 		t.Fatalf("expected 1 init container, got %d", len(result))
 	}
-	if result[0]["name"] != "arena-sync-0" {
-		t.Errorf("expected name=arena-sync-0, got %v", result[0]["name"])
+	if mustGetInitContainer(t, result, 0)["name"] != "arena-sync-0" {
+		t.Errorf("expected name=arena-sync-0, got %v", mustGetInitContainer(t, result, 0)["name"])
 	}
-	envs := result[0]["env"].([]map[string]interface{})
+	envs := mustGetInitContainer(t, result, 0)["env"].([]interface{})
 	found := map[string]string{}
 	for _, e := range envs {
-		found[e["name"].(string)] = e["value"].(string)
+		em := e.(map[string]interface{})
+		found[em["name"].(string)] = em["value"].(string)
 	}
 	if found["GIT_SYNC_REPO"] != "https://github.com/kubeflow/training-operator.git" {
 		t.Errorf("expected GIT_SYNC_REPO, got %v", found["GIT_SYNC_REPO"])
@@ -286,10 +298,10 @@ func TestBuildSyncInitContainers_Rsync(t *testing.T) {
 	if len(result) != 1 {
 		t.Fatalf("expected 1 init container, got %d", len(result))
 	}
-	if result[0]["name"] != "arena-sync-0" {
-		t.Errorf("expected name=arena-sync-0, got %v", result[0]["name"])
+	if mustGetInitContainer(t, result, 0)["name"] != "arena-sync-0" {
+		t.Errorf("expected name=arena-sync-0, got %v", mustGetInitContainer(t, result, 0)["name"])
 	}
-	cmd := result[0]["command"].([]interface{})
+	cmd := mustGetInitContainer(t, result, 0)["command"].([]interface{})
 	if len(cmd) != 4 {
 		t.Fatalf("expected 4 command args, got %d", len(cmd))
 	}
@@ -309,13 +321,13 @@ func TestBuildSyncInitContainers_HDFS(t *testing.T) {
 	if len(result) != 1 {
 		t.Fatalf("expected 1 init container, got %d", len(result))
 	}
-	if result[0]["name"] != "arena-sync-0" {
-		t.Errorf("expected name=arena-sync-0, got %v", result[0]["name"])
+	if mustGetInitContainer(t, result, 0)["name"] != "arena-sync-0" {
+		t.Errorf("expected name=arena-sync-0, got %v", mustGetInitContainer(t, result, 0)["name"])
 	}
-	if result[0]["image"] != "docker.io/apache/hadoop:3.5.0" {
-		t.Errorf("expected default hdfs image, got %v", result[0]["image"])
+	if mustGetInitContainer(t, result, 0)["image"] != "docker.io/apache/hadoop:3.5.0" {
+		t.Errorf("expected default hdfs image, got %v", mustGetInitContainer(t, result, 0)["image"])
 	}
-	cmd := result[0]["command"].([]interface{})
+	cmd := mustGetInitContainer(t, result, 0)["command"].([]interface{})
 	if len(cmd) != 5 {
 		t.Fatalf("expected 5 command args, got %d", len(cmd))
 	}
@@ -342,14 +354,14 @@ func TestBuildSyncInitContainers_CustomImages(t *testing.T) {
 	if len(result) != 3 {
 		t.Fatalf("expected 3 init containers, got %d", len(result))
 	}
-	if result[0]["image"] != "custom/git-sync:v4" {
-		t.Errorf("expected custom git image, got %v", result[0]["image"])
+	if mustGetInitContainer(t, result, 0)["image"] != "custom/git-sync:v4" {
+		t.Errorf("expected custom git image, got %v", mustGetInitContainer(t, result, 0)["image"])
 	}
-	if result[1]["image"] != "custom/rsync:2.0" {
-		t.Errorf("expected custom rsync image, got %v", result[1]["image"])
+	if mustGetInitContainer(t, result, 1)["image"] != "custom/rsync:2.0" {
+		t.Errorf("expected custom rsync image, got %v", mustGetInitContainer(t, result, 1)["image"])
 	}
-	if result[2]["image"] != "custom/hadoop:3.4" {
-		t.Errorf("expected custom hdfs image, got %v", result[2]["image"])
+	if mustGetInitContainer(t, result, 2)["image"] != "custom/hadoop:3.4" {
+		t.Errorf("expected custom hdfs image, got %v", mustGetInitContainer(t, result, 2)["image"])
 	}
 }
 
@@ -365,14 +377,14 @@ func TestBuildSyncInitContainers_MultipleEntries(t *testing.T) {
 	if len(result) != 3 {
 		t.Fatalf("expected 3 init containers, got %d", len(result))
 	}
-	if result[0]["name"] != "arena-sync-0" {
-		t.Errorf("expected first container name=arena-sync-0, got %v", result[0]["name"])
+	if mustGetInitContainer(t, result, 0)["name"] != "arena-sync-0" {
+		t.Errorf("expected first container name=arena-sync-0, got %v", mustGetInitContainer(t, result, 0)["name"])
 	}
-	if result[1]["name"] != "arena-sync-1" {
-		t.Errorf("expected second container name=arena-sync-1, got %v", result[1]["name"])
+	if mustGetInitContainer(t, result, 1)["name"] != "arena-sync-1" {
+		t.Errorf("expected second container name=arena-sync-1, got %v", mustGetInitContainer(t, result, 1)["name"])
 	}
-	if result[2]["name"] != "arena-sync-2" {
-		t.Errorf("expected third container name=arena-sync-2, got %v", result[2]["name"])
+	if mustGetInitContainer(t, result, 2)["name"] != "arena-sync-2" {
+		t.Errorf("expected third container name=arena-sync-2, got %v", mustGetInitContainer(t, result, 2)["name"])
 	}
 }
 
@@ -615,7 +627,7 @@ func TestBuildInitContainersWithMounts(t *testing.T) {
 	containers := buildInitContainers(tt)
 	require.Len(t, containers, 1)
 
-	mounts, ok := containers[0]["volumeMounts"].([]interface{})
+	mounts, ok := mustGetInitContainer(t, containers, 0)["volumeMounts"].([]interface{})
 	require.True(t, ok, "init container should have volumeMounts")
 	require.Len(t, mounts, 1)
 	m0 := mounts[0].(map[string]interface{})
@@ -643,7 +655,7 @@ func TestBuildInitContainersWithMountsSubPath(t *testing.T) {
 	containers := buildInitContainers(tt)
 	require.Len(t, containers, 1)
 
-	mounts, ok := containers[0]["volumeMounts"].([]interface{})
+	mounts, ok := mustGetInitContainer(t, containers, 0)["volumeMounts"].([]interface{})
 	require.True(t, ok, "init container should have volumeMounts")
 	require.Len(t, mounts, 1)
 	m0 := mounts[0].(map[string]interface{})
@@ -666,7 +678,7 @@ func TestBuildInitContainersWithNoMounts(t *testing.T) {
 	containers := buildInitContainers(tt)
 	require.Len(t, containers, 1)
 
-	_, hasVolumeMounts := containers[0]["volumeMounts"]
+	_, hasVolumeMounts := mustGetInitContainer(t, containers, 0)["volumeMounts"]
 	assert.False(t, hasVolumeMounts, "init container without mounts should not have volumeMounts")
 }
 
@@ -681,7 +693,7 @@ func TestBuildInitContainers_SubPathFallback(t *testing.T) {
 	}
 	result := buildInitContainers(tt)
 	require.Len(t, result, 1)
-	mounts := result[0]["volumeMounts"].([]interface{})
+	mounts := mustGetInitContainer(t, result, 0)["volumeMounts"].([]interface{})
 	require.Len(t, mounts, 1)
 	m0 := mounts[0].(map[string]interface{})
 	assert.Equal(t, "ssh", m0["name"])
@@ -700,7 +712,7 @@ func TestBuildInitContainers_MountPathOverride(t *testing.T) {
 	}
 	result := buildInitContainers(tt)
 	require.Len(t, result, 1)
-	mounts := result[0]["volumeMounts"].([]interface{})
+	mounts := mustGetInitContainer(t, result, 0)["volumeMounts"].([]interface{})
 	require.Len(t, mounts, 1)
 	m0 := mounts[0].(map[string]interface{})
 	assert.Equal(t, "/custom-data", m0["mountPath"])
@@ -749,7 +761,7 @@ func TestBuildSyncInitContainersWithMountsOverride(t *testing.T) {
 	require.Len(t, containers, 1)
 
 	// Init container should mount the overridden "code" volume at /workspace, not /default-code
-	mounts, ok := containers[0]["volumeMounts"].([]interface{})
+	mounts, ok := mustGetInitContainer(t, containers, 0)["volumeMounts"].([]interface{})
 	require.True(t, ok)
 	require.Len(t, mounts, 1)
 	m0 := mounts[0].(map[string]interface{})
@@ -782,7 +794,7 @@ func TestBuildSyncInitContainers_RsyncWithMountsOverride(t *testing.T) {
 	require.Len(t, containers, 1)
 
 	// Check volume mount uses the override path
-	mounts, ok := containers[0]["volumeMounts"].([]interface{})
+	mounts, ok := mustGetInitContainer(t, containers, 0)["volumeMounts"].([]interface{})
 	require.True(t, ok)
 	require.Len(t, mounts, 1)
 	m0 := mounts[0].(map[string]interface{})
@@ -790,7 +802,7 @@ func TestBuildSyncInitContainers_RsyncWithMountsOverride(t *testing.T) {
 	assert.Equal(t, "/data", m0["mountPath"])
 
 	// Check command destination uses LocalPath (/old-path), not mountPath (/data)
-	cmd := containers[0]["command"].([]interface{})
+	cmd := mustGetInitContainer(t, containers, 0)["command"].([]interface{})
 	require.Len(t, cmd, 4)
 	assert.Equal(t, "rsync", cmd[0])
 	assert.Equal(t, "-avP", cmd[1])
@@ -823,7 +835,7 @@ func TestBuildSyncInitContainers_HDFSWithMountsOverride(t *testing.T) {
 	require.Len(t, containers, 1)
 
 	// Check volume mount uses the override path
-	mounts, ok := containers[0]["volumeMounts"].([]interface{})
+	mounts, ok := mustGetInitContainer(t, containers, 0)["volumeMounts"].([]interface{})
 	require.True(t, ok)
 	require.Len(t, mounts, 1)
 	m0 := mounts[0].(map[string]interface{})
@@ -831,7 +843,7 @@ func TestBuildSyncInitContainers_HDFSWithMountsOverride(t *testing.T) {
 	assert.Equal(t, "/models", m0["mountPath"])
 
 	// Check command destination uses LocalPath (/old-path), not mountPath (/models)
-	cmd := containers[0]["command"].([]interface{})
+	cmd := mustGetInitContainer(t, containers, 0)["command"].([]interface{})
 	require.Len(t, cmd, 5)
 	assert.Equal(t, "hdfs", cmd[0])
 	assert.Equal(t, "dfs", cmd[1])
@@ -989,9 +1001,9 @@ func TestBuildSyncInitContainers_NewNaming(t *testing.T) {
 	}
 	result := buildSyncInitContainers(tt)
 	require.Len(t, result, 3)
-	assert.Equal(t, "arena-sync-0", result[0]["name"])
-	assert.Equal(t, "arena-sync-1", result[1]["name"])
-	assert.Equal(t, "arena-sync-2", result[2]["name"])
+	assert.Equal(t, "arena-sync-0", mustGetInitContainer(t, result, 0)["name"])
+	assert.Equal(t, "arena-sync-1", mustGetInitContainer(t, result, 1)["name"])
+	assert.Equal(t, "arena-sync-2", mustGetInitContainer(t, result, 2)["name"])
 }
 
 func TestBuildSyncInitContainers_GitUsesLocalPath(t *testing.T) {
@@ -1010,15 +1022,16 @@ func TestBuildSyncInitContainers_GitUsesLocalPath(t *testing.T) {
 	require.Len(t, result, 1)
 
 	// GIT_SYNC_ROOT uses local_path, not mount_path
-	envs := result[0]["env"].([]map[string]interface{})
+	envs := mustGetInitContainer(t, result, 0)["env"].([]interface{})
 	found := map[string]string{}
 	for _, e := range envs {
-		found[e["name"].(string)] = e["value"].(string)
+		em := e.(map[string]interface{})
+		found[em["name"].(string)] = em["value"].(string)
 	}
 	assert.Equal(t, "/code", found["GIT_SYNC_ROOT"])
 
 	// Volume mount references storage by name, uses storage's mount_path
-	mounts := result[0]["volumeMounts"].([]interface{})
+	mounts := mustGetInitContainer(t, result, 0)["volumeMounts"].([]interface{})
 	require.Len(t, mounts, 1)
 	m0 := mounts[0].(map[string]interface{})
 	assert.Equal(t, "code", m0["name"])
@@ -1040,7 +1053,7 @@ func TestBuildSyncInitContainers_RsyncUsesLocalPath(t *testing.T) {
 	require.Len(t, result, 1)
 
 	// Rsync dest uses local_path, not mount_path
-	cmd := result[0]["command"].([]interface{})
+	cmd := mustGetInitContainer(t, result, 0)["command"].([]interface{})
 	require.Len(t, cmd, 4)
 	assert.Equal(t, "/old-path", cmd[3])
 }
@@ -1060,7 +1073,7 @@ func TestBuildSyncInitContainers_HDFSUsesLocalPath(t *testing.T) {
 	require.Len(t, result, 1)
 
 	// HDFS dest uses local_path, not mount_path
-	cmd := result[0]["command"].([]interface{})
+	cmd := mustGetInitContainer(t, result, 0)["command"].([]interface{})
 	require.Len(t, cmd, 5)
 	assert.Equal(t, "/local-models", cmd[4])
 }
@@ -1073,10 +1086,10 @@ func TestBuildSyncInitContainers_NoMounts(t *testing.T) {
 	}
 	result := buildSyncInitContainers(tt)
 	require.Len(t, result, 1)
-	assert.Equal(t, "arena-sync-0", result[0]["name"])
+	assert.Equal(t, "arena-sync-0", mustGetInitContainer(t, result, 0)["name"])
 
 	// No volumeMounts when sync has no mounts
-	_, hasMounts := result[0]["volumeMounts"]
+	_, hasMounts := mustGetInitContainer(t, result, 0)["volumeMounts"]
 	assert.False(t, hasMounts)
 }
 
@@ -1094,7 +1107,7 @@ func TestBuildSyncInitContainers_FallsBackToAllStorages(t *testing.T) {
 	require.Len(t, result, 1)
 
 	// With storages but no mounts, all storages should be mounted
-	mounts, ok := result[0]["volumeMounts"].([]interface{})
+	mounts, ok := mustGetInitContainer(t, result, 0)["volumeMounts"].([]interface{})
 	require.True(t, ok, "sync container should have volumeMounts when storages exist")
 	require.Len(t, mounts, 2)
 	m0 := mounts[0].(map[string]interface{})
@@ -1118,7 +1131,7 @@ func TestBuildInitContainers_FallsBackToAllStorages(t *testing.T) {
 	require.Len(t, result, 1)
 
 	// With storages but no mounts, all storages should be mounted
-	mounts, ok := result[0]["volumeMounts"].([]interface{})
+	mounts, ok := mustGetInitContainer(t, result, 0)["volumeMounts"].([]interface{})
 	require.True(t, ok, "init container should have volumeMounts when storages exist")
 	require.Len(t, mounts, 1)
 	m0 := mounts[0].(map[string]interface{})
@@ -1391,4 +1404,40 @@ func TestTotalReplicas_EdgeCases(t *testing.T) {
 			assert.Equal(t, tt.expected, totalReplicas(tt.task))
 		})
 	}
+}
+
+func TestSyncWritesToEphemeral(t *testing.T) {
+	tt := &task.Task{
+		Storages: []task.Storage{{Name: "code", MountPath: "/workspace", Tmp: "5Gi"}},
+		Sync: []task.SyncEntry{
+			{Git: "https://github.com/org/repo.git", LocalPath: "/workspace"},
+		},
+	}
+	assert.False(t, syncWritesToEphemeral(tt.Sync[0], tt),
+		"local_path equal to the mount path must not warn")
+
+	tt.Sync[0].LocalPath = "/workspace/src"
+	assert.False(t, syncWritesToEphemeral(tt.Sync[0], tt),
+		"local_path under the mount path must not warn (containment, not equality)")
+
+	tt.Sync[0].LocalPath = "/elsewhere"
+	assert.True(t, syncWritesToEphemeral(tt.Sync[0], tt),
+		"local_path outside every mount must warn")
+
+	pvcTask := &task.Task{
+		Storages: []task.Storage{{Name: "dataset", MountPath: "/data", PVC: "data-pvc"}},
+		Sync: []task.SyncEntry{
+			{Git: "https://github.com/org/repo.git", LocalPath: "/data/code"},
+		},
+	}
+	assert.False(t, syncWritesToEphemeral(pvcTask.Sync[0], pvcTask),
+		"warning is about mount mismatch only; banned targets are rejected by validation")
+
+	noStorages := &task.Task{
+		Sync: []task.SyncEntry{
+			{Git: "https://github.com/org/repo.git", LocalPath: "/code"},
+		},
+	}
+	assert.False(t, syncWritesToEphemeral(noStorages.Sync[0], noStorages),
+		"no resolved mounts keeps the existing silent behavior")
 }

--- a/pkg/provider/mpi.go
+++ b/pkg/provider/mpi.go
@@ -233,6 +233,7 @@ func (p *MPIProvider) buildMPICRD(t *task.Task, apiVersion string) (*unstructure
 // Global task envs (t.Envs) are always merged by buildEnvVars inside buildRoleReplicaSpec.
 func (p *MPIProvider) buildLauncherSpec(t *task.Task, restartPolicy string) (map[string]interface{}, error) {
 	var resources task.Resources
+	var limits task.Resources
 	var envs map[string]task.EnvValue
 	var launcherRun string
 
@@ -240,31 +241,40 @@ func (p *MPIProvider) buildLauncherSpec(t *task.Task, restartPolicy string) (map
 	case t.Launcher != nil:
 		// Launcher explicitly configured: use its own config only
 		resources = t.Launcher.Resources
+		limits = t.Launcher.Limits
 		envs = t.Launcher.Envs
 		launcherRun = t.Launcher.Run
 	case t.Framework.Options.RunLauncherAsWorker:
 		// No launcher config + run_launcher_as_worker: inherit from worker
 		resources = t.Worker.Resources
+		limits = t.Worker.Limits
 		envs = t.Worker.Envs
 	default:
 		// No launcher config + no run_launcher_as_worker: CPU-only
 		resources = nil
+		limits = nil
 		envs = nil
 	}
 
-	includeVolumes := t.Framework.Options.MountsOnLauncher
+	// Always build the launcher with all volumes; when mounts_on_launcher=false
+	// only the main container's volumeMounts are cleared — volumes stay declared
+	// so init containers keep working exactly as declared.
 	spec, err := buildRoleReplicaSpec(replicaSpecOptions{
-		ContainerName:  constants.FrameworkMPI,
-		Task:           t,
-		Resources:      resources,
-		Envs:           envs,
-		Replicas:       1,
-		RestartPolicy:  restartPolicy,
-		IncludeVolumes: includeVolumes,
-		Run:            effectiveRun(t, launcherRun),
+		ContainerName: constants.FrameworkMPI,
+		Task:          t,
+		Resources:     resources,
+		Limits:        limits,
+		Envs:          envs,
+		Replicas:      1,
+		RestartPolicy: restartPolicy,
+		Run:           effectiveRun(t, launcherRun),
 	})
 	if err != nil {
 		return nil, err
+	}
+
+	if !t.Framework.Options.MountsOnLauncher {
+		clearLauncherContainerMounts(spec)
 	}
 
 	// Inject launcher SA if user hasn't specified one.
@@ -281,6 +291,30 @@ func (p *MPIProvider) buildLauncherSpec(t *task.Task, restartPolicy string) (map
 	return spec, nil
 }
 
+// clearLauncherContainerMounts removes volumeMounts from the launcher main
+// container when mounts_on_launcher=false. Volumes stay declared in the pod
+// spec so init containers keep working exactly as the user declared them —
+// dangling mounts are impossible. The launcher main container only runs
+// mpirun over SSH on the workers; it does not execute user code, so it needs
+// no data volumes.
+func clearLauncherContainerMounts(spec map[string]interface{}) {
+	template, ok := spec["template"].(map[string]interface{})
+	if !ok {
+		return
+	}
+	podSpec, ok := template["spec"].(map[string]interface{})
+	if !ok {
+		return
+	}
+	containers, ok := podSpec["containers"].([]interface{})
+	if !ok || len(containers) == 0 {
+		return
+	}
+	if container, ok := containers[0].(map[string]interface{}); ok {
+		delete(container, "volumeMounts")
+	}
+}
+
 // buildWorkerReplicaSpec creates the Worker replica spec with full resources.
 // MPI workers run as SSH daemons for the launcher to dispatch commands to.
 // They must not receive the user's run command — only the launcher executes it.
@@ -290,11 +324,12 @@ func (p *MPIProvider) buildWorkerReplicaSpec(t *task.Task, replicas int64, resta
 		Image:     t.Image,
 		Task:      t,
 		Resources: t.Worker.Resources,
+		Limits:    t.Worker.Limits,
 		RoleEnvs:  t.Worker.Envs,
 		Run:       "",
 		Mounts:    nil,
 	})
-	podSpec, err := buildPodSpec(t, container, true)
+	podSpec, err := buildPodSpec(t, container)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/provider/mpi_test.go
+++ b/pkg/provider/mpi_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/kubeflow/arena/pkg/task"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 func TestMPIBuildCRD(t *testing.T) {
@@ -321,6 +322,165 @@ func TestMPIBuildCRDMountsOnLauncher(t *testing.T) {
 	if ok {
 		assert.Len(t, volumes.([]interface{}), 1)
 	}
+}
+
+func TestMPIBuildCRDWithInitContainers(t *testing.T) {
+	tk := &task.Task{
+		Name:  "mpi-init",
+		Image: "openmpi:4.1",
+		Run:   "mpirun -np 2 ./train",
+		Framework: task.Framework{
+			Name: "mpi",
+		},
+		Worker: &task.Worker{Replicas: 2},
+		Init: []task.InitContainer{
+			{Name: "setup", Image: "busybox:1.35", Run: "echo setup"},
+		},
+	}
+
+	provider := &MPIProvider{APIVersion: MPIAPIVersionV2beta1}
+	crd, err := provider.BuildCRD(tk)
+	require.NoError(t, err)
+
+	spec := crd.Object["spec"].(map[string]interface{})
+	replicaSpecs := spec["mpiReplicaSpecs"].(map[string]interface{})
+	launcher := replicaSpecs["Launcher"].(map[string]interface{})
+
+	// The launcher spec must be JSON-native so unstructured helpers can
+	// traverse it without panicking on typed Go slices.
+	podSpec, found, err := unstructured.NestedMap(launcher, "template", "spec")
+	require.NoError(t, err)
+	require.True(t, found, "launcher template.spec not found")
+
+	inits, found, err := unstructured.NestedSlice(podSpec, "initContainers")
+	require.NoError(t, err)
+	require.True(t, found, "launcher initContainers not found")
+	require.Len(t, inits, 1)
+
+	initContainer, ok := inits[0].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "setup", initContainer["name"])
+}
+
+// mounts_on_launcher=false contract: ALL volumes stay declared in the pod
+// spec (init containers may reference them), the launcher main container
+// gets no volumeMounts at all, and init containers are never rewritten.
+func TestMPIBuildCRDLauncherVolumesMountsOnLauncherFalse(t *testing.T) {
+	tk := &task.Task{
+		Name:  "mpi-volumes",
+		Image: "openmpi:4.1",
+		Run:   "mpirun -np 2 ./train",
+		Framework: task.Framework{
+			Name:    "mpi",
+			Options: task.FrameworkConfig{MountsOnLauncher: false},
+		},
+		Worker: &task.Worker{Replicas: 2},
+		Storages: []task.Storage{
+			{Name: "dataset", PVC: "data-pvc", MountPath: "/data"},
+			{Name: "cache", Tmp: "5Gi", MountPath: "/cache"},
+			{Name: "dshm", SHM: "2Gi"},
+		},
+		Init: []task.InitContainer{
+			{Name: "setup", Image: "busybox:1.35", Run: "echo setup",
+				Mounts: []task.Mount{{Name: "dataset"}}},
+		},
+	}
+
+	provider := &MPIProvider{APIVersion: MPIAPIVersionV2beta1}
+	crd, err := provider.BuildCRD(tk)
+	require.NoError(t, err)
+
+	spec := crd.Object["spec"].(map[string]interface{})
+	replicaSpecs := spec["mpiReplicaSpecs"].(map[string]interface{})
+	launcher := replicaSpecs["Launcher"].(map[string]interface{})
+	podSpec, found, err := unstructured.NestedMap(launcher, "template", "spec")
+	require.NoError(t, err)
+	require.True(t, found)
+
+	// Launcher keeps ALL volumes declared (PVC included) so init containers
+	// can reference them — no dangling mounts are possible.
+	volNames := volumeNames(podSpec["volumes"])
+	assert.ElementsMatch(t, []string{"dataset", "cache", "dshm"}, volNames,
+		"launcher should keep all volumes declared when mounts_on_launcher=false")
+
+	// The launcher main container mounts nothing.
+	main := podSpec["containers"].([]interface{})[0].(map[string]interface{})
+	assert.Empty(t, mountNames(main["volumeMounts"]),
+		"launcher main container should have no volumeMounts when mounts_on_launcher=false")
+
+	// Init container mounts are exactly as the user declared.
+	inits := podSpec["initContainers"].([]interface{})
+	require.Len(t, inits, 1)
+	initMounts := mountNames(inits[0].(map[string]interface{})["volumeMounts"])
+	assert.ElementsMatch(t, []string{"dataset"}, initMounts,
+		"init container mounts must never be rewritten")
+
+	// Worker keeps all volumes and mounts.
+	worker := replicaSpecs["Worker"].(map[string]interface{})
+	workerPod := worker["template"].(map[string]interface{})["spec"].(map[string]interface{})
+	assert.ElementsMatch(t, []string{"dataset", "cache", "dshm"}, volumeNames(workerPod["volumes"]))
+	workerMain := workerPod["containers"].([]interface{})[0].(map[string]interface{})
+	assert.ElementsMatch(t, []string{"dataset", "cache", "dshm"}, mountNames(workerMain["volumeMounts"]))
+}
+
+func TestMPIBuildCRDLauncherVolumesMountsOnLauncherTrue(t *testing.T) {
+	tk := &task.Task{
+		Name:  "mpi-volumes-on",
+		Image: "openmpi:4.1",
+		Run:   "mpirun -np 2 ./train",
+		Framework: task.Framework{
+			Name:    "mpi",
+			Options: task.FrameworkConfig{MountsOnLauncher: true},
+		},
+		Worker: &task.Worker{Replicas: 2},
+		Storages: []task.Storage{
+			{Name: "dataset", PVC: "data-pvc", MountPath: "/data"},
+			{Name: "cache", Tmp: "5Gi", MountPath: "/cache"},
+		},
+	}
+
+	provider := &MPIProvider{APIVersion: MPIAPIVersionV2beta1}
+	crd, err := provider.BuildCRD(tk)
+	require.NoError(t, err)
+
+	spec := crd.Object["spec"].(map[string]interface{})
+	replicaSpecs := spec["mpiReplicaSpecs"].(map[string]interface{})
+	launcher := replicaSpecs["Launcher"].(map[string]interface{})
+	podSpec, found, err := unstructured.NestedMap(launcher, "template", "spec")
+	require.NoError(t, err)
+	require.True(t, found)
+
+	assert.ElementsMatch(t, []string{"dataset", "cache"}, volumeNames(podSpec["volumes"]))
+	main := podSpec["containers"].([]interface{})[0].(map[string]interface{})
+	assert.ElementsMatch(t, []string{"dataset", "cache"}, mountNames(main["volumeMounts"]))
+}
+
+func volumeNames(v interface{}) []string {
+	items, ok := v.([]interface{})
+	if !ok {
+		return nil
+	}
+	names := make([]string, 0, len(items))
+	for _, item := range items {
+		if m, ok := item.(map[string]interface{}); ok {
+			names = append(names, m["name"].(string))
+		}
+	}
+	return names
+}
+
+func mountNames(v interface{}) []string {
+	items, ok := v.([]interface{})
+	if !ok {
+		return nil
+	}
+	names := make([]string, 0, len(items))
+	for _, item := range items {
+		if m, ok := item.(map[string]interface{}); ok {
+			names = append(names, m["name"].(string))
+		}
+	}
+	return names
 }
 
 func TestMPIBuildCRDSuspendAndManagedBy(t *testing.T) {

--- a/pkg/provider/pytorch.go
+++ b/pkg/provider/pytorch.go
@@ -58,14 +58,14 @@ func (p *PyTorchProvider) BuildCRD(t *task.Task) (*unstructured.Unstructured, er
 	if t.Worker == nil {
 		// Master-only mode: single-node training
 		masterSpec, err := buildRoleReplicaSpec(replicaSpecOptions{
-			ContainerName:  constants.FrameworkPyTorch,
-			Task:           t,
-			Resources:      t.Master.Resources,
-			Envs:           t.Master.Envs,
-			Replicas:       1,
-			RestartPolicy:  restartPolicy,
-			IncludeVolumes: true,
-			Run:            effectiveRun(t, t.Master.Run),
+			ContainerName: constants.FrameworkPyTorch,
+			Task:          t,
+			Resources:     t.Master.Resources,
+			Limits:        t.Master.Limits,
+			Envs:          t.Master.Envs,
+			Replicas:      1,
+			RestartPolicy: restartPolicy,
+			Run:           effectiveRun(t, t.Master.Run),
 		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to build master replica spec: %w", err)
@@ -74,14 +74,14 @@ func (p *PyTorchProvider) BuildCRD(t *task.Task) (*unstructured.Unstructured, er
 	} else {
 		// Worker present: always generate Worker replicaSpec
 		workerSpec, err := buildRoleReplicaSpec(replicaSpecOptions{
-			ContainerName:  constants.FrameworkPyTorch,
-			Task:           t,
-			Resources:      t.Worker.Resources,
-			Envs:           t.Worker.Envs,
-			Replicas:       int64(t.Worker.Replicas),
-			RestartPolicy:  restartPolicy,
-			IncludeVolumes: true,
-			Run:            effectiveRun(t, t.Worker.Run),
+			ContainerName: constants.FrameworkPyTorch,
+			Task:          t,
+			Resources:     t.Worker.Resources,
+			Limits:        t.Worker.Limits,
+			Envs:          t.Worker.Envs,
+			Replicas:      int64(t.Worker.Replicas),
+			RestartPolicy: restartPolicy,
+			Run:           effectiveRun(t, t.Worker.Run),
 		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to build worker replica spec: %w", err)
@@ -90,27 +90,30 @@ func (p *PyTorchProvider) BuildCRD(t *task.Task) (*unstructured.Unstructured, er
 
 		// Master: inherit from worker if not explicitly configured
 		var masterResources task.Resources
+		var masterLimits task.Resources
 		var masterEnvs map[string]task.EnvValue
 		var masterRun string
 		if t.Master != nil {
 			masterResources = t.Master.Resources
+			masterLimits = t.Master.Limits
 			masterEnvs = t.Master.Envs
 			masterRun = t.Master.Run
 		} else {
 			masterResources = t.Worker.Resources
+			masterLimits = t.Worker.Limits
 			masterEnvs = t.Worker.Envs
 			masterRun = t.Worker.Run
 		}
 
 		masterSpec, err := buildRoleReplicaSpec(replicaSpecOptions{
-			ContainerName:  constants.FrameworkPyTorch,
-			Task:           t,
-			Resources:      masterResources,
-			Envs:           masterEnvs,
-			Replicas:       1,
-			RestartPolicy:  restartPolicy,
-			IncludeVolumes: true,
-			Run:            effectiveRun(t, masterRun),
+			ContainerName: constants.FrameworkPyTorch,
+			Task:          t,
+			Resources:     masterResources,
+			Limits:        masterLimits,
+			Envs:          masterEnvs,
+			Replicas:      1,
+			RestartPolicy: restartPolicy,
+			Run:           effectiveRun(t, masterRun),
 		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to build master replica spec: %w", err)

--- a/pkg/provider/tensorflow.go
+++ b/pkg/provider/tensorflow.go
@@ -46,14 +46,14 @@ func (p *TensorFlowProvider) BuildCRD(t *task.Task) (*unstructured.Unstructured,
 
 	// Worker: always present (validated)
 	workerSpec, err := buildRoleReplicaSpec(replicaSpecOptions{
-		ContainerName:  constants.FrameworkTensorFlow,
-		Task:           t,
-		Resources:      t.Worker.Resources,
-		Envs:           t.Worker.Envs,
-		Replicas:       int64(t.Worker.Replicas),
-		RestartPolicy:  restartPolicy,
-		IncludeVolumes: true,
-		Run:            effectiveRun(t, t.Worker.Run),
+		ContainerName: constants.FrameworkTensorFlow,
+		Task:          t,
+		Resources:     t.Worker.Resources,
+		Limits:        t.Worker.Limits,
+		Envs:          t.Worker.Envs,
+		Replicas:      int64(t.Worker.Replicas),
+		RestartPolicy: restartPolicy,
+		Run:           effectiveRun(t, t.Worker.Run),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to build worker replica spec: %w", err)
@@ -63,14 +63,14 @@ func (p *TensorFlowProvider) BuildCRD(t *task.Task) (*unstructured.Unstructured,
 	// Chief: only if section present
 	if t.Chief != nil {
 		chiefSpec, err := buildRoleReplicaSpec(replicaSpecOptions{
-			ContainerName:  constants.FrameworkTensorFlow,
-			Task:           t,
-			Resources:      t.Chief.Resources,
-			Envs:           t.Chief.Envs,
-			Replicas:       1,
-			RestartPolicy:  restartPolicy,
-			IncludeVolumes: true,
-			Run:            effectiveRun(t, t.Chief.Run),
+			ContainerName: constants.FrameworkTensorFlow,
+			Task:          t,
+			Resources:     t.Chief.Resources,
+			Limits:        t.Chief.Limits,
+			Envs:          t.Chief.Envs,
+			Replicas:      1,
+			RestartPolicy: restartPolicy,
+			Run:           effectiveRun(t, t.Chief.Run),
 		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to build chief replica spec: %w", err)
@@ -82,14 +82,14 @@ func (p *TensorFlowProvider) BuildCRD(t *task.Task) (*unstructured.Unstructured,
 	// Validator guarantees PS.Replicas >= 1.
 	if t.PS != nil {
 		psSpec, err := buildRoleReplicaSpec(replicaSpecOptions{
-			ContainerName:  constants.FrameworkTensorFlow,
-			Task:           t,
-			Resources:      t.PS.Resources,
-			Envs:           t.PS.Envs,
-			Replicas:       int64(t.PS.Replicas),
-			RestartPolicy:  restartPolicy,
-			IncludeVolumes: true,
-			Run:            effectiveRun(t, t.PS.Run),
+			ContainerName: constants.FrameworkTensorFlow,
+			Task:          t,
+			Resources:     t.PS.Resources,
+			Limits:        t.PS.Limits,
+			Envs:          t.PS.Envs,
+			Replicas:      int64(t.PS.Replicas),
+			RestartPolicy: restartPolicy,
+			Run:           effectiveRun(t, t.PS.Run),
 		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to build PS replica spec: %w", err)
@@ -100,14 +100,14 @@ func (p *TensorFlowProvider) BuildCRD(t *task.Task) (*unstructured.Unstructured,
 	// Evaluator: only if section present, uses own config only
 	if t.Evaluator != nil {
 		evalSpec, err := buildRoleReplicaSpec(replicaSpecOptions{
-			ContainerName:  constants.FrameworkTensorFlow,
-			Task:           t,
-			Resources:      t.Evaluator.Resources,
-			Envs:           t.Evaluator.Envs,
-			Replicas:       1,
-			RestartPolicy:  restartPolicy,
-			IncludeVolumes: true,
-			Run:            effectiveRun(t, t.Evaluator.Run),
+			ContainerName: constants.FrameworkTensorFlow,
+			Task:          t,
+			Resources:     t.Evaluator.Resources,
+			Limits:        t.Evaluator.Limits,
+			Envs:          t.Evaluator.Envs,
+			Replicas:      1,
+			RestartPolicy: restartPolicy,
+			Run:           effectiveRun(t, t.Evaluator.Run),
 		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to build evaluator replica spec: %w", err)

--- a/pkg/provider/tensorflow_test.go
+++ b/pkg/provider/tensorflow_test.go
@@ -589,3 +589,71 @@ func TestTensorFlowBuildCRDWithChiefWorkerAlias(t *testing.T) {
 	assert.False(t, hasSuccessPolicy,
 		"successPolicy field should be absent when ChiefWorker is normalized to default \"\"")
 }
+
+func TestTensorFlowLimitsOverlayRendering(t *testing.T) {
+	tk := &task.Task{
+		Name:      "tf-limits",
+		Namespace: "default",
+		Image:     "tf:2.15",
+		Framework: task.Framework{Name: constants.FrameworkTensorFlow},
+		Run:       "python train.py",
+		Worker: &task.Worker{
+			Replicas:  1,
+			Resources: task.Resources{"cpu": "1"},
+			Limits:    task.Resources{"cpu": "2"},
+		},
+		PS: &task.RoleConfig{
+			Replicas:  1,
+			Resources: task.Resources{"cpu": "1"},
+			Limits:    task.Resources{"cpu": "3"},
+		},
+	}
+	crd, err := (&TensorFlowProvider{}).BuildCRD(tk)
+	require.NoError(t, err)
+
+	spec := crd.Object["spec"].(map[string]interface{})
+	replicaSpecs := spec["tfReplicaSpecs"].(map[string]interface{})
+
+	containerOf := func(role string) map[string]interface{} {
+		rs := replicaSpecs[role].(map[string]interface{})
+		template := rs["template"].(map[string]interface{})
+		podSpec := template["spec"].(map[string]interface{})
+		containers := podSpec["containers"].([]interface{})
+		return containers[0].(map[string]interface{})
+	}
+
+	workerRes := containerOf("Worker")["resources"].(map[string]interface{})
+	assert.Equal(t, "1", workerRes["requests"].(map[string]interface{})["cpu"])
+	assert.Equal(t, "2", workerRes["limits"].(map[string]interface{})["cpu"])
+
+	psRes := containerOf("PS")["resources"].(map[string]interface{})
+	assert.Equal(t, "1", psRes["requests"].(map[string]interface{})["cpu"])
+	assert.Equal(t, "3", psRes["limits"].(map[string]interface{})["cpu"])
+}
+
+func TestTensorFlowLimitsOnlyRendering(t *testing.T) {
+	tk := &task.Task{
+		Name:      "tf-limits-only",
+		Namespace: "default",
+		Image:     "tf:2.15",
+		Framework: task.Framework{Name: constants.FrameworkTensorFlow},
+		Run:       "python train.py",
+		Worker: &task.Worker{
+			Replicas: 1,
+			Limits:   task.Resources{"nvidia.com/gpu": "2"},
+		},
+	}
+	crd, err := (&TensorFlowProvider{}).BuildCRD(tk)
+	require.NoError(t, err)
+
+	spec := crd.Object["spec"].(map[string]interface{})
+	replicaSpecs := spec["tfReplicaSpecs"].(map[string]interface{})
+	worker := replicaSpecs["Worker"].(map[string]interface{})
+	template := worker["template"].(map[string]interface{})
+	podSpec := template["spec"].(map[string]interface{})
+	containers := podSpec["containers"].([]interface{})
+	res := containers[0].(map[string]interface{})["resources"].(map[string]interface{})
+	assert.Equal(t, "2", res["limits"].(map[string]interface{})["nvidia.com/gpu"])
+	_, hasRequests := res["requests"]
+	assert.False(t, hasRequests, "requests should be omitted when only limits are set")
+}

--- a/pkg/task/override.go
+++ b/pkg/task/override.go
@@ -2,6 +2,7 @@ package task
 
 import (
 	"fmt"
+	"path"
 	"strconv"
 	"strings"
 
@@ -57,8 +58,8 @@ func setBoolFlag(flags map[string]interface{}, flag string, target *bool) error 
 }
 
 // ApplyOverrides applies flag-based overrides to a Task struct.
-// Flag keys match the CLI flag names (without the leading --).
-// Returns an error when a flag value has an unexpected type.
+// Flag keys match the submit command's CLI flag names (v1 names, without the
+// leading --). Returns an error when a flag value has an unexpected type.
 func ApplyOverrides(t *Task, flags map[string]interface{}) error {
 	if err := applyIdentityOverrides(t, flags); err != nil {
 		return err
@@ -79,6 +80,12 @@ func ApplyOverrides(t *Task, flags map[string]interface{}) error {
 		return err
 	}
 	if err := applyFrameworkOverrides(t, flags); err != nil {
+		return err
+	}
+	if err := applyRoleResourceOverrides(t, flags); err != nil {
+		return err
+	}
+	if err := applySyncOverrides(t, flags); err != nil {
 		return err
 	}
 	return nil
@@ -122,8 +129,8 @@ func applyIdentityOverrides(t *Task, flags map[string]interface{}) error {
 	return nil
 }
 
-// applyResourceOverrides handles image, workers, gpus, gpu-type, cpus, memory,
-// shm, device, envs, data, data-dir, and config-file.
+// applyResourceOverrides handles image, workers, gpus, gpu-type, cpu, memory,
+// share-memory, device, envs, data, data-dir, and config-file.
 func applyResourceOverrides(t *Task, flags map[string]interface{}) error {
 	if err := setStrFlag(flags, "image", &t.Image); err != nil {
 		return err
@@ -133,28 +140,6 @@ func applyResourceOverrides(t *Task, flags map[string]interface{}) error {
 		if t.Worker == nil {
 			t.Worker = &Worker{}
 		}
-	}
-
-	// ensureResourceTarget returns the Resources map that resource overrides
-	// should be applied to. When Worker exists, it returns Worker.Resources.
-	// When Worker is nil but Master exists (single-node PyTorch), it returns
-	// Master.Resources. Otherwise it creates a Worker with Replicas=1.
-	ensureResourceTarget := func() Resources {
-		if t.Worker != nil {
-			if t.Worker.Resources == nil {
-				t.Worker.Resources = Resources{}
-			}
-			return t.Worker.Resources
-		}
-		if t.Master != nil {
-			if t.Master.Resources == nil {
-				t.Master.Resources = Resources{}
-			}
-			return t.Master.Resources
-		}
-		t.Worker = &Worker{Replicas: 1}
-		t.Worker.Resources = Resources{}
-		return t.Worker.Resources
 	}
 
 	// Scale
@@ -171,7 +156,7 @@ func applyResourceOverrides(t *Task, flags map[string]interface{}) error {
 
 	// Resources
 	if gpus, ok := flags["gpus"].(int); ok && gpus > 0 {
-		target := ensureResourceTarget()
+		target := ensureResourceTarget(t)
 		target["nvidia.com/gpu"] = strconv.Itoa(gpus)
 	}
 	if gpuType, ok := flags["gpu-type"].(string); ok && gpuType != "" {
@@ -181,16 +166,16 @@ func applyResourceOverrides(t *Task, flags map[string]interface{}) error {
 		t.Scheduling.NodeSelector["nvidia.com/gpu.product"] = gpuType
 	}
 
-	if v, ok := flags["cpus"].(string); ok && v != "" {
-		target := ensureResourceTarget()
+	if v, ok := flags["cpu"].(string); ok && v != "" {
+		target := ensureResourceTarget(t)
 		target["cpu"] = v
 	}
-	if v, ok := flags["mem"].(string); ok && v != "" {
-		target := ensureResourceTarget()
+	if v, ok := flags["memory"].(string); ok && v != "" {
+		target := ensureResourceTarget(t)
 		target["memory"] = v
 	}
 
-	if shm, ok := flags["shm"].(string); ok && shm != "" {
+	if shm, ok := flags["share-memory"].(string); ok && shm != "" {
 		t.Storages = append(t.Storages, Storage{
 			Name:      "shm",
 			SHM:       shm,
@@ -199,7 +184,7 @@ func applyResourceOverrides(t *Task, flags map[string]interface{}) error {
 	}
 
 	if devices, ok := flags["device"].([]string); ok {
-		target := ensureResourceTarget()
+		target := ensureResourceTarget(t)
 		for _, d := range devices {
 			k, v := splitKV(d)
 			if k != "" {
@@ -224,60 +209,154 @@ func applyResourceOverrides(t *Task, flags map[string]interface{}) error {
 	// Data
 	if dataEntries, ok := flags["data"].([]string); ok {
 		for _, d := range dataEntries {
-			parts := strings.SplitN(d, ":", 3)
-			if len(parts) == 3 {
-				t.Storages = append(t.Storages, Storage{
-					Name:      parts[0],
-					MountPath: parts[1],
-					PVC:       parts[2],
-				})
+			s, err := parseDataEntry(d)
+			if err != nil {
+				return err
 			}
+			t.Storages = append(t.Storages, s)
 		}
 	}
 
 	// Data-dir (hostpath volumes)
 	if dataDirs, ok := flags["data-dir"].([]string); ok {
-		for _, d := range dataDirs {
-			parts := strings.SplitN(d, ":", 3)
-			if len(parts) == 3 {
-				t.Storages = append(t.Storages, Storage{
-					Name:      parts[0],
-					MountPath: parts[1],
-					HostPath:  parts[2],
-				})
+		for i, d := range dataDirs {
+			s, err := parseDataDirEntry(d, i)
+			if err != nil {
+				return err
 			}
+			t.Storages = append(t.Storages, s)
 		}
 	}
 
 	// Config-file (configmap volumes)
 	if configFiles, ok := flags["config-file"].([]string); ok {
 		for _, c := range configFiles {
-			parts := strings.SplitN(c, ":", 3)
-			if len(parts) == 3 {
-				t.Storages = append(t.Storages, Storage{
-					Name:      parts[0],
-					MountPath: parts[1],
-					ConfigMap: parts[2],
-				})
+			s, err := parseConfigFileEntry(c)
+			if err != nil {
+				return err
 			}
+			t.Storages = append(t.Storages, s)
 		}
 	}
 	return nil
 }
 
+// validateAbsPath rejects non-absolute paths for v1-compat entries (v1
+// validateHostPath behavior).
+func validateAbsPath(what, p string) error {
+	if !path.IsAbs(p) {
+		return fmt.Errorf("%s %q must be an absolute path", what, p)
+	}
+	return nil
+}
+
+// parseDataEntry parses one --data value.
+//   - v1 form   "<pvc>:<mount_path>"          mounts the PVC named <pvc>
+//   - v2 form   "<name>:<mount_path>:<pvc>"   mounts <pvc> as volume <name>
+func parseDataEntry(v string) (Storage, error) {
+	parts := strings.Split(v, ":")
+	switch len(parts) {
+	case 2:
+		if err := validateAbsPath("data mount path", parts[1]); err != nil {
+			return Storage{}, err
+		}
+		return Storage{Name: parts[0], MountPath: parts[1], PVC: parts[0]}, nil
+	case 3:
+		if err := validateAbsPath("data mount path", parts[1]); err != nil {
+			return Storage{}, err
+		}
+		return Storage{Name: parts[0], MountPath: parts[1], PVC: parts[2]}, nil
+	default:
+		return Storage{}, fmt.Errorf("invalid --data value %q: expected <pvc>:<mount_path> (v1) or <name>:<mount_path>:<pvc> (v2)", v)
+	}
+}
+
+// parseDataDirEntry parses one --data-dir value.
+//   - v1 forms  "<host_path>"                 host path mounted at the same path
+//     "<host_path>:<container_path>"
+//   - v2 form   "<name>:<mount_path>:<host_path>"
+//
+// v1 entries use the v1 volume naming convention training-data-<index>.
+func parseDataDirEntry(v string, index int) (Storage, error) {
+	parts := strings.Split(v, ":")
+	name := fmt.Sprintf("training-data-%d", index)
+	switch len(parts) {
+	case 1:
+		if err := validateAbsPath("data-dir host path", parts[0]); err != nil {
+			return Storage{}, err
+		}
+		return Storage{Name: name, MountPath: parts[0], HostPath: parts[0]}, nil
+	case 2:
+		if err := validateAbsPath("data-dir host path", parts[0]); err != nil {
+			return Storage{}, err
+		}
+		if err := validateAbsPath("data-dir container path", parts[1]); err != nil {
+			return Storage{}, err
+		}
+		return Storage{Name: name, MountPath: parts[1], HostPath: parts[0]}, nil
+	case 3:
+		if err := validateAbsPath("data-dir container path", parts[1]); err != nil {
+			return Storage{}, err
+		}
+		if err := validateAbsPath("data-dir host path", parts[2]); err != nil {
+			return Storage{}, err
+		}
+		return Storage{Name: parts[0], MountPath: parts[1], HostPath: parts[2]}, nil
+	default:
+		return Storage{}, fmt.Errorf("invalid --data-dir value %q: expected <host_path>[:<container_path>] (v1) or <name>:<mount_path>:<host_path> (v2)", v)
+	}
+}
+
+// parseConfigFileEntry parses one --config-file value. Only the v2 configmap
+// form is supported; the v1 host-file form errors with guidance because v2
+// cannot yet create a configmap from a local file.
+func parseConfigFileEntry(v string) (Storage, error) {
+	parts := strings.Split(v, ":")
+	switch len(parts) {
+	case 3:
+		if err := validateAbsPath("config-file mount path", parts[1]); err != nil {
+			return Storage{}, err
+		}
+		return Storage{Name: parts[0], MountPath: parts[1], ConfigMap: parts[2]}, nil
+	case 1, 2:
+		return Storage{}, fmt.Errorf("v1-style --config-file %q (local file mount) is not supported by arena-v2 yet: pre-create a configmap and use --config-file <name>:<mount_path>:<configmap>", v)
+	default:
+		return Storage{}, fmt.Errorf("invalid --config-file value %q: expected <name>:<mount_path>:<configmap>", v)
+	}
+}
+
+// ensureResourceTarget returns the Resources map that worker-scoped resource
+// overrides apply to. When Worker exists, it returns Worker.Resources. When
+// Worker is nil but Master exists (single-node PyTorch), it returns
+// Master.Resources. Otherwise it creates a Worker with Replicas=1.
+func ensureResourceTarget(t *Task) Resources {
+	if t.Worker != nil {
+		if t.Worker.Resources == nil {
+			t.Worker.Resources = Resources{}
+		}
+		return t.Worker.Resources
+	}
+	if t.Master != nil {
+		if t.Master.Resources == nil {
+			t.Master.Resources = Resources{}
+		}
+		return t.Master.Resources
+	}
+	t.Worker = &Worker{Replicas: 1}
+	t.Worker.Resources = Resources{}
+	return t.Worker.Resources
+}
+
 // applySchedulingOverrides handles scheduler, queue, priority, gang, affinity,
 // selector, and toleration.
 func applySchedulingOverrides(t *Task, flags map[string]interface{}) error {
-	if err := setIntFlag(flags, "priority", &t.Scheduling.Priority); err != nil {
-		return err
-	}
-	if err := setStrFlag(flags, "priority-class-name", &t.Scheduling.PriorityClassName); err != nil {
+	if err := setStrFlag(flags, "priority", &t.Scheduling.PriorityClassName); err != nil {
 		return err
 	}
 	if err := setBoolFlag(flags, "gang", &t.Scheduling.Gang.Enabled); err != nil {
 		return err
 	}
-	if err := setStrFlag(flags, "scheduler-name", &t.Scheduling.SchedulerName); err != nil {
+	if err := setStrFlag(flags, "scheduler", &t.Scheduling.SchedulerName); err != nil {
 		return err
 	}
 
@@ -316,19 +395,23 @@ func applySchedulingOverrides(t *Task, flags map[string]interface{}) error {
 		}
 	}
 
-	if err := setStrFlag(flags, "queue", &t.Scheduling.Queue); err != nil {
-		return err
+	// v1 --queue is a bool that suspends the job so an external queue
+	// manager (kube-queue) can take over scheduling. The queue *name*
+	// (scheduling.queue) is only settable via YAML on job run.
+	if v, ok := flags["queue"].(bool); ok && v {
+		suspend := true
+		t.Lifecycle.Suspend = &suspend
 	}
 	return nil
 }
 
-// applyLifecycleOverrides handles clean-pod-policy, active-deadline,
-// ttl-after-finished, success-policy, and backoff-limit.
+// applyLifecycleOverrides handles clean-task-policy, running-timeout,
+// ttl-after-finished, success-policy, and job-backoff-limit.
 func applyLifecycleOverrides(t *Task, flags map[string]interface{}) error {
-	if err := setStrFlag(flags, "clean-pod-policy", &t.Lifecycle.CleanPodPolicy); err != nil {
+	if err := setStrFlag(flags, "clean-task-policy", &t.Lifecycle.CleanPodPolicy); err != nil {
 		return err
 	}
-	if err := setStrFlag(flags, "active-deadline", &t.Lifecycle.ActiveDeadline); err != nil {
+	if err := setStrFlag(flags, "running-timeout", &t.Lifecycle.ActiveDeadline); err != nil {
 		return err
 	}
 	if err := setStrFlag(flags, "ttl-after-finished", &t.Lifecycle.TTLAfterFinished); err != nil {
@@ -338,10 +421,10 @@ func applyLifecycleOverrides(t *Task, flags map[string]interface{}) error {
 		return err
 	}
 
-	if v, exists := flags["backoff-limit"]; exists {
+	if v, exists := flags["job-backoff-limit"]; exists {
 		n, ok := v.(int)
 		if !ok {
-			return fmt.Errorf("flag %q: expected int, got %T", "backoff-limit", v)
+			return fmt.Errorf("flag %q: expected int, got %T", "job-backoff-limit", v)
 		}
 		if n >= 0 {
 			t.Lifecycle.BackoffLimit = &n
@@ -351,7 +434,7 @@ func applyLifecycleOverrides(t *Task, flags map[string]interface{}) error {
 }
 
 // applyRuntimeOverrides handles run, shell, working-dir, image-pull-policy,
-// service-account, restart, host-network, host-ipc, host-pid, and image-pull-secret.
+// service-account, job-restart-policy, hostNetwork, hostIPC, hostPID, and image-pull-secret.
 func applyRuntimeOverrides(t *Task, flags map[string]interface{}) error {
 	if err := setStrFlag(flags, "run", &t.Run); err != nil {
 		return err
@@ -368,16 +451,16 @@ func applyRuntimeOverrides(t *Task, flags map[string]interface{}) error {
 	if err := setStrFlag(flags, "service-account", &t.ServiceAccount); err != nil {
 		return err
 	}
-	if err := setStrFlag(flags, "restart", &t.Restart); err != nil {
+	if err := setStrFlag(flags, "job-restart-policy", &t.Restart); err != nil {
 		return err
 	}
-	if err := setBoolFlag(flags, "host-network", &t.HostNetwork); err != nil {
+	if err := setBoolFlag(flags, "hostNetwork", &t.HostNetwork); err != nil {
 		return err
 	}
-	if err := setBoolFlag(flags, "host-ipc", &t.HostIPC); err != nil {
+	if err := setBoolFlag(flags, "hostIPC", &t.HostIPC); err != nil {
 		return err
 	}
-	if err := setBoolFlag(flags, "host-pid", &t.HostPID); err != nil {
+	if err := setBoolFlag(flags, "hostPID", &t.HostPID); err != nil {
 		return err
 	}
 
@@ -387,7 +470,7 @@ func applyRuntimeOverrides(t *Task, flags map[string]interface{}) error {
 	return nil
 }
 
-// applyLoggingOverrides handles tensorboard, tensorboard-logdir, and tensorboard-image.
+// applyLoggingOverrides handles tensorboard, logdir, and tensorboard-image.
 func applyLoggingOverrides(t *Task, flags map[string]interface{}) error {
 	if v, ok := flags["tensorboard"].(bool); ok {
 		if t.Logging.TensorBoard == nil {
@@ -395,7 +478,7 @@ func applyLoggingOverrides(t *Task, flags map[string]interface{}) error {
 		}
 		t.Logging.TensorBoard.Enabled = v
 	}
-	if v, ok := flags["tensorboard-logdir"].(string); ok && v != "" {
+	if v, ok := flags["logdir"].(string); ok && v != "" {
 		if t.Logging.TensorBoard == nil {
 			t.Logging.TensorBoard = &TensorBoardConfig{}
 		}
@@ -410,8 +493,8 @@ func applyLoggingOverrides(t *Task, flags map[string]interface{}) error {
 	return nil
 }
 
-// applyFrameworkOverrides handles nproc-per-node, slots-per-worker, gpu-topology,
-// mounts-on-launcher, chief, evaluator, and ps-count.
+// applyFrameworkOverrides handles nproc-per-node, slots-per-worker, gputopology,
+// mounts-on-launcher, chief, evaluator, and ps.
 func applyFrameworkOverrides(t *Task, flags map[string]interface{}) error {
 	if err := setStrFlag(flags, "nproc-per-node", &t.Framework.Options.NprocPerNode); err != nil {
 		return err
@@ -419,8 +502,15 @@ func applyFrameworkOverrides(t *Task, flags map[string]interface{}) error {
 	if err := setIntFlag(flags, "slots-per-worker", &t.Framework.Options.SlotsPerWorker); err != nil {
 		return err
 	}
-	if err := setBoolFlag(flags, "gpu-topology", &t.Framework.Options.GPUTopology); err != nil {
-		return err
+	if v, ok := flags["gputopology"].(bool); ok && v {
+		t.Framework.Options.GPUTopology = true
+		// v1 semantics: gputopology implies host networking and topology labels.
+		t.HostNetwork = true
+		if t.Labels == nil {
+			t.Labels = make(map[string]string)
+		}
+		t.Labels["gpu-topology"] = "true"
+		t.Labels["gpu-topology-replica"] = "true"
 	}
 	if err := setBoolFlag(flags, "mounts-on-launcher", &t.Framework.Options.MountsOnLauncher); err != nil {
 		return err
@@ -437,7 +527,7 @@ func applyFrameworkOverrides(t *Task, flags map[string]interface{}) error {
 			t.Evaluator = &RoleConfig{}
 		}
 	}
-	if v, ok := flags["ps-count"].(int); ok && v > 0 {
+	if v, ok := flags["ps"].(int); ok && v > 0 {
 		if t.PS == nil {
 			t.PS = &RoleConfig{}
 		}
@@ -529,4 +619,198 @@ func parseTolerationFlag(s string) (*Toleration, error) {
 	}
 
 	return tol, nil
+}
+
+// applyRoleResourceOverrides handles the v1 per-role resource flags:
+// ps-cpu/ps-memory/ps-gpus, chief-cpu/chief-memory,
+// evaluator-cpu/evaluator-memory, worker-cpu/worker-memory, and their
+// -limit variants (which write the role's Limits overlay without touching
+// requests). It runs after applyFrameworkOverrides (which creates the
+// roles), so role-specific flags override the generic --cpu/--memory —
+// the v1 precedence.
+func applyRoleResourceOverrides(t *Task, flags map[string]interface{}) error {
+	setRoleStr := func(key, resource string, role **RoleConfig) error {
+		v, exists := flags[key]
+		if !exists {
+			return nil
+		}
+		s, ok := v.(string)
+		if !ok {
+			return fmt.Errorf("flag %q: expected string, got %T", key, v)
+		}
+		if s != "" {
+			ensureRole(role).Resources[resource] = s
+		}
+		return nil
+	}
+
+	setRoleLimitStr := func(key, resource string, role **RoleConfig) error {
+		v, exists := flags[key]
+		if !exists {
+			return nil
+		}
+		s, ok := v.(string)
+		if !ok {
+			return fmt.Errorf("flag %q: expected string, got %T", key, v)
+		}
+		if s != "" {
+			ensureRoleLimits(role).Limits[resource] = s
+		}
+		return nil
+	}
+
+	if err := setRoleLimitStr("ps-cpu-limit", "cpu", &t.PS); err != nil {
+		return err
+	}
+	if err := setRoleLimitStr("ps-memory-limit", "memory", &t.PS); err != nil {
+		return err
+	}
+	if err := setRoleLimitStr("chief-cpu-limit", "cpu", &t.Chief); err != nil {
+		return err
+	}
+	if err := setRoleLimitStr("chief-memory-limit", "memory", &t.Chief); err != nil {
+		return err
+	}
+	if err := setRoleLimitStr("evaluator-cpu-limit", "cpu", &t.Evaluator); err != nil {
+		return err
+	}
+	if err := setRoleLimitStr("evaluator-memory-limit", "memory", &t.Evaluator); err != nil {
+		return err
+	}
+	if v, ok := flags["worker-cpu-limit"].(string); ok && v != "" {
+		ensureLimitsTarget(t)["cpu"] = v
+	}
+	if v, ok := flags["worker-memory-limit"].(string); ok && v != "" {
+		ensureLimitsTarget(t)["memory"] = v
+	}
+
+	if err := setRoleStr("ps-cpu", "cpu", &t.PS); err != nil {
+		return err
+	}
+	if err := setRoleStr("ps-memory", "memory", &t.PS); err != nil {
+		return err
+	}
+	if gpus, ok := flags["ps-gpus"].(int); ok && gpus > 0 {
+		ensureRole(&t.PS).Resources["nvidia.com/gpu"] = strconv.Itoa(gpus)
+	}
+	if err := setRoleStr("chief-cpu", "cpu", &t.Chief); err != nil {
+		return err
+	}
+	if err := setRoleStr("chief-memory", "memory", &t.Chief); err != nil {
+		return err
+	}
+	if err := setRoleStr("evaluator-cpu", "cpu", &t.Evaluator); err != nil {
+		return err
+	}
+	if err := setRoleStr("evaluator-memory", "memory", &t.Evaluator); err != nil {
+		return err
+	}
+
+	// Worker flags target Worker, else Master (single-node PyTorch), else a
+	// new Worker — the same resolution as the generic --cpu/--memory overrides.
+	if v, ok := flags["worker-cpu"].(string); ok && v != "" {
+		ensureResourceTarget(t)["cpu"] = v
+	}
+	if v, ok := flags["worker-memory"].(string); ok && v != "" {
+		ensureResourceTarget(t)["memory"] = v
+	}
+	return nil
+}
+
+// ensureRole returns the role config, creating it (with an empty Resources
+// map) when nil.
+func ensureRole(rc **RoleConfig) *RoleConfig {
+	if *rc == nil {
+		*rc = &RoleConfig{}
+	}
+	if (*rc).Resources == nil {
+		(*rc).Resources = Resources{}
+	}
+	return *rc
+}
+
+// ensureRoleLimits returns the role config, creating it (with an empty
+// Limits map) when nil.
+func ensureRoleLimits(rc **RoleConfig) *RoleConfig {
+	if *rc == nil {
+		*rc = &RoleConfig{}
+	}
+	if (*rc).Limits == nil {
+		(*rc).Limits = Resources{}
+	}
+	return *rc
+}
+
+// ensureLimitsTarget returns the Limits map that worker-scoped limit
+// overrides apply to, mirroring ensureResourceTarget's role resolution.
+func ensureLimitsTarget(t *Task) Resources {
+	if t.Worker != nil {
+		if t.Worker.Limits == nil {
+			t.Worker.Limits = Resources{}
+		}
+		return t.Worker.Limits
+	}
+	if t.Master != nil {
+		if t.Master.Limits == nil {
+			t.Master.Limits = Resources{}
+		}
+		return t.Master.Limits
+	}
+	t.Worker = &Worker{Replicas: 1}
+	t.Worker.Limits = Resources{}
+	return t.Worker.Limits
+}
+
+// code-sync storage constants. v1 wired sync through a shared code-sync
+// emptyDir volume mounted by both the sync init container and the main
+// container; v2 storages require a size for emptyDir volumes (v1 was
+// unlimited).
+const (
+	codeSyncStorageName = "code-sync"
+	codeSyncStorageSize = "10Gi"
+)
+
+// applySyncOverrides handles the v1 code-sync flags: sync-mode, sync-source,
+// and sync-image. Synced code lands in $workingDir/code (default /root) and
+// is exchanged through a shared code-sync emptyDir volume mounted by both
+// the sync init container and the main container — without it the synced
+// files die with the init container's filesystem.
+func applySyncOverrides(t *Task, flags map[string]interface{}) error {
+	mode, _ := flags["sync-mode"].(string)
+	if mode == "" {
+		return nil
+	}
+	source, _ := flags["sync-source"].(string)
+	if source == "" {
+		return fmt.Errorf("--sync-source is required when --sync-mode is set")
+	}
+	image, _ := flags["sync-image"].(string)
+
+	entry := SyncEntry{Image: image}
+	switch strings.ToLower(mode) {
+	case "git":
+		entry.Git = source
+	case "rsync":
+		entry.Rsync = source
+	case "hdfs":
+		entry.HDFS = source
+	default:
+		return fmt.Errorf("invalid --sync-mode %q: must be git, rsync, or hdfs", mode)
+	}
+
+	wd := t.WorkingDir
+	if wd == "" {
+		wd = "/root"
+	}
+	entry.LocalPath = path.Join(wd, "code")
+
+	t.Storages = append(t.Storages, Storage{
+		Name:      codeSyncStorageName,
+		MountPath: entry.LocalPath,
+		Tmp:       codeSyncStorageSize,
+	})
+	entry.Mounts = []Mount{{Name: codeSyncStorageName}}
+
+	t.Sync = append(t.Sync, entry)
+	return nil
 }

--- a/pkg/task/override_test.go
+++ b/pkg/task/override_test.go
@@ -46,11 +46,11 @@ func TestApplyOverrides_GPUType(t *testing.T) {
 	assert.Equal(t, "A100", task.Scheduling.NodeSelector["nvidia.com/gpu.product"])
 }
 
-func TestApplyOverrides_CPUsAndMemory(t *testing.T) {
+func TestApplyOverrides_CPUAndMemory(t *testing.T) {
 	task := &Task{}
 	err := ApplyOverrides(task, map[string]interface{}{
-		"cpus": "4",
-		"mem":  "16Gi",
+		"cpu":    "4",
+		"memory": "16Gi",
 	})
 	require.NoError(t, err)
 	require.NotNil(t, task.Worker, "Worker should be auto-created by CPU/memory override")
@@ -60,7 +60,7 @@ func TestApplyOverrides_CPUsAndMemory(t *testing.T) {
 
 func TestApplyOverrides_SHM(t *testing.T) {
 	task := &Task{}
-	err := ApplyOverrides(task, map[string]interface{}{"shm": "8Gi"})
+	err := ApplyOverrides(task, map[string]interface{}{"share-memory": "8Gi"})
 	require.NoError(t, err)
 	require.Len(t, task.Storages, 1)
 	assert.Equal(t, "shm", task.Storages[0].Name)
@@ -81,18 +81,24 @@ func TestApplyOverrides_Envs(t *testing.T) {
 func TestApplyOverrides_Scheduling(t *testing.T) {
 	task := &Task{}
 	err := ApplyOverrides(task, map[string]interface{}{
-		"priority":            100,
-		"priority-class-name": "high",
-		"gang":                true,
-		"scheduler-name":      "volcano",
-		"selector":            []string{"zone=us-west-2a"},
+		"priority":  "high",
+		"gang":      true,
+		"scheduler": "volcano",
+		"selector":  []string{"zone=us-west-2a"},
 	})
 	require.NoError(t, err)
-	assert.Equal(t, 100, task.Scheduling.Priority)
 	assert.Equal(t, "high", task.Scheduling.PriorityClassName)
 	assert.True(t, task.Scheduling.Gang.Enabled)
 	assert.Equal(t, "volcano", task.Scheduling.SchedulerName)
 	assert.Equal(t, "us-west-2a", task.Scheduling.NodeSelector["zone"])
+}
+
+func TestApplyOverrides_QueueSuspendsJob(t *testing.T) {
+	task := &Task{}
+	err := ApplyOverrides(task, map[string]interface{}{"queue": true})
+	require.NoError(t, err)
+	require.NotNil(t, task.Lifecycle.Suspend, "v1 --queue should suspend the job")
+	assert.True(t, *task.Lifecycle.Suspend)
 }
 
 func TestApplyOverrides_Affinity(t *testing.T) {
@@ -112,10 +118,10 @@ func TestApplyOverrides_Affinity(t *testing.T) {
 func TestApplyOverrides_Lifecycle(t *testing.T) {
 	task := &Task{}
 	err := ApplyOverrides(task, map[string]interface{}{
-		"clean-pod-policy":   "Running",
-		"active-deadline":    "2h",
+		"clean-task-policy":  "Running",
+		"running-timeout":    "2h",
 		"ttl-after-finished": "7d",
-		"backoff-limit":      3,
+		"job-backoff-limit":  3,
 		"success-policy":     constants.SuccessPolicyChiefWorkerAlias,
 	})
 	require.NoError(t, err)
@@ -129,13 +135,13 @@ func TestApplyOverrides_Lifecycle(t *testing.T) {
 func TestApplyOverrides_Runtime(t *testing.T) {
 	task := &Task{}
 	err := ApplyOverrides(task, map[string]interface{}{
-		"image-pull-policy": "IfNotPresent",
-		"image-pull-secret": []string{"reg-secret"},
-		"service-account":   "training-sa",
-		"restart":           "OnFailure",
-		"host-network":      true,
-		"host-ipc":          true,
-		"host-pid":          false,
+		"image-pull-policy":  "IfNotPresent",
+		"image-pull-secret":  []string{"reg-secret"},
+		"service-account":    "training-sa",
+		"job-restart-policy": "OnFailure",
+		"hostNetwork":        true,
+		"hostIPC":            true,
+		"hostPID":            false,
 	})
 	require.NoError(t, err)
 	assert.Equal(t, "IfNotPresent", task.ImagePullPolicy)
@@ -152,7 +158,7 @@ func TestApplyOverrides_FrameworkOptions(t *testing.T) {
 	err := ApplyOverrides(task, map[string]interface{}{
 		"nproc-per-node":     "auto",
 		"slots-per-worker":   4,
-		"gpu-topology":       true,
+		"gputopology":        true,
 		"mounts-on-launcher": true,
 	})
 	require.NoError(t, err)
@@ -165,9 +171,9 @@ func TestApplyOverrides_FrameworkOptions(t *testing.T) {
 func TestApplyOverrides_Logging(t *testing.T) {
 	task := &Task{}
 	err := ApplyOverrides(task, map[string]interface{}{
-		"tensorboard":        true,
-		"tensorboard-logdir": "/logs",
-		"tensorboard-image":  "custom/tb:latest",
+		"tensorboard":       true,
+		"logdir":            "/logs",
+		"tensorboard-image": "custom/tb:latest",
 	})
 	require.NoError(t, err)
 	require.NotNil(t, task.Logging.TensorBoard)
@@ -223,13 +229,13 @@ func TestApplyOverrides_WrongTypeReturnsError(t *testing.T) {
 	assert.Contains(t, err.Error(), "flag \"name\"")
 	assert.Contains(t, err.Error(), "expected string")
 
-	// Pass wrong type for priority (string instead of int)
+	// Pass wrong type for priority (int instead of string)
 	err = ApplyOverrides(task, map[string]interface{}{
-		"priority": "not-an-int",
+		"priority": 12345,
 	})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "flag \"priority\"")
-	assert.Contains(t, err.Error(), "expected int")
+	assert.Contains(t, err.Error(), "expected string")
 
 	// Pass wrong type for run (int instead of string)
 	err = ApplyOverrides(task, map[string]interface{}{
@@ -239,12 +245,12 @@ func TestApplyOverrides_WrongTypeReturnsError(t *testing.T) {
 	assert.Contains(t, err.Error(), "flag \"run\"")
 	assert.Contains(t, err.Error(), "expected string")
 
-	// Pass wrong type for backoff-limit (string instead of int)
+	// Pass wrong type for job-backoff-limit (string instead of int)
 	err = ApplyOverrides(task, map[string]interface{}{
-		"backoff-limit": "not-an-int",
+		"job-backoff-limit": "not-an-int",
 	})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "flag \"backoff-limit\"")
+	assert.Contains(t, err.Error(), "flag \"job-backoff-limit\"")
 	assert.Contains(t, err.Error(), "expected int")
 
 	// Name should be unchanged
@@ -254,7 +260,7 @@ func TestApplyOverrides_WrongTypeReturnsError(t *testing.T) {
 func TestApplyOverrides_WrongBoolTypeReturnsError(t *testing.T) {
 	task := &Task{}
 	err := ApplyOverrides(task, map[string]interface{}{
-		"host-network": "yes",
+		"hostNetwork": "yes",
 	})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "expected bool")
@@ -276,7 +282,7 @@ func TestApplyOverrides_RoleSections(t *testing.T) {
 	err := ApplyOverrides(task, map[string]interface{}{
 		"chief":     true,
 		"evaluator": true,
-		"ps-count":  2,
+		"ps":        2,
 	})
 	require.NoError(t, err)
 	require.NotNil(t, task.Chief)
@@ -285,10 +291,10 @@ func TestApplyOverrides_RoleSections(t *testing.T) {
 	assert.Equal(t, 2, task.PS.Replicas)
 }
 
-func TestApplyOverrides_PSCountCreatesSection(t *testing.T) {
+func TestApplyOverrides_PSCreatesSection(t *testing.T) {
 	task := &Task{}
 	err := ApplyOverrides(task, map[string]interface{}{
-		"ps-count": 3,
+		"ps": 3,
 	})
 	require.NoError(t, err)
 	require.NotNil(t, task.PS)
@@ -313,10 +319,10 @@ func TestApplyOverrides_EvaluatorFalseNoSection(t *testing.T) {
 	assert.Nil(t, task.Evaluator)
 }
 
-func TestApplyOverrides_PSCountZeroNoSection(t *testing.T) {
+func TestApplyOverrides_PSZeroNoSection(t *testing.T) {
 	task := &Task{}
 	err := ApplyOverrides(task, map[string]interface{}{
-		"ps-count": 0,
+		"ps": 0,
 	})
 	require.NoError(t, err)
 	assert.Nil(t, task.PS)
@@ -328,8 +334,8 @@ func TestApplyOverrides_RoleSectionsPreserveExisting(t *testing.T) {
 		PS:    &RoleConfig{Replicas: 5},
 	}
 	err := ApplyOverrides(task, map[string]interface{}{
-		"chief":    true,
-		"ps-count": 3,
+		"chief": true,
+		"ps":    3,
 	})
 	require.NoError(t, err)
 	// Chief should still be non-nil (not overwritten)
@@ -537,8 +543,8 @@ func TestApplyOverrides_PytorchSingleNodeGpus_RoutesToMaster(t *testing.T) {
 func TestApplyOverrides_PytorchSingleNodeCPUMem_RoutesToMaster(t *testing.T) {
 	task := &Task{Master: &RoleConfig{}}
 	err := ApplyOverrides(task, map[string]interface{}{
-		"cpus": "4",
-		"mem":  "16Gi",
+		"cpu":    "4",
+		"memory": "16Gi",
 	})
 	require.NoError(t, err)
 	assert.Nil(t, task.Worker, "Worker should remain nil for single-node PyTorch")
@@ -575,4 +581,320 @@ func TestApplyOverrides_NoWorkerNoMaster_GpusCreatesWorkerWithReplicas1(t *testi
 	require.NotNil(t, task.Worker, "Worker should be auto-created")
 	assert.Equal(t, 1, task.Worker.Replicas, "auto-created Worker should have Replicas=1")
 	assert.Equal(t, "1", task.Worker.Resources["nvidia.com/gpu"])
+}
+
+func TestApplyOverrides_PerRoleResources(t *testing.T) {
+	tk := &Task{Worker: &Worker{Replicas: 2}}
+	err := ApplyOverrides(tk, map[string]interface{}{
+		"ps": 1, "chief": true, "evaluator": true,
+		"ps-cpu": "2", "ps-memory": "4Gi", "ps-gpus": 1,
+		"chief-cpu": "4", "chief-memory": "16Gi",
+		"evaluator-cpu": "1", "evaluator-memory": "2Gi",
+		"worker-cpu": "8", "worker-memory": "32Gi",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, tk.PS)
+	assert.Equal(t, "2", tk.PS.Resources["cpu"])
+	assert.Equal(t, "4Gi", tk.PS.Resources["memory"])
+	assert.Equal(t, "1", tk.PS.Resources["nvidia.com/gpu"])
+	require.NotNil(t, tk.Chief)
+	assert.Equal(t, "4", tk.Chief.Resources["cpu"])
+	assert.Equal(t, "16Gi", tk.Chief.Resources["memory"])
+	require.NotNil(t, tk.Evaluator)
+	assert.Equal(t, "1", tk.Evaluator.Resources["cpu"])
+	assert.Equal(t, "2Gi", tk.Evaluator.Resources["memory"])
+	assert.Equal(t, "8", tk.Worker.Resources["cpu"])
+	assert.Equal(t, "32Gi", tk.Worker.Resources["memory"])
+}
+
+func TestApplyOverrides_PerRoleBeatsGenericResources(t *testing.T) {
+	tk := &Task{Worker: &Worker{Replicas: 2}}
+	err := ApplyOverrides(tk, map[string]interface{}{
+		"cpu":        "2",
+		"worker-cpu": "8",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "8", tk.Worker.Resources["cpu"], "worker-cpu must override the generic --cpu value")
+}
+
+func TestApplyOverrides_WorkerResourcesOnMasterOnlyPyTorch(t *testing.T) {
+	tk := &Task{Master: &RoleConfig{}}
+	err := ApplyOverrides(tk, map[string]interface{}{
+		"worker-cpu":    "4",
+		"worker-memory": "8Gi",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "4", tk.Master.Resources["cpu"])
+	assert.Equal(t, "8Gi", tk.Master.Resources["memory"])
+}
+
+func TestApplyOverrides_SyncCreatesSharedStorage(t *testing.T) {
+	tk := &Task{Worker: &Worker{Replicas: 1}}
+	err := ApplyOverrides(tk, map[string]interface{}{
+		"sync-mode":   "git",
+		"sync-source": "https://github.com/kubeflow/arena.git",
+		"sync-image":  "alpine/git:latest",
+	})
+	require.NoError(t, err)
+
+	require.Len(t, tk.Sync, 1)
+	entry := tk.Sync[0]
+	assert.Equal(t, "https://github.com/kubeflow/arena.git", entry.Git)
+	assert.Equal(t, "alpine/git:latest", entry.Image)
+	// v1 semantics: code lands in $workingDir/code (default /root)
+	assert.Equal(t, "/root/code", entry.LocalPath)
+
+	var codeSync *Storage
+	for i := range tk.Storages {
+		if tk.Storages[i].Name == "code-sync" {
+			codeSync = &tk.Storages[i]
+		}
+	}
+	require.NotNil(t, codeSync, "sync should create a code-sync storage")
+	assert.Equal(t, entry.LocalPath, codeSync.MountPath,
+		"code-sync must mount at the sync local_path so the main container sees the files")
+	assert.Equal(t, "10Gi", codeSync.Tmp, "code-sync should be a size-limited emptyDir storage")
+	require.Len(t, entry.Mounts, 1)
+	assert.Equal(t, "code-sync", entry.Mounts[0].Name,
+		"sync entry must mount code-sync so the init container writes into the volume")
+}
+
+func TestApplyOverrides_SyncModes(t *testing.T) {
+	t.Run("rsync", func(t *testing.T) {
+		tk := &Task{}
+		err := ApplyOverrides(tk, map[string]interface{}{
+			"sync-mode":   "rsync",
+			"sync-source": "10.88.29.56::backup/data.zip",
+		})
+		require.NoError(t, err)
+		require.Len(t, tk.Sync, 1)
+		assert.Equal(t, "10.88.29.56::backup/data.zip", tk.Sync[0].Rsync)
+	})
+	t.Run("hdfs", func(t *testing.T) {
+		tk := &Task{}
+		err := ApplyOverrides(tk, map[string]interface{}{
+			"sync-mode":   "hdfs",
+			"sync-source": "hdfs://namenode:9000/data",
+		})
+		require.NoError(t, err)
+		require.Len(t, tk.Sync, 1)
+		assert.Equal(t, "hdfs://namenode:9000/data", tk.Sync[0].HDFS)
+	})
+}
+
+func TestApplyOverrides_SyncLocalPathFollowsWorkingDir(t *testing.T) {
+	tk := &Task{}
+	err := ApplyOverrides(tk, map[string]interface{}{
+		"sync-mode":   "git",
+		"sync-source": "https://github.com/kubeflow/arena.git",
+		"working-dir": "/workspace",
+	})
+	require.NoError(t, err)
+	require.Len(t, tk.Sync, 1)
+	assert.Equal(t, "/workspace/code", tk.Sync[0].LocalPath)
+}
+
+func TestApplyOverrides_SyncModeValidation(t *testing.T) {
+	t.Run("missing source", func(t *testing.T) {
+		err := ApplyOverrides(&Task{}, map[string]interface{}{"sync-mode": "git"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "--sync-source is required when --sync-mode is set")
+	})
+	t.Run("invalid mode", func(t *testing.T) {
+		err := ApplyOverrides(&Task{}, map[string]interface{}{
+			"sync-mode":   "svn",
+			"sync-source": "https://example.com/repo",
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `invalid --sync-mode "svn": must be git, rsync, or hdfs`)
+	})
+}
+
+func TestApplyOverrides_GPUTopology(t *testing.T) {
+	t.Run("implies host networking and topology labels", func(t *testing.T) {
+		tk := &Task{Worker: &Worker{Replicas: 2}}
+		err := ApplyOverrides(tk, map[string]interface{}{"gputopology": true})
+		require.NoError(t, err)
+		assert.True(t, tk.Framework.Options.GPUTopology)
+		assert.True(t, tk.HostNetwork, "gputopology implies host networking (v1 semantics)")
+		assert.Equal(t, "true", tk.Labels["gpu-topology"])
+		assert.Equal(t, "true", tk.Labels["gpu-topology-replica"])
+	})
+
+	t.Run("beats conflicting user label", func(t *testing.T) {
+		// User labels are applied before the gputopology branch, which sets
+		// the topology labels unconditionally — so gputopology must win over
+		// a user-supplied conflicting --label value.
+		tk := &Task{Worker: &Worker{Replicas: 2}}
+		err := ApplyOverrides(tk, map[string]interface{}{
+			"label":       []string{"gpu-topology=false"},
+			"gputopology": true,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "true", tk.Labels["gpu-topology"],
+			"gputopology must beat a conflicting user-supplied label")
+		assert.Equal(t, "true", tk.Labels["gpu-topology-replica"])
+	})
+}
+
+func TestApplyOverrides_V1DataSyntax(t *testing.T) {
+	t.Run("v1 two-part data mounts the named pvc", func(t *testing.T) {
+		tk := &Task{}
+		err := ApplyOverrides(tk, map[string]interface{}{"data": []string{"my-pvc:/data"}})
+		require.NoError(t, err)
+		require.Len(t, tk.Storages, 1)
+		s := tk.Storages[0]
+		assert.Equal(t, "my-pvc", s.Name)
+		assert.Equal(t, "my-pvc", s.PVC)
+		assert.Equal(t, "/data", s.MountPath)
+	})
+
+	t.Run("v2 three-part data unchanged", func(t *testing.T) {
+		tk := &Task{}
+		err := ApplyOverrides(tk, map[string]interface{}{"data": []string{"training-data:/data:my-pvc"}})
+		require.NoError(t, err)
+		require.Len(t, tk.Storages, 1)
+		s := tk.Storages[0]
+		assert.Equal(t, "training-data", s.Name)
+		assert.Equal(t, "my-pvc", s.PVC)
+		assert.Equal(t, "/data", s.MountPath)
+	})
+
+	t.Run("one-part data errors", func(t *testing.T) {
+		tk := &Task{}
+		err := ApplyOverrides(tk, map[string]interface{}{"data": []string{"justaname"}})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "justaname")
+	})
+
+	t.Run("relative mount path errors", func(t *testing.T) {
+		tk := &Task{}
+		err := ApplyOverrides(tk, map[string]interface{}{"data": []string{"my-pvc:data"}})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "absolute")
+	})
+
+	t.Run("v2 three-part data with relative mount path errors", func(t *testing.T) {
+		tk := &Task{}
+		err := ApplyOverrides(tk, map[string]interface{}{"data": []string{"training-data:data:my-pvc"}})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "absolute")
+	})
+}
+
+func TestApplyOverrides_V1DataDirSyntax(t *testing.T) {
+	t.Run("v1 one-part data-dir mounts hostpath at same path", func(t *testing.T) {
+		tk := &Task{}
+		err := ApplyOverrides(tk, map[string]interface{}{"data-dir": []string{"/data"}})
+		require.NoError(t, err)
+		require.Len(t, tk.Storages, 1)
+		s := tk.Storages[0]
+		assert.Equal(t, "training-data-0", s.Name)
+		assert.Equal(t, "/data", s.HostPath)
+		assert.Equal(t, "/data", s.MountPath)
+	})
+
+	t.Run("v1 two-part data-dir splits host and container paths", func(t *testing.T) {
+		tk := &Task{}
+		err := ApplyOverrides(tk, map[string]interface{}{"data-dir": []string{"/host/data:/container/data"}})
+		require.NoError(t, err)
+		require.Len(t, tk.Storages, 1)
+		s := tk.Storages[0]
+		assert.Equal(t, "training-data-0", s.Name)
+		assert.Equal(t, "/host/data", s.HostPath)
+		assert.Equal(t, "/container/data", s.MountPath)
+	})
+
+	t.Run("v2 three-part data-dir unchanged", func(t *testing.T) {
+		tk := &Task{}
+		err := ApplyOverrides(tk, map[string]interface{}{"data-dir": []string{"d:/c:/host"}})
+		require.NoError(t, err)
+		require.Len(t, tk.Storages, 1)
+		s := tk.Storages[0]
+		assert.Equal(t, "d", s.Name)
+		assert.Equal(t, "/host", s.HostPath)
+		assert.Equal(t, "/c", s.MountPath)
+	})
+
+	t.Run("relative host path errors", func(t *testing.T) {
+		tk := &Task{}
+		err := ApplyOverrides(tk, map[string]interface{}{"data-dir": []string{"data"}})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "absolute")
+	})
+
+	t.Run("v2 three-part data-dir with relative mount path errors", func(t *testing.T) {
+		tk := &Task{}
+		err := ApplyOverrides(tk, map[string]interface{}{"data-dir": []string{"d:c:/host"}})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "absolute")
+	})
+
+	t.Run("v2 three-part data-dir with relative host path errors", func(t *testing.T) {
+		tk := &Task{}
+		err := ApplyOverrides(tk, map[string]interface{}{"data-dir": []string{"d:/c:host"}})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "absolute")
+	})
+}
+
+func TestApplyOverrides_V1ConfigFileSyntax(t *testing.T) {
+	t.Run("v2 three-part configmap unchanged", func(t *testing.T) {
+		tk := &Task{}
+		err := ApplyOverrides(tk, map[string]interface{}{"config-file": []string{"cfg:/etc/app:my-cm"}})
+		require.NoError(t, err)
+		require.Len(t, tk.Storages, 1)
+		s := tk.Storages[0]
+		assert.Equal(t, "cfg", s.Name)
+		assert.Equal(t, "my-cm", s.ConfigMap)
+		assert.Equal(t, "/etc/app", s.MountPath)
+	})
+
+	t.Run("v2 three-part config-file with relative mount path errors", func(t *testing.T) {
+		tk := &Task{}
+		err := ApplyOverrides(tk, map[string]interface{}{"config-file": []string{"cfg:etc/app:my-cm"}})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "absolute")
+	})
+
+	t.Run("v1 two-part host file form errors with configmap guidance", func(t *testing.T) {
+		tk := &Task{}
+		err := ApplyOverrides(tk, map[string]interface{}{"config-file": []string{"/host/file.conf:/etc/file.conf"}})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not supported")
+		assert.Contains(t, err.Error(), "configmap")
+	})
+
+	t.Run("one-part config-file errors", func(t *testing.T) {
+		tk := &Task{}
+		err := ApplyOverrides(tk, map[string]interface{}{"config-file": []string{"/host/file.conf"}})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not supported")
+	})
+}
+
+func TestApplyOverrides_PerRoleLimitFlags(t *testing.T) {
+	tk := &Task{Framework: Framework{Name: "tensorflow"}, Worker: &Worker{Replicas: 1}}
+	err := ApplyOverrides(tk, map[string]interface{}{
+		"ps-cpu":           "1",
+		"ps-cpu-limit":     "2",
+		"worker-cpu":       "1",
+		"worker-cpu-limit": "3",
+	})
+	require.NoError(t, err)
+
+	require.NotNil(t, tk.PS)
+	assert.Equal(t, Resources{"cpu": "1"}, tk.PS.Resources)
+	assert.Equal(t, Resources{"cpu": "2"}, tk.PS.Limits)
+
+	assert.Equal(t, Resources{"cpu": "1"}, tk.Worker.Resources)
+	assert.Equal(t, Resources{"cpu": "3"}, tk.Worker.Limits)
+}
+
+func TestApplyOverrides_LimitFlagAlone(t *testing.T) {
+	tk := &Task{Framework: Framework{Name: "tensorflow"}, Worker: &Worker{Replicas: 1}}
+	err := ApplyOverrides(tk, map[string]interface{}{"worker-memory-limit": "16Gi"})
+	require.NoError(t, err)
+	assert.Empty(t, tk.Worker.Resources)
+	assert.Equal(t, Resources{"memory": "16Gi"}, tk.Worker.Limits)
 }

--- a/pkg/task/setter_test.go
+++ b/pkg/task/setter_test.go
@@ -915,7 +915,7 @@ worker:
 storages:
   - name: code
     mount_path: /workspace
-    pvc: code-pvc
+    tmp: 5Gi
 sync:
   - git: https://github.com/example/repo.git
     local_path: /workspace
@@ -994,7 +994,7 @@ worker:
 storages:
   - name: code
     mount_path: /workspace
-    pvc: code-pvc
+    tmp: 5Gi
 `)
 	result, err := ApplySetOverrides(yamlData, []string{
 		"sync[0].git=https://github.com/example/repo.git",

--- a/pkg/task/types.go
+++ b/pkg/task/types.go
@@ -3,6 +3,7 @@ package task
 import (
 	"errors"
 	"fmt"
+	"path"
 	"regexp"
 	"strconv"
 	"strings"
@@ -128,6 +129,7 @@ type FrameworkConfig struct {
 type Worker struct {
 	Replicas  int                 `yaml:"replicas"`
 	Resources Resources           `yaml:"resources,omitempty"`
+	Limits    Resources           `yaml:"limits,omitempty"`
 	Envs      map[string]EnvValue `yaml:"envs,omitempty"`
 	Run       string              `yaml:"run,omitempty"`
 }
@@ -139,12 +141,14 @@ type RoleConfig struct {
 	// Constrained roles (master, chief, launcher, evaluator) force replicas=1.
 	Replicas  int                 `yaml:"replicas,omitempty"`
 	Resources Resources           `yaml:"resources,omitempty"`
+	Limits    Resources           `yaml:"limits,omitempty"`
 	Envs      map[string]EnvValue `yaml:"envs,omitempty"`
 	Run       string              `yaml:"run,omitempty"`
 }
 
 // Resources maps K8s resource names to quantities. Values are applied to
-// both requests and limits (Guaranteed QoS).
+// both requests and limits (Guaranteed QoS). A separate Limits map on the
+// role overrides individual limit entries without touching requests.
 type Resources map[string]string
 
 // GangConfig controls gang scheduling behavior.
@@ -842,6 +846,23 @@ func validateSync(t *Task) error {
 				}
 			}
 		}
+		// Sync is a per-pod temporary pull: every pod of the job runs this
+		// init container, so a write target on a persistent or shared storage
+		// (pvc/hostpath) means concurrent writes, and configmap/secret volumes
+		// are read-only. Detection is local_path-based — only the storage the
+		// write actually lands on matters, not which storages are mounted.
+		if st, mp := ResolveSyncWriteTarget(s, t.Storages); st != nil {
+			switch {
+			case st.PVC != "":
+				return fmt.Errorf("sync[%d].local_path %q resolves to pvc storage %q (mount_path %q): PVC is persistent storage — preload data onto the PVC instead of pulling it per-pod with sync; sync targets must be tmp or shm storages", i, s.LocalPath, st.Name, mp)
+			case st.HostPath != "":
+				return fmt.Errorf("sync[%d].local_path %q resolves to hostpath storage %q (mount_path %q): hostPath is node-local storage shared by same-node pods and outlives the pod — not a sync target; sync targets must be tmp or shm storages", i, s.LocalPath, st.Name, mp)
+			case st.ConfigMap != "":
+				return fmt.Errorf("sync[%d].local_path %q resolves to configmap storage %q (mount_path %q): configMap volumes are read-only — sync cannot write to them; sync targets must be tmp or shm storages", i, s.LocalPath, st.Name, mp)
+			case st.Secret != "":
+				return fmt.Errorf("sync[%d].local_path %q resolves to secret storage %q (mount_path %q): secret volumes are read-only — sync cannot write to them; sync targets must be tmp or shm storages", i, s.LocalPath, st.Name, mp)
+			}
+		}
 	}
 
 	// TensorBoard mounts validation (identical to sync mount validation)
@@ -863,6 +884,105 @@ func validateSync(t *Task) error {
 		}
 	}
 	return nil
+}
+
+// ResolveSyncWriteTarget returns the storage whose effective mount path
+// contains the sync entry's local_path (longest match wins; nested mounts
+// shadow outer ones), or nil when local_path matches no mount and the data
+// lands on ephemeral container storage. mountPath is the effective mount
+// path of the match, which may come from an explicit mount's mount_path
+// override rather than the storage itself.
+func ResolveSyncWriteTarget(s SyncEntry, storages []Storage) (*Storage, string) {
+	type candidate struct {
+		storage   *Storage
+		mountPath string
+	}
+	var candidates []candidate
+
+	if len(s.Mounts) > 0 {
+		storageMap := make(map[string]Storage, len(storages))
+		for i := range storages {
+			storageMap[storages[i].Name] = storages[i]
+		}
+		for _, m := range s.Mounts {
+			if m.Name == "" {
+				continue
+			}
+			st, ok := storageMap[m.Name]
+			if !ok {
+				continue
+			}
+			mountPath := m.MountPath
+			if mountPath == "" {
+				mountPath = st.MountPath
+			}
+			candidates = append(candidates, candidate{storage: &st, mountPath: normalizeMountPath(mountPath)})
+		}
+	} else {
+		for i := range storages {
+			st := storages[i]
+			mountPath := st.MountPath
+			if mountPath == "" && st.SHM != "" {
+				mountPath = constants.DefaultSHMMountPath
+			}
+			candidates = append(candidates, candidate{storage: &st, mountPath: normalizeMountPath(mountPath)})
+		}
+	}
+
+	var best *candidate
+	for j := range candidates {
+		c := &candidates[j]
+		if !pathContains(c.mountPath, s.LocalPath) {
+			continue
+		}
+		if best == nil || len(c.mountPath) > len(best.mountPath) {
+			best = c
+		} else if len(c.mountPath) == len(best.mountPath) && isBannedStorage(c.storage) {
+			best = c
+		}
+	}
+	if best == nil {
+		return nil, ""
+	}
+	return best.storage, best.mountPath
+}
+
+// normalizeMountPath cleans a declared mount path for containment matching.
+// Trailing slashes and dot-dot components are resolved lexically so a
+// local_path like /tmp/../data is matched against where it actually lands,
+// not against its literal string.
+func normalizeMountPath(p string) string {
+	if p == "" {
+		return ""
+	}
+	return path.Clean(p)
+}
+
+// pathContains reports whether target is inside dir: equal to dir, or a
+// component-wise subpath of it. An empty dir matches nothing; "/" matches
+// everything. Both sides are cleaned first so dot-dot components and
+// trailing slashes cannot skew the containment check.
+func pathContains(dir, target string) bool {
+	dir = normalizeMountPath(dir)
+	if dir == "" {
+		return false
+	}
+	target = path.Clean(target)
+	if dir == "/" {
+		return true
+	}
+	if target == dir {
+		return true
+	}
+	return strings.HasPrefix(target, dir+"/")
+}
+
+// isBannedStorage reports whether the storage type may never be a sync write
+// target: pvc/hostpath are persistent or shared, configmap/secret are
+// read-only. Classification is conservative for malformed storages that
+// declare multiple types: any banned field wins.
+func isBannedStorage(st *Storage) bool {
+	return st.PVC != "" || st.HostPath != "" || st.ConfigMap != "" || st.Secret != ""
 }
 
 // validateRoles validates master, chief, launcher, evaluator, and PS roles.

--- a/pkg/task/types_test.go
+++ b/pkg/task/types_test.go
@@ -2175,3 +2175,305 @@ func TestParseDuration_InvalidInputs(t *testing.T) {
 		})
 	}
 }
+
+func TestResolveSyncWriteTarget(t *testing.T) {
+	storages := []Storage{
+		{Name: "dataset", MountPath: "/data", PVC: "data-pvc"},
+		{Name: "code", MountPath: "/workspace", Tmp: "5Gi"},
+	}
+
+	t.Run("exact match", func(t *testing.T) {
+		st, mp := ResolveSyncWriteTarget(SyncEntry{LocalPath: "/workspace"}, storages)
+		require.NotNil(t, st)
+		assert.Equal(t, "code", st.Name)
+		assert.Equal(t, "/workspace", mp)
+	})
+
+	t.Run("subpath match", func(t *testing.T) {
+		st, mp := ResolveSyncWriteTarget(SyncEntry{LocalPath: "/data/code"}, storages)
+		require.NotNil(t, st)
+		assert.Equal(t, "dataset", st.Name)
+		assert.Equal(t, "/data", mp)
+	})
+
+	t.Run("no match returns nil", func(t *testing.T) {
+		st, mp := ResolveSyncWriteTarget(SyncEntry{LocalPath: "/ephemeral"}, storages)
+		assert.Nil(t, st)
+		assert.Equal(t, "", mp)
+	})
+
+	t.Run("sibling path does not match", func(t *testing.T) {
+		st, _ := ResolveSyncWriteTarget(SyncEntry{LocalPath: "/database"}, storages)
+		assert.Nil(t, st, "prefix matching must be component-wise, not string-wise")
+	})
+
+	t.Run("longest match wins", func(t *testing.T) {
+		nested := []Storage{
+			{Name: "dataset", MountPath: "/data", PVC: "data-pvc"},
+			{Name: "code", MountPath: "/workspace", Tmp: "5Gi"},
+			{Name: "inner", MountPath: "/data/inner", Tmp: "1Gi"},
+		}
+		st, mp := ResolveSyncWriteTarget(SyncEntry{LocalPath: "/data/inner/x"}, nested)
+		require.NotNil(t, st)
+		assert.Equal(t, "inner", st.Name)
+		assert.Equal(t, "/data/inner", mp)
+	})
+
+	t.Run("explicit mount overrides mount path", func(t *testing.T) {
+		entry := SyncEntry{
+			LocalPath: "/code",
+			Mounts:    []Mount{{Name: "dataset", MountPath: "/code"}},
+		}
+		st, mp := ResolveSyncWriteTarget(entry, storages)
+		require.NotNil(t, st)
+		assert.Equal(t, "dataset", st.Name)
+		assert.Equal(t, "/code", mp)
+	})
+
+	t.Run("explicit mount falls back to storage mount path", func(t *testing.T) {
+		entry := SyncEntry{
+			LocalPath: "/workspace/src",
+			Mounts:    []Mount{{Name: "code"}},
+		}
+		st, mp := ResolveSyncWriteTarget(entry, storages)
+		require.NotNil(t, st)
+		assert.Equal(t, "code", st.Name)
+		assert.Equal(t, "/workspace", mp)
+	})
+
+	t.Run("explicit mounts exclude other storages", func(t *testing.T) {
+		entry := SyncEntry{
+			LocalPath: "/data/repo",
+			Mounts:    []Mount{{Name: "code"}},
+		}
+		st, _ := ResolveSyncWriteTarget(entry, storages)
+		assert.Nil(t, st, "only explicitly mounted storages are candidates")
+	})
+
+	t.Run("no mounts falls back to all storages", func(t *testing.T) {
+		st, _ := ResolveSyncWriteTarget(SyncEntry{LocalPath: "/data/repo"}, storages)
+		require.NotNil(t, st)
+		assert.Equal(t, "dataset", st.Name)
+	})
+
+	t.Run("shm defaults to /dev/shm in fallback", func(t *testing.T) {
+		shmOnly := []Storage{{Name: "shm", SHM: "1Gi"}}
+		st, mp := ResolveSyncWriteTarget(SyncEntry{LocalPath: "/dev/shm/x"}, shmOnly)
+		require.NotNil(t, st)
+		assert.Equal(t, "shm", st.Name)
+		assert.Equal(t, "/dev/shm", mp)
+	})
+
+	t.Run("no storages returns nil", func(t *testing.T) {
+		st, mp := ResolveSyncWriteTarget(SyncEntry{LocalPath: "/data"}, nil)
+		assert.Nil(t, st)
+		assert.Equal(t, "", mp)
+	})
+
+	t.Run("equal-length tie prefers banned storage", func(t *testing.T) {
+		tied := []Storage{
+			{Name: "a", MountPath: "/data", Tmp: "1Gi"},
+			{Name: "b", MountPath: "/data", PVC: "pvc"},
+		}
+		st, _ := ResolveSyncWriteTarget(SyncEntry{LocalPath: "/data/x"}, tied)
+		require.NotNil(t, st)
+		assert.Equal(t, "b", st.Name, "tie at equal mount path length must resolve to the banned storage")
+	})
+
+	t.Run("root mount matches everything", func(t *testing.T) {
+		root := []Storage{{Name: "root", MountPath: "/", PVC: "root-pvc"}}
+		st, mp := ResolveSyncWriteTarget(SyncEntry{LocalPath: "/anything"}, root)
+		require.NotNil(t, st)
+		assert.Equal(t, "root", st.Name)
+		assert.Equal(t, "/", mp)
+	})
+
+	t.Run("dot-dot in local_path resolves through the cleaned path", func(t *testing.T) {
+		st, _ := ResolveSyncWriteTarget(SyncEntry{LocalPath: "/tmp/../data"}, storages)
+		require.NotNil(t, st)
+		assert.Equal(t, "dataset", st.Name, "lexical resolution: /tmp/../data lands on /data (pvc), not /tmp")
+	})
+
+	t.Run("dot-dot in local_path staying inside the same mount still matches", func(t *testing.T) {
+		st, _ := ResolveSyncWriteTarget(SyncEntry{LocalPath: "/workspace/a/../b"}, storages)
+		require.NotNil(t, st)
+		assert.Equal(t, "code", st.Name)
+	})
+
+	t.Run("trailing slash on mount path still matches subpaths", func(t *testing.T) {
+		slash := []Storage{{Name: "dataset", MountPath: "/data/", PVC: "data-pvc"}}
+		st, mp := ResolveSyncWriteTarget(SyncEntry{LocalPath: "/data/code"}, slash)
+		require.NotNil(t, st)
+		assert.Equal(t, "dataset", st.Name)
+		assert.Equal(t, "/data", mp)
+	})
+}
+
+func TestValidateSyncBannedStorageTypes(t *testing.T) {
+	cases := []struct {
+		name    string
+		storage Storage
+		wantErr string
+	}{
+		{
+			name:    "pvc",
+			storage: Storage{Name: "dataset", MountPath: "/data", PVC: "data-pvc"},
+			wantErr: `sync[0].local_path "/data/code" resolves to pvc storage "dataset" (mount_path "/data"): PVC is persistent storage — preload data onto the PVC instead of pulling it per-pod with sync; sync targets must be tmp or shm storages`,
+		},
+		{
+			name:    "hostpath",
+			storage: Storage{Name: "local", MountPath: "/data", HostPath: "/mnt/ssd"},
+			wantErr: `sync[0].local_path "/data/code" resolves to hostpath storage "local" (mount_path "/data"): hostPath is node-local storage shared by same-node pods and outlives the pod — not a sync target; sync targets must be tmp or shm storages`,
+		},
+		{
+			name:    "configmap",
+			storage: Storage{Name: "cfg", MountPath: "/data", ConfigMap: "my-cm"},
+			wantErr: `sync[0].local_path "/data/code" resolves to configmap storage "cfg" (mount_path "/data"): configMap volumes are read-only — sync cannot write to them; sync targets must be tmp or shm storages`,
+		},
+		{
+			name:    "secret",
+			storage: Storage{Name: "sec", MountPath: "/data", Secret: "my-secret"},
+			wantErr: `sync[0].local_path "/data/code" resolves to secret storage "sec" (mount_path "/data"): secret volumes are read-only — sync cannot write to them; sync targets must be tmp or shm storages`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tk := &Task{
+				Name:      "t",
+				Image:     "x:1",
+				Run:       "train",
+				Framework: Framework{Name: "pytorch"},
+				Worker:    &Worker{Replicas: 1},
+				Storages:  []Storage{tc.storage},
+				Sync:      []SyncEntry{{Git: "https://github.com/org/repo.git", LocalPath: "/data/code"}},
+			}
+			err := Validate(tk)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+}
+
+func TestValidateSyncStorageRules(t *testing.T) {
+	newTask := func(storages []Storage, sync []SyncEntry) *Task {
+		return &Task{
+			Name:      "t",
+			Image:     "x:1",
+			Run:       "train",
+			Framework: Framework{Name: "pytorch"},
+			Worker:    &Worker{Replicas: 1},
+			Storages:  storages,
+			Sync:      sync,
+		}
+	}
+	git := func(localPath string, mounts ...Mount) SyncEntry {
+		return SyncEntry{Git: "https://github.com/org/repo.git", LocalPath: localPath, Mounts: mounts}
+	}
+
+	t.Run("tmp storage allowed", func(t *testing.T) {
+		err := Validate(newTask(
+			[]Storage{{Name: "code", MountPath: "/workspace", Tmp: "5Gi"}},
+			[]SyncEntry{git("/workspace/src")},
+		))
+		assert.NoError(t, err)
+	})
+
+	t.Run("shm storage allowed", func(t *testing.T) {
+		err := Validate(newTask(
+			[]Storage{{Name: "shm", SHM: "1Gi"}},
+			[]SyncEntry{git("/dev/shm/code")},
+		))
+		assert.NoError(t, err)
+	})
+
+	t.Run("mount referencing pvc with local_path elsewhere is allowed", func(t *testing.T) {
+		err := Validate(newTask(
+			[]Storage{{Name: "dataset", MountPath: "/data", PVC: "data-pvc"}},
+			[]SyncEntry{git("/ephemeral/code", Mount{Name: "dataset"})},
+		))
+		assert.NoError(t, err, "detection is write-target-based; a mounted-but-unwritten pvc is not an error")
+	})
+
+	t.Run("fallback mounts pvc and local_path lands on it", func(t *testing.T) {
+		err := Validate(newTask(
+			[]Storage{
+				{Name: "dataset", MountPath: "/data", PVC: "data-pvc"},
+				{Name: "code", MountPath: "/workspace", Tmp: "5Gi"},
+			},
+			[]SyncEntry{git("/data/repo")},
+		))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `resolves to pvc storage "dataset"`)
+	})
+
+	t.Run("fallback mounts pvc but local_path elsewhere is allowed", func(t *testing.T) {
+		err := Validate(newTask(
+			[]Storage{
+				{Name: "dataset", MountPath: "/data", PVC: "data-pvc"},
+				{Name: "code", MountPath: "/workspace", Tmp: "5Gi"},
+			},
+			[]SyncEntry{git("/workspace/repo")},
+		))
+		assert.NoError(t, err)
+	})
+
+	t.Run("nested tmp beats outer pvc", func(t *testing.T) {
+		err := Validate(newTask(
+			[]Storage{
+				{Name: "dataset", MountPath: "/data", PVC: "data-pvc"},
+				{Name: "inner", MountPath: "/data/inner", Tmp: "1Gi"},
+			},
+			[]SyncEntry{git("/data/inner/repo")},
+		))
+		assert.NoError(t, err)
+	})
+
+	t.Run("error reports the offending sync index", func(t *testing.T) {
+		err := Validate(newTask(
+			[]Storage{{Name: "dataset", MountPath: "/data", PVC: "data-pvc"}},
+			[]SyncEntry{git("/ephemeral/code"), git("/data/repo")},
+		))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "sync[1].local_path")
+	})
+
+	t.Run("mount_path override is reported in the error", func(t *testing.T) {
+		err := Validate(newTask(
+			[]Storage{{Name: "dataset", MountPath: "/data", PVC: "data-pvc"}},
+			[]SyncEntry{git("/workspace/repo", Mount{Name: "dataset", MountPath: "/workspace"})},
+		))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `(mount_path "/workspace")`)
+	})
+}
+
+func TestTaskYAML_LimitsOverlay(t *testing.T) {
+	yamlContent := `version: 0.1.0
+name: limits-job
+image: pytorch:2.1
+framework:
+  name: pytorch
+worker:
+  replicas: 2
+  resources:
+    cpu: "1"
+    memory: 4Gi
+  limits:
+    cpu: "2"
+master:
+  resources:
+    cpu: "1"
+  limits:
+    memory: 8Gi
+run: python train.py
+`
+	var tk Task
+	err := yaml.Unmarshal([]byte(yamlContent), &tk)
+	require.NoError(t, err)
+	require.NotNil(t, tk.Worker)
+	assert.Equal(t, Resources{"cpu": "1", "memory": "4Gi"}, tk.Worker.Resources)
+	assert.Equal(t, Resources{"cpu": "2"}, tk.Worker.Limits)
+	require.NotNil(t, tk.Master)
+	assert.Equal(t, Resources{"cpu": "1"}, tk.Master.Resources)
+	assert.Equal(t, Resources{"memory": "8Gi"}, tk.Master.Limits)
+}

--- a/test/e2e/mpi_test.go
+++ b/test/e2e/mpi_test.go
@@ -10,6 +10,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"os"
 	"os/exec"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -135,5 +136,147 @@ var _ = Describe("MPI-based Jobs", func() {
 
 	It("DeepSpeed job lifecycle", func() {
 		frameworkLifecycle("deepspeed", busyboxImage())
+	})
+})
+
+const mpiLauncherPVCYAML = `apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: mpi-e2e-pvc
+  namespace: default
+spec:
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      storage: 1Gi
+`
+
+// mounts_on_launcher=false: all volumes stay declared on the launcher pod
+// (init containers may reference them) but the launcher main container
+// mounts nothing.
+var _ = Describe("MPI launcher volume policy", func() {
+	var namespace string
+
+	BeforeEach(func() {
+		namespace = "default"
+		var out bytes.Buffer
+		cmd := exec.Command("kubectl", "apply", "-f", "-")
+		cmd.Stdin = bytes.NewReader([]byte(mpiLauncherPVCYAML))
+		cmd.Stdout = &out
+		cmd.Stderr = &out
+		Expect(cmd.Run()).NotTo(HaveOccurred(),
+			"kubectl apply pvc failed: %s", out.String())
+	})
+
+	AfterEach(func() {
+		var out bytes.Buffer
+		delCmd := exec.Command(arenaV2Bin, "job", "delete", "test-mpi-mounts",
+			"--namespace", namespace)
+		delCmd.Stdout = &out
+		delCmd.Stderr = &out
+		_ = delCmd.Run()
+
+		out.Reset()
+		pvcCmd := exec.Command("kubectl", "delete", "pvc", "mpi-e2e-pvc",
+			"-n", namespace, "--ignore-not-found")
+		pvcCmd.Stdout = &out
+		pvcCmd.Stderr = &out
+		_ = pvcCmd.Run()
+	})
+
+	names := func(field string, holder map[string]interface{}) []string {
+		items, ok := holder[field].([]interface{})
+		if !ok {
+			return nil
+		}
+		result := make([]string, 0, len(items))
+		for _, item := range items {
+			if m, ok := item.(map[string]interface{}); ok {
+				if name, ok := m["name"].(string); ok {
+					result = append(result, name)
+				}
+			}
+		}
+		return result
+	}
+
+	It("should keep volumes on launcher but clear main container mounts when mounts_on_launcher=false", func() {
+		jobYAML := fmt.Sprintf(`version: 0.1.0
+name: test-mpi-mounts
+framework:
+  name: mpi
+  options:
+    mounts_on_launcher: false
+image: %s
+run: sleep 3600
+worker:
+  replicas: 1
+  resources:
+    cpu: 1
+    memory: 1Gi
+storages:
+  - name: dataset
+    pvc: mpi-e2e-pvc
+    mount_path: /data
+  - name: cache
+    tmp: 1Gi
+    mount_path: /cache
+init:
+  - name: setup
+    image: %s
+    run: echo hi
+    mounts:
+      - name: dataset
+`, busyboxImage(), busyboxImage())
+
+		By("Submitting an MPI job with PVC + tmp storages")
+		yamlPath, err := createTempYAML(jobYAML)
+		Expect(err).NotTo(HaveOccurred())
+		defer os.Remove(yamlPath)
+
+		var out bytes.Buffer
+		runCmd := exec.Command(arenaV2Bin, "job", "run", "-f",
+			yamlPath, "--namespace", namespace)
+		runCmd.Stdout = &out
+		runCmd.Stderr = &out
+		Expect(runCmd.Run()).NotTo(HaveOccurred(),
+			"job run failed: %s", out.String())
+
+		By("Fetching the MPIJob CRD")
+		out.Reset()
+		getCmd := exec.Command("kubectl", "get", "mpijob", "test-mpi-mounts",
+			"-n", namespace, "-o", "json")
+		getCmd.Stdout = &out
+		getCmd.Stderr = &out
+		Expect(getCmd.Run()).NotTo(HaveOccurred(),
+			"kubectl get mpijob failed: %s", out.String())
+
+		var crd map[string]interface{}
+		Expect(json.Unmarshal(out.Bytes(), &crd)).NotTo(HaveOccurred())
+
+		spec := crd["spec"].(map[string]interface{})
+		replicaSpecs := spec["mpiReplicaSpecs"].(map[string]interface{})
+
+		By("Verifying launcher keeps all volumes but the main container mounts nothing")
+		launcher := replicaSpecs["Launcher"].(map[string]interface{})
+		launcherPod := launcher["template"].(map[string]interface{})["spec"].(map[string]interface{})
+		Expect(names("volumes", launcherPod)).To(ConsistOf("dataset", "cache"),
+			"launcher should keep all volumes declared (init containers may reference them)")
+
+		launcherContainers := launcherPod["containers"].([]interface{})
+		launcherMain := launcherContainers[0].(map[string]interface{})
+		Expect(names("volumeMounts", launcherMain)).To(BeEmpty(),
+			"launcher main container should have no volumeMounts when mounts_on_launcher=false")
+
+		launcherInits := launcherPod["initContainers"].([]interface{})
+		launcherInit := launcherInits[0].(map[string]interface{})
+		Expect(names("volumeMounts", launcherInit)).To(ConsistOf("dataset"),
+			"init container mounts must never be rewritten")
+
+		By("Verifying worker keeps all volumes")
+		worker := replicaSpecs["Worker"].(map[string]interface{})
+		workerPod := worker["template"].(map[string]interface{})["spec"].(map[string]interface{})
+		Expect(names("volumes", workerPod)).To(ConsistOf("dataset", "cache"),
+			"worker should keep both volumes")
 	})
 })

--- a/test/e2e/submit_dryrun_test.go
+++ b/test/e2e/submit_dryrun_test.go
@@ -100,7 +100,7 @@ var _ = Describe("Submit flags (dry-run)", func() {
 			"--namespace", namespace,
 			"--image", "docker.io/library/tensorflow:2.15",
 			"--workers", "2",
-			"--ps-count", "1",
+			"--ps", "1",
 			"--chief",
 			"--evaluator",
 			"python train.py")
@@ -126,15 +126,15 @@ var _ = Describe("Submit flags (dry-run)", func() {
 		Expect(replicaSpecs).To(HaveKey("Launcher"))
 	})
 
-	It("submit with resource flags --gpus --cpus --mem", func() {
+	It("submit with resource flags --gpus --cpu --memory", func() {
 		crd := runSubmitDryRun("pytorch",
 			"--name", jobName,
 			"--namespace", namespace,
 			"--image", "docker.io/library/pytorch:2.1",
 			"--workers", "1",
 			"--gpus", "2",
-			"--cpus", "4",
-			"--mem", "8Gi",
+			"--cpu", "4",
+			"--memory", "8Gi",
 			"python train.py")
 
 		replicaSpecs := getReplicaSpecs(crd, "pytorchReplicaSpecs")
@@ -209,29 +209,29 @@ var _ = Describe("Submit flags (dry-run)", func() {
 		Expect(tol["effect"]).To(Equal("NoSchedule"))
 	})
 
-	It("submit with --priority", func() {
+	It("submit with --priority (priority class name)", func() {
 		crd := runSubmitDryRun("pytorch",
 			"--name", jobName,
 			"--namespace", namespace,
 			"--image", "docker.io/library/pytorch:2.1",
 			"--workers", "1",
-			"--priority", "10",
+			"--priority", "high-priority",
 			"python train.py")
 
 		replicaSpecs := getReplicaSpecs(crd, "pytorchReplicaSpecs")
 		master := replicaSpecs["Master"].(map[string]interface{})
 		template := master["template"].(map[string]interface{})
 		podSpec := template["spec"].(map[string]interface{})
-		Expect(podSpec["priority"]).To(BeNumerically("==", 10))
+		Expect(podSpec["priorityClassName"]).To(Equal("high-priority"))
 	})
 
-	It("submit with --scheduler-name", func() {
+	It("submit with --scheduler", func() {
 		crd := runSubmitDryRun("pytorch",
 			"--name", jobName,
 			"--namespace", namespace,
 			"--image", "docker.io/library/pytorch:2.1",
 			"--workers", "1",
-			"--scheduler-name", "volcano",
+			"--scheduler", "volcano",
 			"python train.py")
 
 		replicaSpecs := getReplicaSpecs(crd, "pytorchReplicaSpecs")
@@ -357,13 +357,13 @@ run: python train.py
 		Expect(foundMount).To(BeTrue(), "PVC volumeMount not found in container")
 	})
 
-	It("submit with --shm shared memory", func() {
+	It("submit with --share-memory shared memory", func() {
 		crd := runSubmitDryRun("pytorch",
 			"--name", jobName,
 			"--namespace", namespace,
 			"--image", "docker.io/library/pytorch:2.1",
 			"--workers", "1",
-			"--shm", "1Gi",
+			"--share-memory", "1Gi",
 			"python train.py")
 
 		replicaSpecs := getReplicaSpecs(crd, "pytorchReplicaSpecs")
@@ -397,13 +397,13 @@ run: python train.py
 		Expect(foundMount).To(BeTrue(), "SHM volumeMount not found in container")
 	})
 
-	It("submit with --host-network", func() {
+	It("submit with --hostNetwork", func() {
 		crd := runSubmitDryRun("pytorch",
 			"--name", jobName,
 			"--namespace", namespace,
 			"--image", "docker.io/library/pytorch:2.1",
 			"--workers", "1",
-			"--host-network",
+			"--hostNetwork",
 			"python train.py")
 
 		replicaSpecs := getReplicaSpecs(crd, "pytorchReplicaSpecs")
@@ -430,5 +430,63 @@ run: python train.py
 		Expect(secrets).To(HaveLen(1))
 		secret := secrets[0].(map[string]interface{})
 		Expect(secret["name"]).To(Equal("my-registry-secret"))
+	})
+
+	It("v1 two-part --data mounts the named PVC", func() {
+		crd := runSubmitDryRun("pytorch",
+			"--name", jobName,
+			"--namespace", namespace,
+			"--image", "docker.io/library/pytorch:2.1",
+			"--workers", "1",
+			"--data", "my-pvc:/data",
+			"python train.py")
+
+		replicaSpecs := getReplicaSpecs(crd, "pytorchReplicaSpecs")
+		master := replicaSpecs["Master"].(map[string]interface{})
+		template := master["template"].(map[string]interface{})
+		podSpec := template["spec"].(map[string]interface{})
+
+		volumes := podSpec["volumes"].([]interface{})
+		foundPVC := false
+		for _, v := range volumes {
+			vol := v.(map[string]interface{})
+			if vol["name"] == "my-pvc" {
+				pvc := vol["persistentVolumeClaim"].(map[string]interface{})
+				Expect(pvc["claimName"]).To(Equal("my-pvc"))
+				foundPVC = true
+			}
+		}
+		Expect(foundPVC).To(BeTrue(), "v1 --data should mount the PVC named by the first field")
+
+		container := getFirstContainer(master)
+		mounts := container["volumeMounts"].([]interface{})
+		foundMount := false
+		for _, m := range mounts {
+			mnt := m.(map[string]interface{})
+			if mnt["name"] == "my-pvc" {
+				Expect(mnt["mountPath"]).To(Equal("/data"))
+				foundMount = true
+			}
+		}
+		Expect(foundMount).To(BeTrue())
+	})
+
+	It("TF per-role -limit flags split requests and limits", func() {
+		crd := runSubmitDryRun("tensorflow",
+			"--name", jobName,
+			"--namespace", namespace,
+			"--image", "docker.io/library/tensorflow:2.15",
+			"--workers", "1",
+			"--worker-cpu", "1",
+			"--worker-cpu-limit", "2",
+			"python train.py")
+
+		replicaSpecs := getReplicaSpecs(crd, "tfReplicaSpecs")
+		worker := replicaSpecs["Worker"].(map[string]interface{})
+		container := getFirstContainer(worker)
+
+		resources := container["resources"].(map[string]interface{})
+		Expect(resources["requests"].(map[string]interface{})["cpu"]).To(Equal("1"))
+		Expect(resources["limits"].(map[string]interface{})["cpu"]).To(Equal("2"))
 	})
 })

--- a/test/e2e/tensorboard_e2e_test.go
+++ b/test/e2e/tensorboard_e2e_test.go
@@ -38,7 +38,7 @@ var _ = Describe("TensorBoard", func() {
 			"--image", "docker.io/library/pytorch:2.1",
 			"--workers", "1",
 			"--tensorboard",
-			"--tensorboard-logdir", "/logs",
+			"--logdir", "/logs",
 			"--dry-run",
 			"python train.py")
 		cmd.Stdout = &stdout


### PR DESCRIPTION
## Purpose of this PR

Existing v1 scripts break against `arena-v2 submit` because v2 only registered a reduced flag surface. This PR restores the v1 flag compatibility layer so `arena submit <type> --flags` invocations work unchanged, and moves flag semantics out of the CLI layer into `task.ApplyOverrides`.

**Proposed changes:**

- Restore v1 flag names on `arena-v2 submit` (`--cpu`/`--memory` aliases, `--share-memory`, `-p` as priority class name, boolean `--queue`, `--sync-mode`/`--sync-source`/`--sync-image`, TF per-role resource flags, `--retry`, etc.); flag declarations moved into `pkg/cli/submit_flags.go`
- Move flag semantics into `task.ApplyOverrides` so `pkg/cli/submit.go` only parses flags and delegates
- Add `task.ResolveSyncWriteTarget`: sync write targets are matched against mounted storages (longest-prefix path match wins) and rejected when they land on pvc/hostpath (persistent/shared) or configmap/secret (read-only)
- Providers embed JSON-native `[]interface{}` slices to fix apimachinery deep-copy panics on override values
- MPI launcher keeps volumes declared while clearing only the main container's volume mounts when `mounts_on_launcher=false`
- Docs: update `cli-reference.md`, `migration.md`, `yaml-schema.md`, `best-practices.md` for the restored flags
- Tests: new unit tests for submit flags, sync write target resolution, MPI volume handling, and task types; new MPI e2e test

## Commit Message Format

This project uses [conventional commits](https://www.conventionalcommits.org/) for commit hygiene. The release changelog is driven by PR labels, which are auto-assigned based on your branch name prefix and changed files.

**Example commit messages:**

```
feat: add GPU sharing support for MPIJob
fix: correct pytorch replica count in dry-run output
feat(serving): add vLLM as serving framework
docs: update installation guide for v2
```

> **Note:** PR labels are auto-assigned by the Labeler workflow based on your branch name prefix and changed files. This determines how your change appears in the release changelog — `feat/` branch → Features, `fix/` branch → Bug Fixes, `breaking/` branch → Breaking Changes, `doc/` or `docs/` branch or all files in `docs/`/`examples/` → Documentation, `chore/` or `chores/` branch → Maintenance, `refactor/` branch → Refactoring, `test/`/`ci/` branch, all files are `.github/` CI configs, or only `VERSION` changed → excluded.

## Checklist

- [x] Code follows the project's style guidelines (`make v2-fmt`)
- [x] Code passes vet (`make v2-vet`)
- [x] Code passes lint (`make v2-lint`)
- [x] Tests pass (`make v2-test`)
- [x] `go mod tidy` has been run
- [x] Commit messages follow conventional commit format