### PR TITLE
feat(cli): agent-native CLI

### DIFF
--- a/cmd/arena-v2/main.go
+++ b/cmd/arena-v2/main.go
@@ -11,29 +11,39 @@ import (
 
 func main() {
 	if err := cli.Execute(); err != nil {
-		fmt.Fprint(os.Stderr, formatError(err, cli.DebugMode()))
+		fmt.Fprint(os.Stderr, formatError(err, cli.DebugMode(), cli.JSONErrorRequested()))
 		os.Exit(1)
 	}
 }
 
-// formatError formats an error for display to the user.
-// If debug is true, includes full error chain.
-func formatError(err error, debug bool) string {
-	var sb strings.Builder
+// formatError formats an error for display to the user. In machine-readable
+// mode (-o json/yaml) every error renders as a JSON envelope so stderr stays
+// parseable; otherwise the error renders as prose. Debug mode appends the
+// full error chain.
+func formatError(err error, debug, jsonMode bool) string {
+	if jsonMode {
+		s := cli.ErrorEnvelope(err)
+		if debug {
+			s += errorChain(err)
+		}
+		return s
+	}
 
+	var sb strings.Builder
 	sb.WriteString("Error: ")
 	sb.WriteString(err.Error())
 	sb.WriteString("\n")
-
-	// In debug mode, show the full error chain
 	if debug {
-		sb.WriteString("\nFull error chain:\n")
-		current := err
-		for current != nil {
-			fmt.Fprintf(&sb, "  - %v\n", current)
-			current = errors.Unwrap(current)
-		}
+		sb.WriteString(errorChain(err))
 	}
+	return sb.String()
+}
 
+func errorChain(err error) string {
+	var sb strings.Builder
+	sb.WriteString("\nFull error chain:\n")
+	for current := err; current != nil; current = errors.Unwrap(current) {
+		fmt.Fprintf(&sb, "  - %v\n", current)
+	}
 	return sb.String()
 }

--- a/cmd/arena-v2/main_test.go
+++ b/cmd/arena-v2/main_test.go
@@ -3,33 +3,58 @@ package main
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/kubeflow/arena/pkg/cli"
 )
 
-func TestFormatError_BasicError(t *testing.T) {
-	err := errors.New("simple error")
-
-	result := formatError(err, false)
-	assert.Equal(t, "Error: simple error\n", result)
+func TestFormatError_PlainError(t *testing.T) {
+	assert.Equal(t, "Error: boom\n", formatError(errors.New("boom"), false, false))
 }
 
-func TestFormatError_WrappedError(t *testing.T) {
-	innerErr := errors.New("connection refused")
-	middleErr := fmt.Errorf("failed to connect: %w", innerErr)
-	outerErr := fmt.Errorf("failed to create client: %w", middleErr)
-
-	result := formatError(outerErr, false)
-	assert.Contains(t, result, "Error: failed to create client")
-	assert.Contains(t, result, "failed to connect")
-	assert.Contains(t, result, "connection refused")
+func TestFormatError_CLIErrorText(t *testing.T) {
+	err := &cli.CLIError{Message: "invalid value", ValidValues: []string{"a", "b"}}
+	assert.Equal(t, "Error: invalid value; must be one of: a, b\n", formatError(err, false, false))
 }
 
-func TestFormatError_DebugMode(t *testing.T) {
-	err := errors.New("test error")
+func TestFormatError_CLIErrorJSONEnvelope(t *testing.T) {
+	err := &cli.CLIError{Message: "invalid value", ValidValues: []string{"json", "yaml"}}
+	out := formatError(err, false, true)
+	assert.Contains(t, out, `"message": "invalid value"`)
+	assert.Contains(t, out, `"validValues": [`)
+	assert.NotContains(t, out, "Error:")
+	assert.True(t, strings.HasSuffix(out, "\n"), "envelope ends with newline")
+}
 
-	result := formatError(err, true)
-	assert.Contains(t, result, "Error: test error")
-	assert.Contains(t, result, "Full error chain:")
+func TestFormatError_NonCLIErrorInJSONModeRendersEnvelope(t *testing.T) {
+	out := formatError(errors.New("api failure"), false, true)
+	assert.Contains(t, out, `"message": "api failure"`)
+	assert.NotContains(t, out, "Error:", "JSON mode must not render prose errors")
+	assert.True(t, strings.HasSuffix(out, "\n"), "envelope ends with newline")
+}
+
+func TestFormatError_WrappedErrorInJSONModeRendersEnvelope(t *testing.T) {
+	err := fmt.Errorf("failed to create K8s client: %w", errors.New("no such file"))
+	out := formatError(err, false, true)
+	assert.Contains(t, out, `"message": "failed to create K8s client: no such file"`)
+	assert.NotContains(t, out, "Error:")
+}
+
+func TestFormatError_DebugChain(t *testing.T) {
+	err := fmt.Errorf("outer: %w", errors.New("root cause"))
+	out := formatError(err, true, false)
+	assert.Contains(t, out, "Error: outer: root cause\n")
+	assert.Contains(t, out, "Full error chain:")
+	assert.Contains(t, out, "  - outer: root cause\n")
+	assert.Contains(t, out, "  - root cause\n")
+}
+
+func TestFormatError_CLIErrorJSONWithDebugChain(t *testing.T) {
+	err := &cli.CLIError{Message: "invalid value"}
+	out := formatError(err, true, true)
+	assert.Contains(t, out, `"message": "invalid value"`)
+	assert.Contains(t, out, "Full error chain:")
 }

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -18,11 +18,9 @@ These flags are available on all commands.
 
 ## arena job
 
-Parent command for managing training jobs. All subcommands inherit the following persistent flag.
+Parent command for managing training jobs. The group defines no persistent flags of its own.
 
-| Flag | Shorthand | Type | Default | Description |
-|------|-----------|------|---------|-------------|
-| `--output` | `-o` | string | `table` | Output format: `table`, `wide`, `json`, `yaml` |
+Each leaf command that produces structured output registers its own local `-o/--output` flag (`table`, `wide`, `json`, `yaml`; default `table`): `job run`, `job get`, `job status`, `job list`, `job delete`, `job suspend`, `job resume`, and the `arena submit` framework subcommands. `arena job logs` deliberately has no `-o` flag — it streams raw log content directly.
 
 Supported frameworks: `pytorch`, `tensorflow`, `mpi`, `horovod`, `deepspeed`.
 
@@ -45,8 +43,9 @@ arena job run -f <file> [flags]
 | `--file` | `-f` | string | `""` | Path to YAML file (required) |
 | `--dry-run` | | bool | `false` | Print CRD as JSON or YAML without submitting |
 | `--set` | | stringArray | `nil` | Override YAML field (Helm-style: `key=value`, repeatable) |
+| `--output` | `-o` | string | `table` | Output format: `table`, `wide`, `json`, `yaml` |
 
-Also inherits [global flags](#global-flags) and `--output` from `arena job`.
+Also inherits [global flags](#global-flags).
 
 ### Examples
 
@@ -67,7 +66,7 @@ $ arena job run -f examples/v2/quickstart/pytorch-simple.yaml --dry-run
 Job pytorch-simple submitted successfully
 ```
 
-With `--dry-run`, the generated CRD is printed as indented JSON (default) or YAML (`-o yaml`). If TensorBoard is enabled, the Deployment and Service resources are also printed, separated by `---`.
+With `--dry-run`, the generated CRD is printed as indented JSON (default) or YAML (`-o yaml`). If TensorBoard is enabled, the Deployment and Service resources are also printed, separated by `---`. Without `--dry-run`, `-o json` or `-o yaml` renders a structured submit result instead of the one-line confirmation.
 
 ---
 
@@ -83,7 +82,16 @@ arena job list [flags]
 
 ### Flags
 
-This command has no flags of its own. It inherits [global flags](#global-flags) and `--output` from `arena job`.
+| Flag | Shorthand | Type | Default | Description |
+|------|-----------|------|---------|-------------|
+| `--all-namespaces` | `-A` | bool | `false` | List jobs across all namespaces; silently overrides `-n` and adds a leading `NAMESPACE` column to table output |
+| `--selector` | `-l` | string | `""` | Label selector (kubectl syntax, AND-combined with arena's job scope) |
+| `--type` | | string | `""` | Show only jobs of this framework type |
+| `--status` | | string | `""` | Show only jobs in this status phase |
+| `--last` | | int | `50` | Number of most recent jobs to show (0 = unlimited) |
+| `--output` | `-o` | string | `table` | Output format: `table`, `wide`, `json`, `yaml` |
+
+Also inherits [global flags](#global-flags).
 
 ### Examples
 
@@ -93,6 +101,17 @@ $ arena job list
 
 # List jobs in a specific namespace
 $ arena job list -n kubeflow
+
+# List jobs across all namespaces (overrides -n; adds a NAMESPACE column)
+$ arena job list -A
+
+# Narrow by framework type, status phase, or label selector
+$ arena job list --type pytorch
+$ arena job list --status Running
+$ arena job list -l env=prod
+
+# Show only the 10 most recent jobs
+$ arena job list --last 10
 
 # Wide output with additional columns
 $ arena job list -o wide
@@ -112,6 +131,14 @@ tf-distributed    Succeeded  3/3        1h
 mpi-test          Pending    0/2        10s
 ```
 
+With `-A/--all-namespaces`, a leading `NAMESPACE` column is added:
+
+```text
+NAMESPACE   NAME              STATUS     REPLICAS   AGE
+default     pytorch-simple    Running    1/1        5m
+kubeflow    tf-distributed    Succeeded  3/3        1h
+```
+
 Wide format (`-o wide`) adds `NAMESPACE`, `APIVERSION`, `FRAMEWORK`, and `GPU` columns:
 
 ```text
@@ -120,6 +147,8 @@ pytorch-simple    default     Running    kubeflow.org/v1     pytorch     1     1
 tf-distributed    default     Succeeded  kubeflow.org/v1     tensorflow  0     3/3        1h
 mpi-test          default     Pending    kubeflow.org/v1     mpi         2     0/2        10s
 ```
+
+By default the 50 most recent jobs are shown (`--last`, `0` = unlimited). When entries are dropped, a narrowing hint (`Showing N of M jobs...`) is printed to stderr.
 
 When no jobs exist:
 
@@ -150,8 +179,9 @@ arena job get <name> [flags]
 | Flag | Shorthand | Type | Default | Description |
 |------|-----------|------|---------|-------------|
 | `--details` | | bool | `false` | Show job configuration details (from the stored YAML) |
+| `--output` | `-o` | string | `table` | Output format: `table`, `wide`, `json`, `yaml` |
 
-Also inherits [global flags](#global-flags) and `--output` from `arena job`.
+Also inherits [global flags](#global-flags).
 
 ### Examples
 
@@ -218,7 +248,7 @@ arena job logs <name> [flags]
 | `--pod` | | string | `""` | Pod name (skip label selector) |
 | `--container` | | string | `""` | Container name (default: first container) |
 
-Also inherits [global flags](#global-flags) and `--output` from `arena job`.
+Also inherits [global flags](#global-flags). Unlike the other `job` subcommands, `logs` has no `-o/--output` flag — the raw log content is streamed directly, so `arena job logs <name> -o json` is rejected.
 
 ### Examples
 
@@ -260,7 +290,11 @@ arena job suspend <name>
 
 ### Flags
 
-This command has no flags of its own. It inherits [global flags](#global-flags) and `--output` from `arena job`.
+| Flag | Shorthand | Type | Default | Description |
+|------|-----------|------|---------|-------------|
+| `--output` | `-o` | string | `table` | Output format: `table`, `wide`, `json`, `yaml` |
+
+Also inherits [global flags](#global-flags). With `-o json` or `-o yaml`, a structured action result is rendered instead of the one-line confirmation.
 
 ### Examples
 
@@ -294,7 +328,11 @@ arena job resume <name>
 
 ### Flags
 
-This command has no flags of its own. It inherits [global flags](#global-flags) and `--output` from `arena job`.
+| Flag | Shorthand | Type | Default | Description |
+|------|-----------|------|---------|-------------|
+| `--output` | `-o` | string | `table` | Output format: `table`, `wide`, `json`, `yaml` |
+
+Also inherits [global flags](#global-flags). With `-o json` or `-o yaml`, a structured action result is rendered instead of the one-line confirmation.
 
 ### Examples
 
@@ -332,8 +370,9 @@ arena job delete -f <file> [flags]
 | Flag | Shorthand | Type | Default | Description |
 |------|-----------|------|---------|-------------|
 | `--file` | `-f` | string | `""` | Path to YAML file (extracts job name from file) |
+| `--output` | `-o` | string | `table` | Output format: `table`, `wide`, `json`, `yaml` |
 
-Also inherits [global flags](#global-flags) and `--output` from `arena job`.
+Also inherits [global flags](#global-flags). With `-o json` or `-o yaml`, a structured action result is rendered instead of the one-line confirmation.
 
 ### Examples
 
@@ -377,8 +416,9 @@ arena job status <name> [flags]
 | Flag | Shorthand | Type | Default | Description |
 |------|-----------|------|---------|-------------|
 | `--details` | | bool | `false` | Show job configuration details |
+| `--output` | `-o` | string | `table` | Output format: `table`, `wide`, `json`, `yaml` |
 
-Also inherits [global flags](#global-flags) and `--output` from `arena job`.
+Also inherits [global flags](#global-flags).
 
 ### Examples
 
@@ -754,6 +794,7 @@ arena top job [flags]
 
 | Flag | Shorthand | Type | Default | Description |
 |------|-----------|------|---------|-------------|
+| `--all-namespaces` | `-A` | bool | `false` | List jobs across all namespaces; silently overrides `-n` and adds a leading `NAMESPACE` column to table output |
 | `--output` | `-o` | string | `table` | Output format: `table`, `wide`, `json`, `yaml` |
 
 Also inherits [global flags](#global-flags).
@@ -763,6 +804,9 @@ Also inherits [global flags](#global-flags).
 ```shell
 # Show GPU usage of all jobs
 $ arena top job
+
+# Show GPU usage across all namespaces (overrides -n; adds a NAMESPACE column)
+$ arena top job -A
 
 # Wide output with additional columns
 $ arena top job -o wide
@@ -779,6 +823,14 @@ Default table format:
 NAME              STATUS     GPU_REQUESTED   REPLICAS   AGE
 pytorch-simple    Running    1               1/1        5m
 mpi-test          Pending    2               0/2        10s
+```
+
+With `-A/--all-namespaces`, a leading `NAMESPACE` column is added:
+
+```text
+NAMESPACE   NAME              STATUS     GPU_REQUESTED   REPLICAS   AGE
+default     pytorch-simple    Running    1               1/1        5m
+kubeflow    mpi-test          Pending    2               0/2        10s
 ```
 
 Wide format (`-o wide`) adds `NAMESPACE`, `APIVERSION`, and `FRAMEWORK` columns:
@@ -816,7 +868,7 @@ The `STATUS` column in `list`, `get`, and `top job` output reflects the CRD's co
 
 ## Output Formats
 
-The `-o/--output` flag controls the output format for `arena job list`, `arena job get`, and `arena top job`.
+Each command that renders structured output registers its own local `-o/--output` flag: the `arena job` leaf commands (`run`, `get`, `status`, `list`, `delete`, `suspend`, `resume`), the `arena submit` framework subcommands, and `arena top job`. `arena job logs` has no `-o` flag.
 
 | Format | Description |
 |--------|-------------|
@@ -838,4 +890,4 @@ Arena resolves the target Kubernetes namespace using a 4-level priority chain:
 3. Namespace from the kubeconfig context
 4. `default` (lowest priority)
 
-All commands that interact with the cluster use this resolution. For `arena job run`, the YAML namespace is overridable with `-n`. For other commands (`list`, `get`, `logs`, `suspend`, `resume`, `delete`), the namespace comes from the flag or kubeconfig context.
+All commands that interact with the cluster use this resolution. For `arena job run`, the YAML namespace is overridable with `-n`. For other commands (`list`, `get`, `logs`, `suspend`, `resume`, `delete`), the namespace comes from the flag or kubeconfig context. The `-A/--all-namespaces` flag on `job list` and `top job` bypasses this resolution and lists across every namespace (a leading `NAMESPACE` column is added to table output).

--- a/pkg/cli/check.go
+++ b/pkg/cli/check.go
@@ -13,71 +13,78 @@ import (
 	"github.com/kubeflow/arena/pkg/provider"
 )
 
-var checkCmd = &cobra.Command{
-	Use:   "check",
-	Short: "Verify that required CRDs are installed in the cluster",
-	Long:  `Check whether the Kubeflow training operator CRDs (PyTorchJob, TFJob, MPIJob) are installed and accessible in the cluster.`,
-	RunE: func(cmd *cobra.Command, _ []string) error {
-		k8sClient, err := client.NewClient(kubeconfig, kubeContext)
-		if err != nil {
-			return fmt.Errorf("failed to create K8s client: %w", err)
-		}
+func newCheckCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "check",
+		Short: "Verify that required CRDs are installed in the cluster",
+		Long:  `Check whether the Kubeflow training operator CRDs (PyTorchJob, TFJob, MPIJob) are installed and accessible in the cluster.`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			out := cmd.OutOrStdout()
 
-		mpiAvailable := true
-		if err := k8sClient.ResolveMPIVersion(cmdContext(cmd)); err != nil {
-			log.Debug("MPIJob CRD not available", "error", err.Error())
-			mpiAvailable = false
-		}
-
-		kinds := []string{constants.KindPyTorchJob, constants.KindTFJob, constants.KindMPIJob}
-		allOk := true
-
-		for _, kind := range kinds {
-			if kind == constants.KindMPIJob && !mpiAvailable {
-				continue
-			}
-			crdName := crdObjectName(kind)
-			if crdName == "" {
-				continue
-			}
-
-			versions, err := k8sClient.GetCRDVersions(cmdContext(cmd), crdName)
-			if err != nil || versions == nil {
-				fmt.Printf("✗ %s: not installed\n", kind)
-				allOk = false
-				continue
-			}
-
-			expected, err := k8sClient.KindToAPIVersion(kind)
+			k8sClient, err := client.NewClient(kubeconfig, kubeContext)
 			if err != nil {
-				fmt.Printf("? %s: version not resolved\n", kind)
-				allOk = false
-				continue
+				return fmt.Errorf("failed to create K8s client: %w", err)
 			}
-			versionStr := formatCRDVersions(versions)
-			fmt.Printf("✓ %s: installed (expected: %s)\n", kind, expected)
-			fmt.Printf("  versions: %s\n", versionStr)
 
-			// MPIJob compatibility check
-			if kind == constants.KindMPIJob {
-				storageVersion := client.FindStorageVersion(versions)
-				supported := provider.MPISupportedVersions()
-				if isMPIVersionSupportedByProvider(storageVersion) {
-					fmt.Printf("  compatible: ✓ (storage version %s supported by arena)\n", storageVersion)
-				} else {
-					fmt.Printf("  compatible: ✗ (storage version %s, arena supports: %s)\n",
-						storageVersion, strings.Join(supported, ", "))
+			mpiAvailable := true
+			if err := k8sClient.ResolveMPIVersion(cmdContext(cmd)); err != nil {
+				log.Debug("MPIJob CRD not available", "error", err.Error())
+				mpiAvailable = false
+			}
+
+			kinds := []string{constants.KindPyTorchJob, constants.KindTFJob, constants.KindMPIJob}
+			allOk := true
+
+			for _, kind := range kinds {
+				if kind == constants.KindMPIJob && !mpiAvailable {
+					continue
+				}
+				crdName := crdObjectName(kind)
+				if crdName == "" {
+					continue
+				}
+
+				versions, err := k8sClient.GetCRDVersions(cmdContext(cmd), crdName)
+				if err != nil || versions == nil {
+					fmt.Fprintf(out, "✗ %s: not installed\n", kind)
 					allOk = false
+					continue
+				}
+
+				expected, err := k8sClient.KindToAPIVersion(kind)
+				if err != nil {
+					fmt.Fprintf(out, "? %s: version not resolved\n", kind)
+					allOk = false
+					continue
+				}
+				versionStr := formatCRDVersions(versions)
+				fmt.Fprintf(out, "✓ %s: installed (expected: %s)\n", kind, expected)
+				fmt.Fprintf(out, "  versions: %s\n", versionStr)
+
+				// MPIJob compatibility check
+				if kind == constants.KindMPIJob {
+					storageVersion := client.FindStorageVersion(versions)
+					supported := provider.MPISupportedVersions()
+					if isMPIVersionSupportedByProvider(storageVersion) {
+						fmt.Fprintf(out, "  compatible: ✓ (storage version %s supported by arena)\n", storageVersion)
+					} else {
+						fmt.Fprintf(out, "  compatible: ✗ (storage version %s, arena supports: %s)\n",
+							storageVersion, strings.Join(supported, ", "))
+						allOk = false
+					}
 				}
 			}
-		}
 
-		if !allOk {
-			return errors.New("one or more CRDs are not installed or incompatible")
-		}
+			if !allOk {
+				return errors.New("one or more CRDs are not installed or incompatible")
+			}
 
-		return nil
-	},
+			return nil
+		},
+	}
+
+	cmd.ValidArgsFunction = cobra.NoFileCompletions
+	return cmd
 }
 
 // formatCRDVersions formats version info for display.
@@ -117,9 +124,4 @@ func crdObjectName(kind string) string {
 	default:
 		return ""
 	}
-}
-
-func init() {
-	checkCmd.ValidArgsFunction = cobra.NoFileCompletions
-	rootCmd.AddCommand(checkCmd)
 }

--- a/pkg/cli/completion.go
+++ b/pkg/cli/completion.go
@@ -2,15 +2,15 @@ package cli
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 )
 
-var completionCmd = &cobra.Command{
-	Use:   "completion <shell>",
-	Short: "Generate shell completion scripts",
-	Long: `Generate shell completion scripts for arena-v2.
+func newCompletionCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "completion <shell>",
+		Short: "Generate shell completion scripts",
+		Long: `Generate shell completion scripts for arena-v2.
 Supported shells: bash, zsh, fish, powershell.
 
 Usage:
@@ -18,24 +18,24 @@ Usage:
   arena-v2 completion zsh > "${fpath[1]}/_arena-v2"
   arena-v2 completion fish > ~/.config/fish/completions/arena-v2.fish
   arena-v2 completion powershell > arena-v2.ps1`,
-	ValidArgs: []string{"bash", "zsh", "fish", "powershell"},
-	Args:      cobra.ExactArgs(1),
-	RunE: func(_ *cobra.Command, args []string) error {
-		switch args[0] {
-		case "bash":
-			return rootCmd.GenBashCompletionV2(os.Stdout, true)
-		case "zsh":
-			return rootCmd.GenZshCompletion(os.Stdout)
-		case "fish":
-			return rootCmd.GenFishCompletion(os.Stdout, true)
-		case "powershell":
-			return rootCmd.GenPowerShellCompletionWithDesc(os.Stdout)
-		default:
-			return fmt.Errorf("unsupported shell: %q (must be bash, zsh, fish, or powershell)", args[0])
-		}
-	},
-}
-
-func init() {
-	rootCmd.AddCommand(completionCmd)
+		ValidArgs: []string{"bash", "zsh", "fish", "powershell"},
+		Args:      cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			root := cmd.Root()
+			out := cmd.OutOrStdout()
+			switch args[0] {
+			case "bash":
+				return root.GenBashCompletionV2(out, true)
+			case "zsh":
+				return root.GenZshCompletion(out)
+			case "fish":
+				return root.GenFishCompletion(out, true)
+			case "powershell":
+				return root.GenPowerShellCompletionWithDesc(out)
+			default:
+				return fmt.Errorf("unsupported shell: %q (must be bash, zsh, fish, or powershell)", args[0])
+			}
+		},
+	}
+	return cmd
 }

--- a/pkg/cli/delete.go
+++ b/pkg/cli/delete.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -20,6 +19,9 @@ func newDeleteCmd() *cobra.Command {
 		Long:  `Delete a training job by name or YAML file (similar to kubectl delete -f).`,
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := validateOutputFormat(); err != nil {
+				return err
+			}
 			var name string
 
 			var yamlNS string
@@ -55,12 +57,12 @@ func newDeleteCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			fmt.Fprintf(cmd.OutOrStdout(), "%s/%s deleted\n", strings.ToLower(jobType), name)
-			return nil
+			return printActionResult(cmd.OutOrStdout(), name, ns, jobType, "deleted")
 		},
 	}
 
 	cmd.Flags().StringVarP(&deleteFile, "file", "f", "", "path to YAML file")
+	registerOutputFlag(cmd)
 	cmd.ValidArgsFunction = completeJobName
 	_ = cmd.RegisterFlagCompletionFunc("file", completeFile)
 	return cmd

--- a/pkg/cli/delete.go
+++ b/pkg/cli/delete.go
@@ -13,55 +13,55 @@ import (
 
 var deleteFile string
 
-var deleteCmd = &cobra.Command{
-	Use:   "delete [name]",
-	Short: "Delete a training job",
-	Long:  `Delete a training job by name or YAML file (similar to kubectl delete -f).`,
-	Args:  cobra.MaximumNArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		var name string
+func newDeleteCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "delete [name]",
+		Short: "Delete a training job",
+		Long:  `Delete a training job by name or YAML file (similar to kubectl delete -f).`,
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var name string
 
-		var yamlNS string
-		if deleteFile != "" {
-			// Load from file
-			t, err := task.LoadFromFile(deleteFile)
+			var yamlNS string
+			switch {
+			case deleteFile != "":
+				t, err := task.LoadFromFile(deleteFile)
+				if err != nil {
+					return fmt.Errorf("failed to load file %q: %w", deleteFile, err)
+				}
+				name = t.Name
+				if name == "" {
+					return fmt.Errorf("file %q does not specify a job name", deleteFile)
+				}
+				yamlNS = t.Namespace
+			case len(args) > 0:
+				name = args[0]
+			default:
+				return errors.New("either job name or -f flag is required")
+			}
+
+			k8sClient, err := client.NewClient(kubeconfig, kubeContext)
 			if err != nil {
-				return fmt.Errorf("failed to load file %q: %w", deleteFile, err)
+				return fmt.Errorf("failed to create K8s client: %w", err)
 			}
-			name = t.Name
-			if name == "" {
-				return fmt.Errorf("file %q does not specify a job name", deleteFile)
+
+			ns := resolveNS(yamlNS)
+			jobType, err := detectJobType(cmdContext(cmd), k8sClient, ns, name)
+			if err != nil {
+				return err
 			}
-			yamlNS = t.Namespace
-		} else if len(args) > 0 {
-			name = args[0]
-		} else {
-			return errors.New("either job name or -f flag is required")
-		}
 
-		k8sClient, err := client.NewClient(kubeconfig, kubeContext)
-		if err != nil {
-			return fmt.Errorf("failed to create K8s client: %w", err)
-		}
+			err = k8sClient.Delete(cmdContext(cmd), jobType, ns, name)
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "%s/%s deleted\n", strings.ToLower(jobType), name)
+			return nil
+		},
+	}
 
-		ns := resolveNS(yamlNS)
-		jobType, err := detectJobType(cmdContext(cmd), k8sClient, ns, name)
-		if err != nil {
-			return err
-		}
-
-		err = k8sClient.Delete(cmdContext(cmd), jobType, ns, name)
-		if err != nil {
-			return err
-		}
-		fmt.Printf("%s/%s deleted\n", strings.ToLower(jobType), name)
-		return nil
-	},
-}
-
-func init() {
-	deleteCmd.Flags().StringVarP(&deleteFile, "file", "f", "", "path to YAML file")
-	deleteCmd.ValidArgsFunction = completeJobName
-	_ = deleteCmd.RegisterFlagCompletionFunc("file", completeFile)
-	jobCmd.AddCommand(deleteCmd)
+	cmd.Flags().StringVarP(&deleteFile, "file", "f", "", "path to YAML file")
+	cmd.ValidArgsFunction = completeJobName
+	_ = cmd.RegisterFlagCompletionFunc("file", completeFile)
+	return cmd
 }

--- a/pkg/cli/delete_test.go
+++ b/pkg/cli/delete_test.go
@@ -17,24 +17,27 @@ import (
 )
 
 func TestDeleteCmd_AcceptsOneArg(t *testing.T) {
-	err := deleteCmd.Args(deleteCmd, []string{"my-job"})
+	cmd := newDeleteCmd()
+	err := cmd.Args(cmd, []string{"my-job"})
 	assert.NoError(t, err)
 }
 
 func TestDeleteCmd_AcceptsZeroArgs(t *testing.T) {
 	// With -f flag support, zero positional args is valid (name comes from file).
-	err := deleteCmd.Args(deleteCmd, []string{})
+	cmd := newDeleteCmd()
+	err := cmd.Args(cmd, []string{})
 	assert.NoError(t, err)
 }
 
 func TestDeleteCmd_RejectsExtraArgs(t *testing.T) {
-	err := deleteCmd.Args(deleteCmd, []string{"a", "b"})
+	cmd := newDeleteCmd()
+	err := cmd.Args(cmd, []string{"a", "b"})
 	assert.Error(t, err)
 }
 
 func TestDeleteCmd_RegisteredWithJob(t *testing.T) {
 	found := false
-	for _, cmd := range jobCmd.Commands() {
+	for _, cmd := range newJobCmd().Commands() {
 		if cmd.Name() == "delete" {
 			found = true
 			break
@@ -44,12 +47,12 @@ func TestDeleteCmd_RegisteredWithJob(t *testing.T) {
 }
 
 func TestDeleteCmd_HasCorrectMetadata(t *testing.T) {
-	assert.Equal(t, "delete [name]", deleteCmd.Use)
-	assert.NotEmpty(t, deleteCmd.Short)
+	assert.Equal(t, "delete [name]", newDeleteCmd().Use)
+	assert.NotEmpty(t, newDeleteCmd().Short)
 }
 
 func TestDeleteCmd_HasFileFlag(t *testing.T) {
-	f := deleteCmd.Flags().Lookup("file")
+	f := newDeleteCmd().Flags().Lookup("file")
 	require.NotNil(t, f, "delete command should have a --file flag")
 	assert.Equal(t, "f", f.Shorthand)
 }
@@ -60,7 +63,8 @@ func TestDeleteCmd_NotFound(t *testing.T) {
 
 	t.Setenv("KUBECONFIG", "/nonexistent/env-kubeconfig")
 	kubeconfig = "/nonexistent/kubeconfig"
-	err := deleteCmd.RunE(deleteCmd, []string{"nonexistent-job"})
+	cmd := newDeleteCmd()
+	err := cmd.RunE(cmd, []string{"nonexistent-job"})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to create K8s client")
 }
@@ -128,7 +132,8 @@ func TestDelete_ByName(t *testing.T) {
 	defer func() { deleteFile = origFile }()
 	deleteFile = ""
 
-	err := deleteCmd.RunE(deleteCmd, []string{"my-job"})
+	cmd := newDeleteCmd()
+	err := cmd.RunE(cmd, []string{"my-job"})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to create K8s client")
 }
@@ -157,9 +162,10 @@ worker:
 
 	origFile := deleteFile
 	defer func() { deleteFile = origFile }()
-	deleteFile = tmpFile
 
-	err = deleteCmd.RunE(deleteCmd, nil)
+	cmd := newDeleteCmd()
+	deleteFile = tmpFile
+	err = cmd.RunE(cmd, nil)
 	assert.Error(t, err)
 	// Should get past file loading and fail at client creation.
 	assert.Contains(t, err.Error(), "failed to create K8s client")
@@ -168,14 +174,15 @@ worker:
 func TestDelete_FileNotFound(t *testing.T) {
 	origFile := deleteFile
 	defer func() { deleteFile = origFile }()
-	deleteFile = "/nonexistent/path/to/missing.yaml"
 
 	orig := kubeconfig
 	defer func() { kubeconfig = orig }()
 	t.Setenv("KUBECONFIG", "/nonexistent/env-kubeconfig")
 	kubeconfig = "/nonexistent/kubeconfig"
 
-	err := deleteCmd.RunE(deleteCmd, nil)
+	cmd := newDeleteCmd()
+	deleteFile = "/nonexistent/path/to/missing.yaml"
+	err := cmd.RunE(cmd, nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to load file")
 }
@@ -185,7 +192,7 @@ func TestDelete_NoNameNoFile(t *testing.T) {
 	defer func() { deleteFile = origFile }()
 	deleteFile = ""
 
-	err := deleteCmd.RunE(deleteCmd, nil)
+	err := newDeleteCmd().RunE(newDeleteCmd(), nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "either job name or -f flag is required")
 }
@@ -207,9 +214,11 @@ worker:
 
 	origFile := deleteFile
 	defer func() { deleteFile = origFile }()
+
+	cmd := newDeleteCmd()
 	deleteFile = tmpFile
 
-	err = deleteCmd.RunE(deleteCmd, nil)
+	err = cmd.RunE(cmd, nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to load file")
 }

--- a/pkg/cli/errors.go
+++ b/pkg/cli/errors.go
@@ -1,0 +1,82 @@
+package cli
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	outputpkg "github.com/kubeflow/arena/pkg/output"
+)
+
+// CLIError is an error that teaches: it carries the accepted values and an
+// optional hint so users and agents can self-correct without re-reading docs.
+type CLIError struct {
+	Message     string   `json:"message"`
+	ValidValues []string `json:"validValues,omitempty"`
+	Hint        string   `json:"hint,omitempty"`
+}
+
+// Error renders the message plus the enumerated valid values and hint.
+func (e *CLIError) Error() string {
+	msg := e.Message
+	if len(e.ValidValues) > 0 {
+		msg += "; must be one of: " + strings.Join(e.ValidValues, ", ")
+	}
+	if e.Hint != "" {
+		msg += " (" + e.Hint + ")"
+	}
+	return msg
+}
+
+// Envelope renders the error as a JSON object for machine consumption.
+func (e *CLIError) Envelope() string {
+	b, err := json.MarshalIndent(struct {
+		Error *CLIError `json:"error"`
+	}{e}, "", "  ")
+	if err != nil {
+		return "Error: " + e.Error() + "\n"
+	}
+	return string(b) + "\n"
+}
+
+// ErrorEnvelope renders any error as the machine-readable JSON envelope.
+// A CLIError (possibly wrapped) keeps its teaching fields; every other
+// error is carried as a bare message so consumers parsing stderr always
+// receive well-formed output.
+func ErrorEnvelope(err error) string {
+	var cliErr *CLIError
+	if !errors.As(err, &cliErr) {
+		cliErr = &CLIError{Message: err.Error()}
+	}
+	return cliErr.Envelope()
+}
+
+// JSONErrorRequested reports whether errors should be rendered as a JSON
+// envelope, which is the case when the active output format is json or yaml.
+// The shared outputFormat var is bound by every leaf command's local
+// -o/--output registration via registerOutputFlag.
+func JSONErrorRequested() bool {
+	switch outputpkg.Format(outputFormat) {
+	case outputpkg.FormatJSON, outputpkg.FormatYAML:
+		return true
+	}
+	return false
+}
+
+// validateOutputFormatValue validates an output format value, returning a
+// teaching error that enumerates the accepted formats.
+func validateOutputFormatValue(format string) error {
+	if err := outputpkg.Format(format).Validate(); err != nil {
+		return &CLIError{
+			Message:     fmt.Sprintf("invalid output format %q for --output", format),
+			ValidValues: strings.Split(outputpkg.FormatSupported, ", "),
+		}
+	}
+	return nil
+}
+
+// validateOutputFormat validates the shared outputFormat flag value.
+func validateOutputFormat() error {
+	return validateOutputFormatValue(outputFormat)
+}

--- a/pkg/cli/errors_test.go
+++ b/pkg/cli/errors_test.go
@@ -1,0 +1,229 @@
+package cli
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCLIError_Error(t *testing.T) {
+	tests := []struct {
+		name string
+		err  *CLIError
+		want string
+	}{
+		{
+			name: "message only",
+			err:  &CLIError{Message: "something failed"},
+			want: "something failed",
+		},
+		{
+			name: "message with valid values",
+			err:  &CLIError{Message: `invalid value "js" for --output`, ValidValues: []string{"table", "wide", "json", "yaml"}},
+			want: `invalid value "js" for --output; must be one of: table, wide, json, yaml`,
+		},
+		{
+			name: "message with hint",
+			err:  &CLIError{Message: "bad expression", Hint: "expected key=value"},
+			want: "bad expression (expected key=value)",
+		},
+		{
+			name: "message with both",
+			err:  &CLIError{Message: "bad value", ValidValues: []string{"a", "b"}, Hint: "pick one"},
+			want: "bad value; must be one of: a, b (pick one)",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.err.Error())
+		})
+	}
+}
+
+func TestCLIError_Envelope(t *testing.T) {
+	e := &CLIError{
+		Message:     `invalid value "js" for --output`,
+		ValidValues: []string{"table", "wide", "json", "yaml"},
+		Hint:        "pick one",
+	}
+
+	var parsed struct {
+		Error struct {
+			Message     string   `json:"message"`
+			ValidValues []string `json:"validValues"`
+			Hint        string   `json:"hint"`
+		} `json:"error"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(e.Envelope()), &parsed))
+	assert.Equal(t, `invalid value "js" for --output`, parsed.Error.Message)
+	assert.Equal(t, []string{"table", "wide", "json", "yaml"}, parsed.Error.ValidValues)
+	assert.Equal(t, "pick one", parsed.Error.Hint)
+}
+
+func TestCLIError_EnvelopeOmitsEmptyFields(t *testing.T) {
+	e := &CLIError{Message: "boom"}
+	assert.NotContains(t, e.Envelope(), "validValues")
+	assert.NotContains(t, e.Envelope(), "hint")
+}
+
+func TestErrorEnvelope_PlainErrorCarriesMessageOnly(t *testing.T) {
+	out := ErrorEnvelope(errors.New("api failure"))
+	assert.Contains(t, out, `"message": "api failure"`)
+	assert.NotContains(t, out, "validValues")
+	assert.NotContains(t, out, "hint")
+	assert.True(t, strings.HasSuffix(out, "\n"), "envelope ends with newline")
+}
+
+func TestErrorEnvelope_WrappedCLIErrorKeepsTeachingFields(t *testing.T) {
+	err := fmt.Errorf("submit failed: %w", &CLIError{Message: "bad flag", ValidValues: []string{"a", "b"}, Hint: "pick one"})
+	out := ErrorEnvelope(err)
+	assert.Contains(t, out, `"message": "bad flag"`)
+	assert.Contains(t, out, `"validValues": [`)
+	assert.Contains(t, out, `"hint": "pick one"`)
+	assert.NotContains(t, out, "submit failed", "envelope carries the CLIError, not the wrapper")
+}
+
+func TestJSONErrorRequested(t *testing.T) {
+	orig := outputFormat
+	t.Cleanup(func() { outputFormat = orig })
+
+	for _, f := range []string{"json", "yaml"} {
+		outputFormat = f
+		assert.True(t, JSONErrorRequested(), "format %s should request JSON errors", f)
+	}
+	for _, f := range []string{"table", "wide", "", "bogus"} {
+		outputFormat = f
+		assert.False(t, JSONErrorRequested(), "format %q should not request JSON errors", f)
+	}
+}
+
+func TestTopJobCmd_OutputFlagBindsSharedFormat(t *testing.T) {
+	orig := outputFormat
+	t.Cleanup(func() { outputFormat = orig })
+
+	newTopJobCmd() // registerOutputFlag resets the shared var to the default
+	require.NoError(t, newTopJobCmd().Flags().Set("output", "json"))
+	assert.True(t, JSONErrorRequested(), "top -o json must request JSON errors via the shared format var")
+
+	require.NoError(t, newTopJobCmd().Flags().Set("output", "table"))
+	assert.False(t, JSONErrorRequested(), "top -o table must not request JSON errors")
+}
+
+func TestCLIError_ErrorsAs(t *testing.T) {
+	var err error = &CLIError{Message: "wrapped"}
+	var target *CLIError
+	require.True(t, errors.As(err, &target))
+	assert.Equal(t, "wrapped", target.Message)
+}
+
+func TestValidateOutputFormat(t *testing.T) {
+	orig := outputFormat
+	t.Cleanup(func() { outputFormat = orig })
+
+	for _, f := range []string{"table", "wide", "json", "yaml"} {
+		outputFormat = f
+		assert.NoError(t, validateOutputFormat(), "format %q should be valid", f)
+	}
+
+	outputFormat = "js"
+	err := validateOutputFormat()
+	var cliErr *CLIError
+	require.Error(t, err)
+	require.True(t, errors.As(err, &cliErr))
+	assert.Equal(t, []string{"table", "wide", "json", "yaml"}, cliErr.ValidValues)
+	assert.Contains(t, err.Error(), "invalid output format")
+	assert.Contains(t, err.Error(), "must be one of: table, wide, json, yaml")
+}
+
+func TestValidateOutputFormatValue(t *testing.T) {
+	for _, f := range []string{"table", "wide", "json", "yaml"} {
+		assert.NoError(t, validateOutputFormatValue(f), "format %q should be valid", f)
+	}
+
+	err := validateOutputFormatValue("js")
+	var cliErr *CLIError
+	require.Error(t, err)
+	require.True(t, errors.As(err, &cliErr))
+	assert.Equal(t, `invalid output format "js" for --output`, cliErr.Message)
+	assert.Equal(t, []string{"table", "wide", "json", "yaml"}, cliErr.ValidValues)
+	assert.Empty(t, cliErr.Hint)
+}
+
+func TestValidateOutputFormat_Integration(t *testing.T) {
+	orig := outputFormat
+	t.Cleanup(func() { outputFormat = orig })
+
+	tmpFile := writeTestYAML(t, testRunYAML)
+	err := ExecuteWithArgs([]string{"job", "run", "-f", tmpFile, "-o", "bogus"})
+	var cliErr *CLIError
+	require.Error(t, err)
+	require.True(t, errors.As(err, &cliErr))
+	assert.Contains(t, err.Error(), "must be one of: table, wide, json, yaml")
+}
+
+func TestDryRunFormat_IsTeachingError(t *testing.T) {
+	orig := outputFormat
+	t.Cleanup(func() { outputFormat = orig })
+
+	outputFormat = "table"
+	_, err := dryRunFormat()
+	var cliErr *CLIError
+	require.Error(t, err)
+	require.True(t, errors.As(err, &cliErr))
+	assert.Equal(t, []string{"json", "yaml"}, cliErr.ValidValues)
+	assert.Contains(t, err.Error(), "dry-run only supports -o json or yaml")
+}
+
+func TestSubmitFrameworkErrorsAreTeaching(t *testing.T) {
+	tests := []struct {
+		name       string
+		args       []string
+		wantSubstr string
+		wantValid  []string
+	}{
+		{
+			name:       "v1 type lists v2 frameworks",
+			args:       []string{"submit", "ray", "--name", "x", "--image", "img"},
+			wantSubstr: "not supported by arena-v2 yet",
+			wantValid:  []string{"pytorch", "tensorflow", "mpi", "horovod", "deepspeed"},
+		},
+		{
+			name:       "unknown type lists accepted aliases",
+			args:       []string{"submit", "jax", "--name", "x", "--image", "img"},
+			wantSubstr: "unsupported framework type",
+			wantValid:  []string{"pytorch", "pytorchjob", "tf", "tfjob", "tensorflow", "mpi", "mpijob", "mj", "horovod", "horovodjob", "hj", "deepspeed", "deepspeedjob", "dp"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ExecuteWithArgs(tt.args)
+			var cliErr *CLIError
+			require.Error(t, err)
+			require.True(t, errors.As(err, &cliErr), "error should be a CLIError, got %T: %v", err, err)
+			assert.Contains(t, err.Error(), tt.wantSubstr)
+			assert.Equal(t, tt.wantValid, cliErr.ValidValues)
+			assert.Contains(t, err.Error(), "must be one of:")
+		})
+	}
+}
+
+func TestRunCmd_SetSyntaxErrorHasHint(t *testing.T) {
+	orig := outputFormat
+	t.Cleanup(func() { outputFormat = orig })
+
+	tmpFile := writeTestYAML(t, testRunYAML)
+	err := ExecuteWithArgs([]string{"job", "run", "-f", tmpFile, "--set", "noequals"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to apply --set")
+	assert.Contains(t, err.Error(), "failed to parse --set")
+	assert.Contains(t, err.Error(), "worker.replicas=4")
+
+	var cliErr *CLIError
+	require.True(t, errors.As(err, &cliErr))
+	assert.NotEmpty(t, cliErr.Hint)
+}

--- a/pkg/cli/framework_registry.go
+++ b/pkg/cli/framework_registry.go
@@ -25,7 +25,9 @@ var frameworkRegistry = []frameworkDef{
 		aliases: []string{constants.FrameworkPyTorch, "pytorchjob"}},
 	{canonical: constants.FrameworkTensorFlow, original: constants.FrameworkTensorFlow, kind: constants.KindTFJob,
 		cmdName: "tfjob",
-		aliases: []string{constants.FrameworkTensorFlow, "tfjob", "tf"}},
+		// Alias order is user-visible: acceptedFrameworkTypes() renders it in
+		// the unsupported-type error, matching v1's tf/tfjob/tensorflow list.
+		aliases: []string{"tf", "tfjob", constants.FrameworkTensorFlow}},
 	{canonical: constants.FrameworkMPI, original: constants.FrameworkMPI, kind: constants.KindMPIJob,
 		cmdName: "mpijob",
 		aliases: []string{constants.FrameworkMPI, "mpijob", "mj"}},
@@ -108,4 +110,28 @@ func isMPIFamily(framework string) bool {
 	return framework == constants.FrameworkMPI ||
 		framework == constants.FrameworkHorovod ||
 		framework == constants.FrameworkDeepSpeed
+}
+
+// v2FrameworkNames returns the canonical framework names arena-v2 supports,
+// in registry order.
+func v2FrameworkNames() []string {
+	names := make([]string, 0, len(frameworkRegistry))
+	for _, def := range frameworkRegistry {
+		if def.canonical != "" {
+			names = append(names, def.canonical)
+		}
+	}
+	return names
+}
+
+// acceptedFrameworkTypes returns every framework type string the submit
+// command line accepts, across all v2-supported aliases.
+func acceptedFrameworkTypes() []string {
+	var types []string
+	for _, def := range frameworkRegistry {
+		if def.canonical != "" {
+			types = append(types, def.aliases...)
+		}
+	}
+	return types
 }

--- a/pkg/cli/framework_registry_test.go
+++ b/pkg/cli/framework_registry_test.go
@@ -198,11 +198,12 @@ func TestLookupFramework_Unknown(t *testing.T) {
 }
 
 func TestSubmitFrameworkTypeErrors(t *testing.T) {
-	err := submitCmd.RunE(submitCmd, []string{"rayjob"})
+	cmd := newSubmitCmd()
+	err := cmd.RunE(cmd, []string{"rayjob"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not supported by arena-v2 yet")
 
-	err = submitCmd.RunE(submitCmd, []string{"bogus"})
+	err = cmd.RunE(cmd, []string{"bogus"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unsupported framework type")
 }

--- a/pkg/cli/get.go
+++ b/pkg/cli/get.go
@@ -31,6 +31,7 @@ func newGetCmd() *cobra.Command {
 		RunE:  runGet,
 	}
 	cmd.Flags().BoolVar(&getDetails, "details", false, "show job configuration details")
+	registerOutputFlag(cmd)
 	cmd.ValidArgsFunction = completeJobName
 	return cmd
 }
@@ -38,8 +39,7 @@ func newGetCmd() *cobra.Command {
 // runGet backs both `job get` and `job status`; it reads the --details flag
 // from whichever command is executing.
 func runGet(cmd *cobra.Command, args []string) error {
-	// Validate format
-	if err := outputpkg.Format(outputFormat).Validate(); err != nil {
+	if err := validateOutputFormat(); err != nil {
 		return err
 	}
 

--- a/pkg/cli/get.go
+++ b/pkg/cli/get.go
@@ -22,99 +22,99 @@ import (
 
 var getDetails bool
 
-var getCmd = &cobra.Command{
-	Use:   "get <name>",
-	Short: "Get detailed information about a training job",
-	Long:  `Retrieve and display detailed information about a training job, including its status and pod details.`,
-	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		// Validate format
-		if err := outputpkg.Format(outputFormat).Validate(); err != nil {
-			return err
-		}
+func newGetCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "get <name>",
+		Short: "Get detailed information about a training job",
+		Long:  `Retrieve and display detailed information about a training job, including its status and pod details.`,
+		Args:  cobra.ExactArgs(1),
+		RunE:  runGet,
+	}
+	cmd.Flags().BoolVar(&getDetails, "details", false, "show job configuration details")
+	cmd.ValidArgsFunction = completeJobName
+	return cmd
+}
 
-		name := args[0]
+// runGet backs both `job get` and `job status`; it reads the --details flag
+// from whichever command is executing.
+func runGet(cmd *cobra.Command, args []string) error {
+	// Validate format
+	if err := outputpkg.Format(outputFormat).Validate(); err != nil {
+		return err
+	}
 
-		k8sClient, err := client.NewClient(kubeconfig, kubeContext)
-		if err != nil {
-			return fmt.Errorf("failed to create K8s client: %w", err)
-		}
+	name := args[0]
 
-		ns := resolveNS("")
-		jobKind, err := detectJobType(cmdContext(cmd), k8sClient, ns, name)
-		if err != nil {
-			return err
-		}
+	k8sClient, err := client.NewClient(kubeconfig, kubeContext)
+	if err != nil {
+		return fmt.Errorf("failed to create K8s client: %w", err)
+	}
 
-		job, err := k8sClient.Get(cmdContext(cmd), jobKind, ns, name)
-		if err != nil {
-			return err
-		}
+	ns := resolveNS("")
+	jobKind, err := detectJobType(cmdContext(cmd), k8sClient, ns, name)
+	if err != nil {
+		return err
+	}
 
-		status := extractJobStatus(job, jobKind)
-		if fw, ok := job.GetLabels()[frameworkLabel]; ok && fw != "" {
-			status.Framework = fw
-		} else {
-			status.Framework = kindToFramework(jobKind)
-		}
-		status.GPURequested = extractGPURequested(job)
+	job, err := k8sClient.Get(cmdContext(cmd), jobKind, ns, name)
+	if err != nil {
+		return err
+	}
 
-		// Get real pods via typed client using provider selector
-		p, pErr := providerForKind(jobKind)
-		podList := make([]client.PodInfo, 0)
-		if pErr == nil {
-			selector := p.GetJobPodSelector(name)
-			podList = getRealPods(cmdContext(cmd), ns, selector)
-		}
-		// Fallback to synthetic pods from CRD spec if no real pods found
-		if len(podList) == 0 {
-			podList = extractPods(job)
-		}
+	status := extractJobStatus(job, jobKind)
+	if fw, ok := job.GetLabels()[frameworkLabel]; ok && fw != "" {
+		status.Framework = fw
+	} else {
+		status.Framework = kindToFramework(jobKind)
+	}
+	status.GPURequested = extractGPURequested(job)
 
-		info := &client.JobInfo{
-			Status: status,
-			Pods:   podList,
-		}
+	// Get real pods via typed client using provider selector
+	p, pErr := providerForKind(jobKind)
+	podList := make([]client.PodInfo, 0)
+	if pErr == nil {
+		selector := p.GetJobPodSelector(name)
+		podList = getRealPods(cmdContext(cmd), ns, selector)
+	}
+	// Fallback to synthetic pods from CRD spec if no real pods found
+	if len(podList) == 0 {
+		podList = extractPods(job)
+	}
 
-		if getDetails {
-			cm, err := k8sClient.Get(cmdContext(cmd), "ConfigMap", ns, name)
-			if err != nil && !apierrors.IsNotFound(err) {
-				return fmt.Errorf("failed to get ConfigMap: %w", err)
+	info := &client.JobInfo{
+		Status: status,
+		Pods:   podList,
+	}
+
+	if getDetails {
+		cm, err := k8sClient.Get(cmdContext(cmd), "ConfigMap", ns, name)
+		if err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed to get ConfigMap: %w", err)
+		}
+		if err == nil {
+			data, found, dErr := unstructured.NestedMap(cm.Object, "data")
+			if dErr != nil {
+				log.Warning("failed to read ConfigMap data", "namespace", ns, "name", name, "error", dErr.Error())
 			}
-			if err == nil {
-				data, found, dErr := unstructured.NestedMap(cm.Object, "data")
-				if dErr != nil {
-					log.Warning("failed to read ConfigMap data", "namespace", ns, "name", name, "error", dErr.Error())
-				}
-				if dErr == nil && found {
-					yamlContent, ok := data["arena-v2.yaml"].(string)
-					if ok && yamlContent != "" {
-						var config task.Task
-						if uErr := yaml.Unmarshal([]byte(yamlContent), &config); uErr != nil {
-							log.Warning("failed to unmarshal task config", "namespace", ns, "name", name, "error", uErr.Error())
-						} else {
-							info.Configuration = &config
-						}
+			if dErr == nil && found {
+				yamlContent, ok := data["arena-v2.yaml"].(string)
+				if ok && yamlContent != "" {
+					var config task.Task
+					if uErr := yaml.Unmarshal([]byte(yamlContent), &config); uErr != nil {
+						log.Warning("failed to unmarshal task config", "namespace", ns, "name", name, "error", uErr.Error())
+					} else {
+						info.Configuration = &config
 					}
 				}
 			}
 		}
+	}
 
-		renderer := &outputpkg.TableRenderer{}
-		opts := outputpkg.RenderOptions{
-			TableFn: func() string { return renderer.RenderJobDetail(info) },
-		}
-		if err := outputpkg.Format(outputFormat).Render(info, opts); err != nil {
-			return err
-		}
-		return nil
-	},
-}
-
-func init() {
-	jobCmd.AddCommand(getCmd)
-	getCmd.Flags().BoolVar(&getDetails, "details", false, "show job configuration details")
-	getCmd.ValidArgsFunction = completeJobName
+	renderer := &outputpkg.TableRenderer{}
+	opts := outputpkg.RenderOptions{
+		TableFn: func() string { return renderer.RenderJobDetail(info) },
+	}
+	return outputpkg.Format(outputFormat).Render(cmd.OutOrStdout(), info, opts)
 }
 
 // providerForKind returns the Provider for a given CRD kind.

--- a/pkg/cli/get_test.go
+++ b/pkg/cli/get_test.go
@@ -12,13 +12,13 @@ import (
 )
 
 func TestGetCmd_HasDetailsFlag(t *testing.T) {
-	flag := getCmd.Flags().Lookup("details")
+	flag := newGetCmd().Flags().Lookup("details")
 	assert.NotNil(t, flag, "get command should have --details flag")
 	assert.Equal(t, "false", flag.DefValue, "--details default should be false")
 }
 
 func TestGetCmd_DetailsFlagDescription(t *testing.T) {
-	flag := getCmd.Flags().Lookup("details")
+	flag := newGetCmd().Flags().Lookup("details")
 	assert.NotNil(t, flag)
 	assert.Equal(t, "show job configuration details", flag.Usage)
 }

--- a/pkg/cli/helpers.go
+++ b/pkg/cli/helpers.go
@@ -29,7 +29,10 @@ func dryRunFormat() (outputpkg.Format, error) {
 	case outputpkg.FormatYAML, outputpkg.FormatJSON:
 		return f, nil
 	default:
-		return "", fmt.Errorf("dry-run only supports -o json or yaml, got %q", outputFormat)
+		return "", &CLIError{
+			Message:     fmt.Sprintf("dry-run only supports -o json or yaml, got %q", outputFormat),
+			ValidValues: []string{"json", "yaml"},
+		}
 	}
 }
 
@@ -39,6 +42,14 @@ func applyDryRunOutputDefault(cmd *cobra.Command, dryRun bool) {
 	if dryRun && !cmd.Flags().Changed("output") {
 		outputFormat = string(outputpkg.FormatJSON)
 	}
+}
+
+// registerOutputFlag registers -o/--output on a leaf command, binding the
+// shared outputFormat global. Leaf-level registration keeps commands with no
+// structured output (e.g. job logs) free of the flag entirely.
+func registerOutputFlag(cmd *cobra.Command) {
+	cmd.Flags().StringVarP(&outputFormat, "output", "o", string(outputpkg.DefaultFormat), outputpkg.FormatHelpText)
+	_ = cmd.RegisterFlagCompletionFunc("output", completeOutputFormat)
 }
 
 // printCRD marshals a CRD as indented JSON or YAML and writes it to out.
@@ -143,6 +154,17 @@ func resolveNS(yamlNamespace string) string {
 		log.Warning("creating resources in system namespace — ensure this is intentional", "namespace", ns)
 	}
 	return ns
+}
+
+// resolveListNamespace returns the namespace scope for listing commands:
+// "" (all namespaces) when allNamespaces is set, otherwise the resolveNS
+// chain. -A/--all-namespaces silently takes precedence over -n, like kubectl.
+func resolveListNamespace(allNamespaces bool) string {
+	if allNamespaces {
+		log.Debug("listing across all namespaces; --namespace is ignored when set")
+		return ""
+	}
+	return resolveNS("")
 }
 
 // isSystemNamespace returns true for Kubernetes system namespaces where
@@ -259,6 +281,5 @@ func submitCRD(ctx context.Context, out io.Writer, k8sClient *client.Client, t *
 		return fmt.Errorf("failed to create auxiliary resources: %w", err)
 	}
 
-	fmt.Fprintf(out, "Job %s submitted successfully\n", t.Name)
-	return nil
+	return printSubmitResult(out, t.Name, ns, crd.GetKind(), crd.GetAPIVersion())
 }

--- a/pkg/cli/helpers.go
+++ b/pkg/cli/helpers.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -40,8 +41,8 @@ func applyDryRunOutputDefault(cmd *cobra.Command, dryRun bool) {
 	}
 }
 
-// printCRD marshals a CRD as indented JSON or YAML and prints it to stdout.
-func printCRD(crd *unstructured.Unstructured, format outputpkg.Format) error {
+// printCRD marshals a CRD as indented JSON or YAML and writes it to out.
+func printCRD(out io.Writer, crd *unstructured.Unstructured, format outputpkg.Format) error {
 	switch format {
 	case outputpkg.FormatYAML:
 		var buf bytes.Buffer
@@ -53,30 +54,30 @@ func printCRD(crd *unstructured.Unstructured, format outputpkg.Format) error {
 		if err := enc.Close(); err != nil {
 			return fmt.Errorf("failed to close YAML encoder: %w", err)
 		}
-		fmt.Print(buf.String())
+		fmt.Fprint(out, buf.String())
 	case outputpkg.FormatJSON:
 		data, err := json.MarshalIndent(crd.Object, "", "  ")
 		if err != nil {
 			return fmt.Errorf("failed to marshal CRD as JSON: %w", err)
 		}
-		fmt.Println(string(data))
+		fmt.Fprintln(out, string(data))
 	default:
 		return fmt.Errorf("unsupported CRD output format %q", format)
 	}
 	return nil
 }
 
-// printDryRun prints the CRD and all auxiliary resources that would be created
+// printDryRun writes the CRD and all auxiliary resources that would be created
 // during a real submission (TensorBoard Deployment and Service if enabled).
 // Output format respects -o/--output (json or yaml; defaults to json).
 // Multiple resources are separated by "---" for readability.
-func printDryRun(crd *unstructured.Unstructured, t *task.Task) error {
+func printDryRun(out io.Writer, crd *unstructured.Unstructured, t *task.Task) error {
 	format, err := dryRunFormat()
 	if err != nil {
 		return err
 	}
 
-	if err := printCRD(crd, format); err != nil {
+	if err := printCRD(out, crd, format); err != nil {
 		return fmt.Errorf("failed to print CRD: %w", err)
 	}
 
@@ -108,8 +109,8 @@ func printDryRun(crd *unstructured.Unstructured, t *task.Task) error {
 			t,
 			ownerRef,
 		)
-		fmt.Println("---")
-		if err := printCRD(deploy, format); err != nil {
+		fmt.Fprintln(out, "---")
+		if err := printCRD(out, deploy, format); err != nil {
 			return fmt.Errorf("failed to print TensorBoard Deployment: %w", err)
 		}
 
@@ -119,8 +120,8 @@ func printDryRun(crd *unstructured.Unstructured, t *task.Task) error {
 			crd.GetNamespace(),
 			ownerRef,
 		)
-		fmt.Println("---")
-		if err := printCRD(svc, format); err != nil {
+		fmt.Fprintln(out, "---")
+		if err := printCRD(out, svc, format); err != nil {
 			return fmt.Errorf("failed to print TensorBoard Service: %w", err)
 		}
 	}
@@ -184,7 +185,8 @@ func isMPIVersionSupportedByProvider(version string) bool {
 // provider lookup, MPI version detection, CRD build, namespace resolution,
 // dry-run, existence check, RBAC pre-creation, CRD submit, and auxiliary
 // resource finalisation (ConfigMap + ownerRef patching) with rollback on failure.
-func submitCRD(ctx context.Context, k8sClient *client.Client, t *task.Task, frameworkLabel string, dryRun bool) error {
+// All human- and machine-readable output goes to out.
+func submitCRD(ctx context.Context, out io.Writer, k8sClient *client.Client, t *task.Task, frameworkLabel string, dryRun bool) error {
 	p, err := getProvider(t.Framework.Name)
 	if err != nil {
 		return err
@@ -224,7 +226,7 @@ func submitCRD(ctx context.Context, k8sClient *client.Client, t *task.Task, fram
 	log.Debug("CRD built", "kind", crd.GetKind(), "name", crd.GetName(), "namespace", ns)
 
 	if dryRun {
-		return printDryRun(crd, t)
+		return printDryRun(out, crd, t)
 	}
 
 	log.Debug("checking if job exists", "name", t.Name, "namespace", ns)
@@ -257,6 +259,6 @@ func submitCRD(ctx context.Context, k8sClient *client.Client, t *task.Task, fram
 		return fmt.Errorf("failed to create auxiliary resources: %w", err)
 	}
 
-	fmt.Printf("Job %s submitted successfully\n", t.Name)
+	fmt.Fprintf(out, "Job %s submitted successfully\n", t.Name)
 	return nil
 }

--- a/pkg/cli/helpers_test.go
+++ b/pkg/cli/helpers_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bytes"
 	"context"
 	"os"
 	"path/filepath"
@@ -50,7 +51,8 @@ func TestDryRunFormat(t *testing.T) {
 
 func TestPrintCRD_UnsupportedFormat(t *testing.T) {
 	crd := &unstructured.Unstructured{Object: map[string]interface{}{"kind": "PyTorchJob"}}
-	err := printCRD(crd, outputpkg.FormatTable)
+	var buf bytes.Buffer
+	err := printCRD(&buf, crd, outputpkg.FormatTable)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unsupported CRD output format")
 }
@@ -60,8 +62,13 @@ func TestPrintCRD_YAMLAndJSON(t *testing.T) {
 		"apiVersion": "kubeflow.org/v1",
 		"kind":       "PyTorchJob",
 	}}
-	require.NoError(t, printCRD(crd, outputpkg.FormatYAML))
-	require.NoError(t, printCRD(crd, outputpkg.FormatJSON))
+	var yamlBuf bytes.Buffer
+	require.NoError(t, printCRD(&yamlBuf, crd, outputpkg.FormatYAML))
+	assert.Contains(t, yamlBuf.String(), "kind: PyTorchJob")
+
+	var jsonBuf bytes.Buffer
+	require.NoError(t, printCRD(&jsonBuf, crd, outputpkg.FormatJSON))
+	assert.Contains(t, jsonBuf.String(), `"kind": "PyTorchJob"`)
 }
 
 func TestApplyDryRunOutputDefault(t *testing.T) {

--- a/pkg/cli/job.go
+++ b/pkg/cli/job.go
@@ -2,8 +2,6 @@ package cli
 
 import (
 	"github.com/spf13/cobra"
-
-	outputpkg "github.com/kubeflow/arena/pkg/output"
 )
 
 var (
@@ -16,14 +14,6 @@ func newJobCmd() *cobra.Command {
 		Short: "Manage training jobs",
 		Long:  `Commands for submitting, listing, inspecting, and managing training jobs.`,
 	}
-	cmd.PersistentFlags().StringVarP(
-		&outputFormat,
-		"output",
-		"o",
-		string(outputpkg.DefaultFormat),
-		outputpkg.FormatHelpText,
-	)
-	_ = cmd.RegisterFlagCompletionFunc("output", completeOutputFormat)
 
 	cmd.AddCommand(
 		newRunCmd(),

--- a/pkg/cli/job.go
+++ b/pkg/cli/job.go
@@ -10,20 +10,30 @@ var (
 	outputFormat string
 )
 
-var jobCmd = &cobra.Command{
-	Use:   "job",
-	Short: "Manage training jobs",
-	Long:  `Commands for submitting, listing, inspecting, and managing training jobs.`,
-}
-
-func init() {
-	jobCmd.PersistentFlags().StringVarP(
+func newJobCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "job",
+		Short: "Manage training jobs",
+		Long:  `Commands for submitting, listing, inspecting, and managing training jobs.`,
+	}
+	cmd.PersistentFlags().StringVarP(
 		&outputFormat,
 		"output",
 		"o",
 		string(outputpkg.DefaultFormat),
 		outputpkg.FormatHelpText,
 	)
-	_ = jobCmd.RegisterFlagCompletionFunc("output", completeOutputFormat)
-	rootCmd.AddCommand(jobCmd)
+	_ = cmd.RegisterFlagCompletionFunc("output", completeOutputFormat)
+
+	cmd.AddCommand(
+		newRunCmd(),
+		newGetCmd(),
+		newStatusCmd(),
+		newListCmd(),
+		newLogsCmd(),
+		newDeleteCmd(),
+		newSuspendCmd(),
+		newResumeCmd(),
+	)
+	return cmd
 }

--- a/pkg/cli/list.go
+++ b/pkg/cli/list.go
@@ -18,65 +18,67 @@ import (
 // supportedJobKinds lists the CRD kinds that arena manages.
 var supportedJobKinds = []string{constants.KindPyTorchJob, constants.KindTFJob, constants.KindMPIJob}
 
-var listCmd = &cobra.Command{
-	Use:   "list",
-	Short: "List all training jobs",
-	Long:  `List all training jobs across PyTorchJob, TFJob, and MPIJob CRD kinds.`,
-	RunE: func(cmd *cobra.Command, _ []string) error {
-		// Validate format
-		if err := outputpkg.Format(outputFormat).Validate(); err != nil {
-			return err
-		}
-
-		k8sClient, err := client.NewClient(kubeconfig, kubeContext)
-		if err != nil {
-			return fmt.Errorf("failed to create K8s client: %w", err)
-		}
-
-		mpiAvailable := true
-		if err := k8sClient.ResolveMPIVersion(cmdContext(cmd)); err != nil {
-			log.Debug("MPIJob CRD not available", "error", err.Error())
-			mpiAvailable = false
-		}
-
-		ns := resolveNS("")
-		allJobs := make([]client.JobStatus, 0)
-		for _, kind := range supportedJobKinds {
-			if kind == constants.KindMPIJob && !mpiAvailable {
-				continue
+func newListCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List all training jobs",
+		Long:  `List all training jobs across PyTorchJob, TFJob, and MPIJob CRD kinds.`,
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			// Validate format
+			if err := outputpkg.Format(outputFormat).Validate(); err != nil {
+				return err
 			}
-			jobs, err := k8sClient.List(cmdContext(cmd), kind, ns, v2LabelSelector)
+
+			k8sClient, err := client.NewClient(kubeconfig, kubeContext)
 			if err != nil {
-				if apierrors.IsNotFound(err) {
-					log.Debug("CRD not installed", "kind", kind)
+				return fmt.Errorf("failed to create K8s client: %w", err)
+			}
+
+			mpiAvailable := true
+			if err := k8sClient.ResolveMPIVersion(cmdContext(cmd)); err != nil {
+				log.Debug("MPIJob CRD not available", "error", err.Error())
+				mpiAvailable = false
+			}
+
+			ns := resolveNS("")
+			allJobs := make([]client.JobStatus, 0)
+			for _, kind := range supportedJobKinds {
+				if kind == constants.KindMPIJob && !mpiAvailable {
 					continue
 				}
-				apiVer, _ := k8sClient.KindToAPIVersion(kind)
-				log.Warning("failed to list CRD kind", "kind", kind, "apiVersion", apiVer, "error", err.Error())
-				continue
-			}
-			for _, job := range jobs {
-				status := extractJobStatus(job, kind)
-				if fw, ok := job.GetLabels()[frameworkLabel]; ok && fw != "" {
-					status.Framework = fw
-				} else {
-					status.Framework = kindToFramework(kind)
+				jobs, err := k8sClient.List(cmdContext(cmd), kind, ns, v2LabelSelector)
+				if err != nil {
+					if apierrors.IsNotFound(err) {
+						log.Debug("CRD not installed", "kind", kind)
+						continue
+					}
+					apiVer, _ := k8sClient.KindToAPIVersion(kind)
+					log.Warning("failed to list CRD kind", "kind", kind, "apiVersion", apiVer, "error", err.Error())
+					continue
 				}
-				status.GPURequested = extractGPURequested(job)
-				allJobs = append(allJobs, status)
+				for _, job := range jobs {
+					status := extractJobStatus(job, kind)
+					if fw, ok := job.GetLabels()[frameworkLabel]; ok && fw != "" {
+						status.Framework = fw
+					} else {
+						status.Framework = kindToFramework(kind)
+					}
+					status.GPURequested = extractGPURequested(job)
+					allJobs = append(allJobs, status)
+				}
 			}
-		}
 
-		renderer := &outputpkg.TableRenderer{}
-		opts := outputpkg.RenderOptions{
-			TableFn: func() string { return renderer.RenderJobList(allJobs) },
-			WideFn:  func() string { return renderer.RenderJobListWide(allJobs) },
-		}
-		if err := outputpkg.Format(outputFormat).Render(allJobs, opts); err != nil {
-			return err
-		}
-		return nil
-	},
+			renderer := &outputpkg.TableRenderer{}
+			opts := outputpkg.RenderOptions{
+				TableFn: func() string { return renderer.RenderJobList(allJobs) },
+				WideFn:  func() string { return renderer.RenderJobListWide(allJobs) },
+			}
+			return outputpkg.Format(outputFormat).Render(cmd.OutOrStdout(), allJobs, opts)
+		},
+	}
+	cmd.ValidArgsFunction = cobra.NoFileCompletions
+	return cmd
 }
 
 // extractJobStatus converts an unstructured CRD object into a JobStatus.
@@ -233,9 +235,4 @@ func formatAge(creationTime time.Time) string {
 		return "<unknown>"
 	}
 	return duration.HumanDuration(time.Since(creationTime))
-}
-
-func init() {
-	listCmd.ValidArgsFunction = cobra.NoFileCompletions
-	jobCmd.AddCommand(listCmd)
 }

--- a/pkg/cli/list.go
+++ b/pkg/cli/list.go
@@ -1,12 +1,17 @@
 package cli
 
 import (
+	"context"
 	"fmt"
+	"io"
+	"sort"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/duration"
 
 	"github.com/kubeflow/arena/pkg/client"
@@ -18,15 +23,228 @@ import (
 // supportedJobKinds lists the CRD kinds that arena manages.
 var supportedJobKinds = []string{constants.KindPyTorchJob, constants.KindTFJob, constants.KindMPIJob}
 
+var (
+	listSelector      string // -l/--selector: kubectl label selector expression
+	listType          string // --type: framework filter (translated to a label)
+	listStatus        string // --status: client-side phase filter
+	listLast          int    // --last: newest-first cap (0 = unlimited)
+	listAllNamespaces bool   // -A/--all-namespaces: list across all namespaces
+)
+
+// defaultListLast bounds job list output so agent context windows are not
+// flooded by large clusters.
+const defaultListLast = 50
+
+// validJobStatuses enumerates the phase values `--status` accepts: Kubeflow
+// training operator condition types plus arena's fallback phases (see
+// extractJobPhase).
+var validJobStatuses = []string{"Created", "Running", "Succeeded", "Failed", "Restarting", "Pending", "Suspended", "Unknown"}
+
+// containsFold reports whether s matches one of values case-insensitively.
+func containsFold(values []string, s string) bool {
+	for _, v := range values {
+		if strings.EqualFold(v, s) {
+			return true
+		}
+	}
+	return false
+}
+
+// validateListType validates --type case-insensitively against the supported
+// frameworks and returns the canonical framework name used as label value.
+func validateListType(v string) (string, error) {
+	if v == "" {
+		return "", nil
+	}
+	for _, fw := range v2FrameworkNames() {
+		if strings.EqualFold(fw, v) {
+			return fw, nil
+		}
+	}
+	return "", &CLIError{
+		Message:     fmt.Sprintf("invalid value %q for --type", v),
+		ValidValues: v2FrameworkNames(),
+	}
+}
+
+// validateListStatus validates --status case-insensitively against the phases
+// extractJobPhase can derive.
+func validateListStatus(v string) error {
+	if v == "" {
+		return nil
+	}
+	if !containsFold(validJobStatuses, v) {
+		return &CLIError{
+			Message:     fmt.Sprintf("invalid value %q for --status", v),
+			ValidValues: validJobStatuses,
+		}
+	}
+	return nil
+}
+
+// validateListLast rejects negative --last values.
+func validateListLast(n int) error {
+	if n < 0 {
+		return &CLIError{
+			Message: fmt.Sprintf("invalid value %d for --last", n),
+			Hint:    "use a positive number of jobs, or 0 for unlimited",
+		}
+	}
+	return nil
+}
+
+// validateListSelector pre-validates -l/--selector syntax client-side so a
+// typo fails fast with a teaching error instead of an API server 400.
+func validateListSelector(selector string) error {
+	if selector == "" {
+		return nil
+	}
+	if _, err := labels.Parse(selector); err != nil {
+		return &CLIError{
+			Message: fmt.Sprintf("invalid label selector %q: %v", selector, err),
+			Hint:    "expected kubectl selector syntax, e.g. -l app=training or -l 'tier in (frontend, backend)'",
+		}
+	}
+	return nil
+}
+
+// buildListSelector composes the server-side label selector for job list.
+// The arena.io/framework key-exists requirement scopes results to
+// arena-v2-created jobs; an explicit --type replaces it with the equality
+// form. A user -l selector is AND-combined with a comma.
+func buildListSelector(jobType, userSelector string) string {
+	parts := make([]string, 0, 2)
+	if jobType != "" {
+		parts = append(parts, frameworkLabel+"="+jobType)
+	} else {
+		parts = append(parts, v2LabelSelector)
+	}
+	if userSelector != "" {
+		parts = append(parts, userSelector)
+	}
+	return strings.Join(parts, ",")
+}
+
+// applyStatusFilter keeps jobs whose derived phase matches status
+// case-insensitively; an empty status keeps everything.
+func applyStatusFilter(jobs []client.JobStatus, status string) []client.JobStatus {
+	if status == "" {
+		return jobs
+	}
+	result := make([]client.JobStatus, 0, len(jobs))
+	for _, job := range jobs {
+		if strings.EqualFold(job.Status, status) {
+			result = append(result, job)
+		}
+	}
+	return result
+}
+
+// listedJob pairs a listed CRD object with the kind it was listed under, so
+// sorting and extraction survive the cross-kind merge.
+type listedJob struct {
+	kind string
+	obj  *unstructured.Unstructured
+}
+
+// sortListedJobsNewestFirst orders jobs by creation timestamp, newest first,
+// so a bounded list shows the most recent jobs.
+func sortListedJobsNewestFirst(all []listedJob) {
+	sort.SliceStable(all, func(i, j int) bool {
+		return all[i].obj.GetCreationTimestamp().After(all[j].obj.GetCreationTimestamp().Time)
+	})
+}
+
+// extractAllJobStatuses converts listed CRD objects into enriched JobStatus
+// values, preserving the input order.
+func extractAllJobStatuses(all []listedJob) []client.JobStatus {
+	jobs := make([]client.JobStatus, 0, len(all))
+	for _, lj := range all {
+		status := extractJobStatus(lj.obj, lj.kind)
+		if fw, ok := lj.obj.GetLabels()[frameworkLabel]; ok && fw != "" {
+			status.Framework = fw
+		} else {
+			status.Framework = kindToFramework(lj.kind)
+		}
+		status.GPURequested = extractGPURequested(lj.obj)
+		jobs = append(jobs, status)
+	}
+	return jobs
+}
+
+// limitJobList truncates jobs to limit (0 = unlimited). When entries are
+// dropped it writes a narrowing hint to w so output stays bounded at every
+// layer without polluting stdout.
+func limitJobList(w io.Writer, jobs []client.JobStatus, limit int) []client.JobStatus {
+	if limit <= 0 || len(jobs) <= limit {
+		return jobs
+	}
+	fmt.Fprintf(w, "Showing %d of %d jobs. Use --status or --selector to narrow, or --last=0 to show all.\n", limit, len(jobs))
+	return jobs[:limit]
+}
+
+// listJobsAcrossKinds lists every supported job kind with the given label
+// selector and merges the results. Missing CRDs are tolerated (logged and
+// skipped); MPIJob is skipped when the MPI CRD version is unresolved. Real
+// API errors are collected per kind: when every kind fails, the run fails;
+// partial failures are returned so the caller can warn that results may be
+// incomplete.
+func listJobsAcrossKinds(ctx context.Context, k8sClient *client.Client, ns, selector string) ([]listedJob, []string, error) {
+	all := make([]listedJob, 0)
+	apiErrors := make([]string, 0)
+	anySucceeded := false
+	for _, kind := range supportedJobKinds {
+		if kind == constants.KindMPIJob && k8sClient.GetMPIVersion() == "" {
+			continue
+		}
+		jobs, err := k8sClient.List(ctx, kind, ns, selector)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				log.Debug("CRD not installed", "kind", kind)
+				continue
+			}
+			apiVer, _ := k8sClient.KindToAPIVersion(kind)
+			log.Warning("failed to list CRD kind", "kind", kind, "apiVersion", apiVer, "error", err.Error())
+			apiErrors = append(apiErrors, fmt.Sprintf("%s: %s", kind, err.Error()))
+			continue
+		}
+		anySucceeded = true
+		for _, job := range jobs {
+			all = append(all, listedJob{kind: kind, obj: job})
+		}
+	}
+	if !anySucceeded && len(apiErrors) > 0 {
+		return nil, apiErrors, fmt.Errorf("failed to list any job types; checked %d kind(s)", len(apiErrors))
+	}
+	return all, apiErrors, nil
+}
+
 func newListCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List all training jobs",
-		Long:  `List all training jobs across PyTorchJob, TFJob, and MPIJob CRD kinds.`,
-		Args:  cobra.NoArgs,
+		Long: `List arena-v2 training jobs across PyTorchJob, TFJob, and MPIJob CRD kinds.
+
+Narrow results with --type (framework), --status (phase), or -l/--selector
+(kubectl label selector syntax). --last bounds the output to the N most
+recent jobs (default 50, 0 = unlimited). -A/--all-namespaces lists jobs in
+every namespace and adds a NAMESPACE column to table output.`,
+		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			// Validate format
-			if err := outputpkg.Format(outputFormat).Validate(); err != nil {
+			if err := validateOutputFormat(); err != nil {
+				return err
+			}
+			jobType, err := validateListType(listType)
+			if err != nil {
+				return err
+			}
+			if err := validateListStatus(listStatus); err != nil {
+				return err
+			}
+			if err := validateListLast(listLast); err != nil {
+				return err
+			}
+			if err := validateListSelector(listSelector); err != nil {
 				return err
 			}
 
@@ -34,49 +252,51 @@ func newListCmd() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("failed to create K8s client: %w", err)
 			}
-
-			mpiAvailable := true
 			if err := k8sClient.ResolveMPIVersion(cmdContext(cmd)); err != nil {
 				log.Debug("MPIJob CRD not available", "error", err.Error())
-				mpiAvailable = false
 			}
 
-			ns := resolveNS("")
-			allJobs := make([]client.JobStatus, 0)
-			for _, kind := range supportedJobKinds {
-				if kind == constants.KindMPIJob && !mpiAvailable {
-					continue
-				}
-				jobs, err := k8sClient.List(cmdContext(cmd), kind, ns, v2LabelSelector)
-				if err != nil {
-					if apierrors.IsNotFound(err) {
-						log.Debug("CRD not installed", "kind", kind)
-						continue
-					}
-					apiVer, _ := k8sClient.KindToAPIVersion(kind)
-					log.Warning("failed to list CRD kind", "kind", kind, "apiVersion", apiVer, "error", err.Error())
-					continue
-				}
-				for _, job := range jobs {
-					status := extractJobStatus(job, kind)
-					if fw, ok := job.GetLabels()[frameworkLabel]; ok && fw != "" {
-						status.Framework = fw
-					} else {
-						status.Framework = kindToFramework(kind)
-					}
-					status.GPURequested = extractGPURequested(job)
-					allJobs = append(allJobs, status)
+			ns := resolveListNamespace(listAllNamespaces)
+			selector := buildListSelector(jobType, listSelector)
+			all, apiErrors, err := listJobsAcrossKinds(cmdContext(cmd), k8sClient, ns, selector)
+			if err != nil {
+				return err
+			}
+			if len(apiErrors) > 0 {
+				fmt.Fprintf(cmd.ErrOrStderr(),
+					"\nWarning: failed to list %d job type(s) due to API errors; results may be incomplete:\n", len(apiErrors))
+				for _, e := range apiErrors {
+					fmt.Fprintf(cmd.ErrOrStderr(), "  - %s\n", e)
 				}
 			}
+
+			sortListedJobsNewestFirst(all)
+			allJobs := extractAllJobStatuses(all)
+			allJobs = applyStatusFilter(allJobs, listStatus)
+			allJobs = limitJobList(cmd.ErrOrStderr(), allJobs, listLast)
 
 			renderer := &outputpkg.TableRenderer{}
 			opts := outputpkg.RenderOptions{
 				TableFn: func() string { return renderer.RenderJobList(allJobs) },
 				WideFn:  func() string { return renderer.RenderJobListWide(allJobs) },
 			}
+			if listAllNamespaces {
+				opts.TableFn = func() string { return renderer.RenderJobListAllNamespaces(allJobs) }
+			}
 			return outputpkg.Format(outputFormat).Render(cmd.OutOrStdout(), allJobs, opts)
 		},
 	}
+	cmd.Flags().StringVarP(&listSelector, "selector", "l", "", "label selector (kubectl syntax, AND-combined with arena's job scope)")
+	cmd.Flags().StringVar(&listType, "type", "", "show only jobs of this framework type")
+	cmd.Flags().StringVar(&listStatus, "status", "", "show only jobs in this status phase")
+	cmd.Flags().IntVar(&listLast, "last", defaultListLast, "number of most recent jobs to show (0 = unlimited)")
+	cmd.Flags().BoolVarP(&listAllNamespaces, "all-namespaces", "A", false, "list jobs across all namespaces")
+
+	_ = cmd.RegisterFlagCompletionFunc("type", completeStaticChoices(v2FrameworkNames()...))
+	_ = cmd.RegisterFlagCompletionFunc("status", completeStaticChoices(validJobStatuses...))
+	_ = cmd.RegisterFlagCompletionFunc("selector", cobra.NoFileCompletions)
+
+	registerOutputFlag(cmd)
 	cmd.ValidArgsFunction = cobra.NoFileCompletions
 	return cmd
 }

--- a/pkg/cli/list_limit_test.go
+++ b/pkg/cli/list_limit_test.go
@@ -1,0 +1,177 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic/fake"
+
+	"github.com/kubeflow/arena/pkg/client"
+	outputpkg "github.com/kubeflow/arena/pkg/output"
+)
+
+func TestListCmd_HasSelectionFlags(t *testing.T) {
+	cmd := newListCmd()
+
+	sel := cmd.Flags().Lookup("selector")
+	require.NotNil(t, sel, "selector flag should be registered")
+	assert.Equal(t, "l", sel.Shorthand)
+	assert.Equal(t, "", sel.DefValue)
+
+	tp := cmd.Flags().Lookup("type")
+	require.NotNil(t, tp, "type flag should be registered")
+	assert.Equal(t, "", tp.DefValue)
+
+	st := cmd.Flags().Lookup("status")
+	require.NotNil(t, st, "status flag should be registered")
+	assert.Equal(t, "", st.DefValue)
+
+	last := cmd.Flags().Lookup("last")
+	require.NotNil(t, last, "last flag should be registered")
+	assert.Equal(t, "50", last.DefValue)
+
+	assert.Nil(t, cmd.Flags().Lookup("filter"), "--filter should be removed")
+	assert.Nil(t, cmd.Flags().Lookup("limit"), "--limit should be removed")
+}
+
+func TestSortListedJobsNewestFirst(t *testing.T) {
+	mk := func(name string, age time.Duration) listedJob {
+		obj := &unstructured.Unstructured{}
+		obj.SetName(name)
+		obj.SetCreationTimestamp(metav1.NewTime(time.Now().Add(-age)))
+		return listedJob{kind: "PyTorchJob", obj: obj}
+	}
+	all := []listedJob{mk("old", 3*time.Hour), mk("new", 1*time.Minute), mk("mid", 30*time.Minute)}
+	sortListedJobsNewestFirst(all)
+	names := []string{all[0].obj.GetName(), all[1].obj.GetName(), all[2].obj.GetName()}
+	assert.Equal(t, []string{"new", "mid", "old"}, names)
+}
+
+func TestExtractAllJobStatuses(t *testing.T) {
+	obj := &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "kubeflow.org/v1",
+		"kind":       "PyTorchJob",
+		"metadata": map[string]interface{}{
+			"name":      "j1",
+			"namespace": "default",
+			"labels":    map[string]interface{}{frameworkLabel: "deepspeed"},
+		},
+	}}
+	jobs := extractAllJobStatuses([]listedJob{{kind: "MPIJob", obj: obj}})
+	require.Len(t, jobs, 1)
+	assert.Equal(t, "j1", jobs[0].Name)
+	assert.Equal(t, "deepspeed", jobs[0].Framework, "framework label should win over kind fallback")
+}
+
+func TestExtractAllJobStatuses_FallbackFramework(t *testing.T) {
+	obj := &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "kubeflow.org/v1",
+		"kind":       "TFJob",
+		"metadata": map[string]interface{}{
+			"name":      "j2",
+			"namespace": "default",
+		},
+	}}
+	jobs := extractAllJobStatuses([]listedJob{{kind: "TFJob", obj: obj}})
+	require.Len(t, jobs, 1)
+	assert.Equal(t, "tensorflow", jobs[0].Framework)
+}
+
+func TestLimitJobList_TruncatesWithHint(t *testing.T) {
+	jobs := make([]client.JobStatus, 0, 60)
+	for i := 0; i < 60; i++ {
+		jobs = append(jobs, client.JobStatus{Name: fmt.Sprintf("job-%d", i)})
+	}
+	var buf bytes.Buffer
+	got := limitJobList(&buf, jobs, 50)
+	assert.Len(t, got, 50)
+	assert.Equal(t, "Showing 50 of 60 jobs. Use --status or --selector to narrow, or --last=0 to show all.\n", buf.String())
+}
+
+func TestLimitJobList_ZeroIsUnlimited(t *testing.T) {
+	jobs := make([]client.JobStatus, 60)
+	var buf bytes.Buffer
+	got := limitJobList(&buf, jobs, 0)
+	assert.Len(t, got, 60)
+	assert.Empty(t, buf.String())
+}
+
+func TestLimitJobList_UnderLimitNoHint(t *testing.T) {
+	jobs := make([]client.JobStatus, 10)
+	var buf bytes.Buffer
+	got := limitJobList(&buf, jobs, 50)
+	assert.Len(t, got, 10)
+	assert.Empty(t, buf.String())
+}
+
+func TestLimitJobList_AtLimitNoHint(t *testing.T) {
+	jobs := make([]client.JobStatus, 50)
+	var buf bytes.Buffer
+	got := limitJobList(&buf, jobs, 50)
+	assert.Len(t, got, 50)
+	assert.Empty(t, buf.String())
+}
+
+// newListTestClient builds a fake dynamic client with all three job-kind
+// GVRs registered, the MPI version pre-resolved, and the given objects
+// preloaded.
+func newListTestClient(t *testing.T, objs ...runtime.Object) (*client.Client, *fake.FakeDynamicClient) {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	listKinds := map[schema.GroupVersionResource]string{
+		{Group: "kubeflow.org", Version: "v1", Resource: "pytorchjobs"}: "PyTorchJobList",
+		{Group: "kubeflow.org", Version: "v1", Resource: "tfjobs"}:      "TFJobList",
+		{Group: "kubeflow.org", Version: "v1", Resource: "mpijobs"}:     "MPIJobList",
+	}
+	fakeDynamic := fake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds, objs...)
+	c := client.NewClientForInterface(fakeDynamic)
+	c.SetMPIVersion("v1")
+	return c, fakeDynamic
+}
+
+func TestListPipeline_DefaultPathKeepsNewest50(t *testing.T) {
+	objs := make([]runtime.Object, 0, 60)
+	for i := 0; i < 60; i++ {
+		obj := &unstructured.Unstructured{Object: map[string]interface{}{
+			"apiVersion": "kubeflow.org/v1",
+			"kind":       "PyTorchJob",
+			"metadata": map[string]interface{}{
+				"name":      fmt.Sprintf("job-%02d", i),
+				"namespace": "default",
+				"labels":    map[string]interface{}{frameworkLabel: "pytorch"},
+			},
+		}}
+		obj.SetCreationTimestamp(metav1.NewTime(time.Now().Add(-time.Duration(60-i) * time.Minute)))
+		objs = append(objs, obj)
+	}
+	c, _ := newListTestClient(t, objs...)
+
+	all, _, err := listJobsAcrossKinds(context.Background(), c, "default", buildListSelector("", ""))
+	require.NoError(t, err)
+	require.Len(t, all, 60)
+
+	sortListedJobsNewestFirst(all)
+	allJobs := extractAllJobStatuses(all)
+	allJobs = applyStatusFilter(allJobs, "")
+	var buf bytes.Buffer
+	allJobs = limitJobList(&buf, allJobs, defaultListLast)
+
+	require.Len(t, allJobs, 50)
+	assert.Equal(t, "job-59", allJobs[0].Name)
+	assert.Equal(t, "job-10", allJobs[49].Name)
+	assert.Equal(t, "Showing 50 of 60 jobs. Use --status or --selector to narrow, or --last=0 to show all.\n", buf.String())
+
+	renderer := &outputpkg.TableRenderer{}
+	out := renderer.RenderJobList(allJobs)
+	assert.Contains(t, out, "job-59")
+	assert.NotContains(t, out, "job-09")
+}

--- a/pkg/cli/list_selectors_test.go
+++ b/pkg/cli/list_selectors_test.go
@@ -1,0 +1,279 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	ktesting "k8s.io/client-go/testing"
+
+	"github.com/kubeflow/arena/pkg/client"
+)
+
+func TestValidateListType(t *testing.T) {
+	for _, fw := range v2FrameworkNames() {
+		got, err := validateListType(fw)
+		require.NoError(t, err, "framework %q should be valid", fw)
+		assert.Equal(t, fw, got)
+	}
+
+	// Case-insensitive validation, canonical lowercase output.
+	got, err := validateListType("PyTorch")
+	require.NoError(t, err)
+	assert.Equal(t, "pytorch", got)
+
+	got, err = validateListType("")
+	require.NoError(t, err)
+	assert.Empty(t, got)
+
+	_, err = validateListType("jax")
+	var cliErr *CLIError
+	require.Error(t, err)
+	require.True(t, errors.As(err, &cliErr))
+	assert.Equal(t, []string{"pytorch", "tensorflow", "mpi", "horovod", "deepspeed"}, cliErr.ValidValues)
+	assert.Contains(t, err.Error(), `invalid value "jax" for --type`)
+}
+
+func TestValidateListStatus(t *testing.T) {
+	for _, s := range validJobStatuses {
+		require.NoError(t, validateListStatus(s), "status %q should be valid", s)
+	}
+	require.NoError(t, validateListStatus(""))
+	require.NoError(t, validateListStatus("succeeded")) // case-insensitive
+
+	err := validateListStatus("Zombie")
+	var cliErr *CLIError
+	require.Error(t, err)
+	require.True(t, errors.As(err, &cliErr))
+	assert.Equal(t, validJobStatuses, cliErr.ValidValues)
+	assert.Contains(t, err.Error(), `invalid value "Zombie" for --status`)
+}
+
+func TestValidateListLast(t *testing.T) {
+	require.NoError(t, validateListLast(0))
+	require.NoError(t, validateListLast(50))
+
+	err := validateListLast(-1)
+	var cliErr *CLIError
+	require.Error(t, err)
+	require.True(t, errors.As(err, &cliErr))
+	assert.Equal(t, "use a positive number of jobs, or 0 for unlimited", cliErr.Hint)
+	assert.Contains(t, err.Error(), `invalid value -1 for --last`)
+}
+
+func TestValidateListSelector(t *testing.T) {
+	require.NoError(t, validateListSelector(""))
+	for _, s := range []string{
+		"app=training",
+		"app==training",
+		"tier!=frontend",
+		"tier in (frontend, backend)",
+		"environment", // key-exists
+	} {
+		require.NoError(t, validateListSelector(s), "selector %q should be valid", s)
+	}
+
+	err := validateListSelector("a=b=c")
+	var cliErr *CLIError
+	require.Error(t, err)
+	require.True(t, errors.As(err, &cliErr))
+	assert.Contains(t, err.Error(), `invalid label selector "a=b=c"`)
+	assert.Equal(t, "expected kubectl selector syntax, e.g. -l app=training or -l 'tier in (frontend, backend)'", cliErr.Hint)
+}
+
+func TestBuildListSelector(t *testing.T) {
+	tests := []struct {
+		name         string
+		jobType      string
+		userSelector string
+		want         string
+	}{
+		{name: "empty keeps key-exists scope", want: "arena.io/framework"},
+		{name: "type only becomes equality", jobType: "pytorch", want: "arena.io/framework=pytorch"},
+		{name: "user selector only", userSelector: "app=training", want: "arena.io/framework,app=training"},
+		{name: "type and user selector AND-combined", jobType: "mpi", userSelector: "team=ai", want: "arena.io/framework=mpi,team=ai"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, buildListSelector(tt.jobType, tt.userSelector))
+		})
+	}
+}
+
+func TestBuildListSelector_IsParseable(t *testing.T) {
+	for _, sel := range []string{
+		buildListSelector("", ""),
+		buildListSelector("pytorch", ""),
+		buildListSelector("", "app=training"),
+		buildListSelector("deepspeed", "tier in (frontend, backend)"),
+	} {
+		_, err := labels.Parse(sel)
+		require.NoError(t, err, "selector %q must be parseable", sel)
+	}
+}
+
+func jobNames(jobs []client.JobStatus) []string {
+	names := make([]string, 0, len(jobs))
+	for _, j := range jobs {
+		names = append(names, j.Name)
+	}
+	return names
+}
+
+func TestApplyStatusFilter(t *testing.T) {
+	jobs := []client.JobStatus{
+		{Name: "a", Status: "Running"},
+		{Name: "b", Status: "Succeeded"},
+		{Name: "c", Status: "Pending"},
+	}
+
+	assert.Equal(t, jobs, applyStatusFilter(jobs, ""), "empty status keeps all")
+	assert.Equal(t, []string{"a"}, jobNames(applyStatusFilter(jobs, "running")))
+	assert.Equal(t, []string{"b"}, jobNames(applyStatusFilter(jobs, "Succeeded")))
+	assert.Empty(t, applyStatusFilter(jobs, "Failed"))
+}
+
+func TestListJobsAcrossKinds_PassesComposedSelector(t *testing.T) {
+	c, fakeDynamic := newListTestClient(t)
+
+	selector := buildListSelector("pytorch", "app=training")
+	_, _, err := listJobsAcrossKinds(context.Background(), c, "default", selector)
+	require.NoError(t, err)
+
+	var got []string
+	for _, action := range fakeDynamic.Actions() {
+		if action.GetVerb() != "list" {
+			continue
+		}
+		listAction, ok := action.(ktesting.ListActionImpl)
+		require.True(t, ok, "list action should be ListActionImpl, got %T", action)
+		got = append(got, listAction.GetListRestrictions().Labels.String())
+	}
+	require.Len(t, got, 3, "one list call per job kind")
+
+	// labels.Selector.String() renders requirements in canonical (sorted)
+	// order, so compare against the parsed expected selector rather than the
+	// raw composed string.
+	want, err := labels.Parse("arena.io/framework=pytorch,app=training")
+	require.NoError(t, err)
+	for _, sel := range got {
+		assert.Equal(t, want.String(), sel)
+	}
+}
+
+func TestListCmd_RemovedFlagsAreRejected(t *testing.T) {
+	orig := outputFormat
+	t.Cleanup(func() { outputFormat = orig })
+
+	for _, flag := range []string{"--filter", "--limit"} {
+		err := ExecuteWithArgs([]string{"job", "list", flag, "name=x"})
+		require.Error(t, err, "%s should be rejected as unknown flag", flag)
+		assert.Contains(t, err.Error(), "unknown flag")
+	}
+}
+
+func TestResolveListNamespace(t *testing.T) {
+	orig := namespace
+	t.Cleanup(func() { namespace = orig })
+
+	namespace = "team-a"
+	assert.Empty(t, resolveListNamespace(true), "-A must return the all-namespaces scope")
+	assert.Equal(t, "team-a", resolveListNamespace(false), "without -A the resolveNS chain applies")
+
+	namespace = "e2e-b"
+	assert.Empty(t, resolveListNamespace(true), "-A silently overrides -n")
+}
+
+func TestListJobsAcrossKinds_EmptyNamespaceIsPassedThrough(t *testing.T) {
+	c, fakeDynamic := newListTestClient(t)
+
+	_, _, err := listJobsAcrossKinds(context.Background(), c, "", "arena.io/framework")
+	require.NoError(t, err)
+
+	listed := 0
+	for _, action := range fakeDynamic.Actions() {
+		if action.GetVerb() != "list" {
+			continue
+		}
+		listAction, ok := action.(ktesting.ListActionImpl)
+		require.True(t, ok, "list action should be ListActionImpl, got %T", action)
+		assert.Empty(t, listAction.GetNamespace(), "all-namespaces listing must pass an empty namespace to the API")
+		listed++
+	}
+	require.Equal(t, 3, listed, "one list call per job kind")
+}
+
+func TestListCmd_AllNamespacesFlagRegistered(t *testing.T) {
+	flag := newListCmd().Flags().Lookup("all-namespaces")
+	require.NotNil(t, flag, "job list must register --all-namespaces")
+	assert.Equal(t, "A", flag.Shorthand)
+}
+
+func TestListCmd_AllNamespacesParses(t *testing.T) {
+	err := ExecuteWithArgs([]string{"job", "list", "-A", "--kubeconfig", "/nonexistent/kubeconfig"})
+	require.Error(t, err, "nonexistent kubeconfig must fail the run")
+	assert.NotContains(t, err.Error(), "unknown", "-A must parse as a known flag")
+	assert.Contains(t, err.Error(), "failed to create K8s client")
+}
+
+func forbiddenReactor(_ ktesting.Action) (bool, runtime.Object, error) {
+	return true, nil, apierrors.NewForbidden(
+		schema.GroupResource{Group: "kubeflow.org", Resource: "jobs"},
+		"list",
+		errors.New("insufficient permissions"),
+	)
+}
+
+func notFoundReactor(_ ktesting.Action) (bool, runtime.Object, error) {
+	return true, nil, apierrors.NewNotFound(
+		schema.GroupResource{Group: "kubeflow.org", Resource: "pytorchjobs"},
+		"",
+	)
+}
+
+func TestListJobsAcrossKinds_AllKindsAPIErrorsFailLoudly(t *testing.T) {
+	c, fakeDynamic := newListTestClient(t)
+	fakeDynamic.PrependReactor("list", "*", forbiddenReactor)
+
+	_, apiErrs, err := listJobsAcrossKinds(context.Background(), c, "default", "arena.io/framework")
+	require.Error(t, err, "all kinds failing with API errors must surface an error")
+	assert.Contains(t, err.Error(), "failed to list any job types")
+	assert.Len(t, apiErrs, 3, "one API error per job kind")
+}
+
+func TestListJobsAcrossKinds_PartialFailureStillListsJobs(t *testing.T) {
+	obj := &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "kubeflow.org/v1",
+		"kind":       "PyTorchJob",
+		"metadata": map[string]interface{}{
+			"name":      "job-a",
+			"namespace": "default",
+			"labels":    map[string]interface{}{frameworkLabel: "pytorch"},
+		},
+	}}
+	c, fakeDynamic := newListTestClient(t, obj)
+	fakeDynamic.PrependReactor("list", "tfjobs", forbiddenReactor)
+
+	jobs, apiErrs, err := listJobsAcrossKinds(context.Background(), c, "default", "arena.io/framework")
+	require.NoError(t, err, "partial failure must not fail the whole listing")
+	assert.Len(t, jobs, 1, "jobs from succeeding kinds are still listed")
+	assert.Len(t, apiErrs, 1)
+	assert.Contains(t, apiErrs[0], "TFJob")
+}
+
+func TestListJobsAcrossKinds_AllCRDsMissingReturnsEmpty(t *testing.T) {
+	c, fakeDynamic := newListTestClient(t)
+	fakeDynamic.PrependReactor("list", "*", notFoundReactor)
+
+	jobs, apiErrs, err := listJobsAcrossKinds(context.Background(), c, "default", "arena.io/framework")
+	require.NoError(t, err, "missing CRDs are not API failures")
+	assert.Empty(t, jobs)
+	assert.Empty(t, apiErrs)
+}

--- a/pkg/cli/list_test.go
+++ b/pkg/cli/list_test.go
@@ -620,26 +620,30 @@ func TestFormatAge(t *testing.T) {
 }
 
 func TestListCmd_Help(t *testing.T) {
-	assert.Equal(t, "list", listCmd.Use)
-	assert.NotEmpty(t, listCmd.Short)
+	cmd := newListCmd()
+	assert.Equal(t, "list", cmd.Use)
+	assert.NotEmpty(t, cmd.Short)
 }
 
 func TestGetCmd_RequiresArg(t *testing.T) {
-	err := getCmd.Args(getCmd, []string{})
+	cmd := newGetCmd()
+	err := cmd.Args(cmd, []string{})
 	assert.Error(t, err)
 }
 
 func TestGetCmd_AcceptsOneArg(t *testing.T) {
-	err := getCmd.Args(getCmd, []string{"my-job"})
+	cmd := newGetCmd()
+	err := cmd.Args(cmd, []string{"my-job"})
 	assert.NoError(t, err)
 }
 
 func TestGetCmd_NotFound(t *testing.T) {
+	cmd := newGetCmd()
 	orig := kubeconfig
 	defer func() { kubeconfig = orig }()
 
 	kubeconfig = "/nonexistent/kubeconfig"
-	err := getCmd.RunE(getCmd, []string{"nonexistent-job"})
+	err := cmd.RunE(cmd, []string{"nonexistent-job"})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to create K8s client")
 }
@@ -699,7 +703,7 @@ func TestSupportedJobKinds(t *testing.T) {
 
 // Verify the job subcommands are registered
 func TestCommandsRegistered(t *testing.T) {
-	commands := jobCmd.Commands()
+	commands := newJobCmd().Commands()
 	var names []string
 	for _, cmd := range commands {
 		names = append(names, cmd.Name())
@@ -710,7 +714,7 @@ func TestCommandsRegistered(t *testing.T) {
 
 	// submit is a top-level command, not under job
 	rootNames := []string{}
-	for _, cmd := range rootCmd.Commands() {
+	for _, cmd := range NewRootCommand().Commands() {
 		rootNames = append(rootNames, cmd.Name())
 	}
 	assert.Contains(t, rootNames, "submit")

--- a/pkg/cli/logs.go
+++ b/pkg/cli/logs.go
@@ -23,10 +23,11 @@ var (
 	logsContainer string // container name (default: first container)
 )
 
-var logsCmd = &cobra.Command{
-	Use:   "logs <name>",
-	Short: "View logs from a training job",
-	Long: `Stream logs from a training job pod. By default, streams from the primary pod
+func newLogsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "logs <name>",
+		Short: "View logs from a training job",
+		Long: `Stream logs from a training job pod. By default, streams from the primary pod
 (master/chief/launcher). Use --pod to specify a pod by name and --container to select
 a specific container within the pod.
 
@@ -42,157 +43,157 @@ Examples:
 
   # Follow logs with tail
   arena job logs my-job -f --tail 100`,
-	Args: cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		name := args[0]
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			name := args[0]
 
-		// Use arena client to find the job kind
-		k8sClient, err := client.NewClient(kubeconfig, kubeContext)
-		if err != nil {
-			return fmt.Errorf("failed to create K8s client: %w", err)
-		}
-
-		ns := resolveNS("")
-		// Determine job kind using ConfigMap anchor (consistent with other commands)
-		jobKind, err := detectJobType(cmdContext(cmd), k8sClient, ns, name)
-		if err != nil {
-			return err
-		}
-
-		// Get the matching provider for this job kind
-		frameworkName := kindToFramework(jobKind)
-		p, err := getProvider(frameworkName)
-		if err != nil {
-			return fmt.Errorf("failed to get provider for %s: %w", jobKind, err)
-		}
-
-		// Build the clientset for pod log streaming
-		config, err := client.LoadRestConfig(kubeconfig, kubeContext)
-		if err != nil {
-			return fmt.Errorf("failed to build config: %w", err)
-		}
-
-		clientset, err := kubernetes.NewForConfig(config)
-		if err != nil {
-			return fmt.Errorf("failed to create clientset: %w", err)
-		}
-
-		var podName string
-		var selectedPod *corev1.Pod
-
-		if logsPod != "" {
-			// User specified pod name - validate it exists and belongs to job
-			pod, err := clientset.CoreV1().Pods(ns).Get(
-				cmdContext(cmd),
-				logsPod,
-				metav1.GetOptions{},
-			)
+			// Use arena client to find the job kind
+			k8sClient, err := client.NewClient(kubeconfig, kubeContext)
 			if err != nil {
-				if apierrors.IsNotFound(err) {
-					return fmt.Errorf("pod %q not found in namespace %q", logsPod, ns)
+				return fmt.Errorf("failed to create K8s client: %w", err)
+			}
+
+			ns := resolveNS("")
+			// Determine job kind using ConfigMap anchor (consistent with other commands)
+			jobKind, err := detectJobType(cmdContext(cmd), k8sClient, ns, name)
+			if err != nil {
+				return err
+			}
+
+			// Get the matching provider for this job kind
+			frameworkName := kindToFramework(jobKind)
+			p, err := getProvider(frameworkName)
+			if err != nil {
+				return fmt.Errorf("failed to get provider for %s: %w", jobKind, err)
+			}
+
+			// Build the clientset for pod log streaming
+			config, err := client.LoadRestConfig(kubeconfig, kubeContext)
+			if err != nil {
+				return fmt.Errorf("failed to build config: %w", err)
+			}
+
+			clientset, err := kubernetes.NewForConfig(config)
+			if err != nil {
+				return fmt.Errorf("failed to create clientset: %w", err)
+			}
+
+			var podName string
+			var selectedPod *corev1.Pod
+
+			if logsPod != "" {
+				// User specified pod name - validate it exists and belongs to job
+				pod, err := clientset.CoreV1().Pods(ns).Get(
+					cmdContext(cmd),
+					logsPod,
+					metav1.GetOptions{},
+				)
+				if err != nil {
+					if apierrors.IsNotFound(err) {
+						return fmt.Errorf("pod %q not found in namespace %q", logsPod, ns)
+					}
+					return fmt.Errorf("failed to get pod %q: %w", logsPod, err)
 				}
-				return fmt.Errorf("failed to get pod %q: %w", logsPod, err)
-			}
 
-			// Validate pod belongs to job using provider's label convention
-			if !podBelongsToJob(pod, name) {
-				return fmt.Errorf("pod %q does not belong to job %q", logsPod, name)
-			}
+				// Validate pod belongs to job using provider's label convention
+				if !podBelongsToJob(pod, name) {
+					return fmt.Errorf("pod %q does not belong to job %q", logsPod, name)
+				}
 
-			podName = pod.Name
-			selectedPod = pod
-		} else {
-			// Use the provider's log pod selector
-			selector := p.GetLogPodSelector(name)
+				podName = pod.Name
+				selectedPod = pod
+			} else {
+				// Use the provider's log pod selector
+				selector := p.GetLogPodSelector(name)
 
-			// Find pod using provider's selector
-			pods, err := clientset.CoreV1().Pods(ns).List(
-				cmdContext(cmd),
-				metav1.ListOptions{
-					LabelSelector: selector,
-				},
-			)
-			if err != nil {
-				return fmt.Errorf("failed to list pods: %w", err)
-			}
-
-			// For TFJob, if chief selector found zero pods, fall back to worker replica
-			// (chief is conditional in TFJob; when absent, worker is the primary log target)
-			if len(pods.Items) == 0 && jobKind == constants.KindTFJob {
-				fallbackSelector := buildTFJobFallbackSelector(name)
-				pods, err = clientset.CoreV1().Pods(ns).List(
+				// Find pod using provider's selector
+				pods, err := clientset.CoreV1().Pods(ns).List(
 					cmdContext(cmd),
 					metav1.ListOptions{
-						LabelSelector: fallbackSelector,
+						LabelSelector: selector,
 					},
 				)
 				if err != nil {
-					return fmt.Errorf("failed to list pods with fallback selector: %w", err)
+					return fmt.Errorf("failed to list pods: %w", err)
 				}
-				selector = fallbackSelector
+
+				// For TFJob, if chief selector found zero pods, fall back to worker replica
+				// (chief is conditional in TFJob; when absent, worker is the primary log target)
+				if len(pods.Items) == 0 && jobKind == constants.KindTFJob {
+					fallbackSelector := buildTFJobFallbackSelector(name)
+					pods, err = clientset.CoreV1().Pods(ns).List(
+						cmdContext(cmd),
+						metav1.ListOptions{
+							LabelSelector: fallbackSelector,
+						},
+					)
+					if err != nil {
+						return fmt.Errorf("failed to list pods with fallback selector: %w", err)
+					}
+					selector = fallbackSelector
+				}
+
+				if len(pods.Items) == 0 {
+					return fmt.Errorf("no pods found for job %q in namespace %q using selector %q", name, ns, selector)
+				}
+
+				podName = pods.Items[0].Name
+				selectedPod = &pods.Items[0]
 			}
 
-			if len(pods.Items) == 0 {
-				return fmt.Errorf("no pods found for job %q in namespace %q using selector %q", name, ns, selector)
+			// Build log options.
+			logOptions := &corev1.PodLogOptions{
+				Follow: logsFollow,
+			}
+			if logsTail > 0 {
+				tail := int64(logsTail)
+				logOptions.TailLines = &tail
 			}
 
-			podName = pods.Items[0].Name
-			selectedPod = &pods.Items[0]
-		}
+			// Validate container if specified.
+			if logsContainer != "" {
+				if !containerExists(selectedPod, logsContainer) {
+					available := getAvailableContainers(selectedPod)
+					return fmt.Errorf("container %q not found in pod %q (available: %s)",
+						logsContainer, podName, strings.Join(available, ", "))
+				}
 
-		// Build log options.
-		logOptions := &corev1.PodLogOptions{
-			Follow: logsFollow,
-		}
-		if logsTail > 0 {
-			tail := int64(logsTail)
-			logOptions.TailLines = &tail
-		}
-
-		// Validate container if specified.
-		if logsContainer != "" {
-			if !containerExists(selectedPod, logsContainer) {
-				available := getAvailableContainers(selectedPod)
-				return fmt.Errorf("container %q not found in pod %q (available: %s)",
-					logsContainer, podName, strings.Join(available, ", "))
+				logOptions.Container = logsContainer
 			}
 
-			logOptions.Container = logsContainer
-		}
-
-		// Stream logs from the pod.
-		req := clientset.CoreV1().Pods(ns).GetLogs(podName, logOptions)
-		stream, err := req.Stream(cmdContext(cmd))
-		if err != nil {
-			return fmt.Errorf("failed to stream logs from pod %q: %w", podName, err)
-		}
-		defer func() {
-			if err := stream.Close(); err != nil {
-				log.Debug("error closing log stream", "error", err.Error())
+			// Stream logs from the pod.
+			req := clientset.CoreV1().Pods(ns).GetLogs(podName, logOptions)
+			stream, err := req.Stream(cmdContext(cmd))
+			if err != nil {
+				return fmt.Errorf("failed to stream logs from pod %q: %w", podName, err)
 			}
-		}()
+			defer func() {
+				if err := stream.Close(); err != nil {
+					log.Debug("error closing log stream", "error", err.Error())
+				}
+			}()
 
-		scanner := bufio.NewScanner(stream)
-		// Increase buffer from default 64KB to 1MB — training logs can emit
-		// long JSON lines or stack traces that exceed the default token limit.
-		scanner.Buffer(make([]byte, 64*1024), 1024*1024)
-		for scanner.Scan() {
-			fmt.Println(scanner.Text())
-		}
+			scanner := bufio.NewScanner(stream)
+			// Increase buffer from default 64KB to 1MB — training logs can emit
+			// long JSON lines or stack traces that exceed the default token limit.
+			scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+			out := cmd.OutOrStdout()
+			for scanner.Scan() {
+				fmt.Fprintln(out, scanner.Text())
+			}
 
-		if err := scanner.Err(); err != nil {
-			return fmt.Errorf("error reading log stream: %w", err)
-		}
+			if err := scanner.Err(); err != nil {
+				return fmt.Errorf("error reading log stream: %w", err)
+			}
 
-		return nil
-	},
-}
+			return nil
+		},
+	}
 
-func init() {
-	logsCmd.Flags().BoolVarP(&logsFollow, "follow", "f", false, "follow log output")
-	logsCmd.Flags().IntVar(&logsTail, "tail", -1, "number of lines to show from end")
-	logsCmd.Flags().StringVar(&logsPod, "pod", "", "pod name (skip label selector)")
-	logsCmd.Flags().StringVar(&logsContainer, "container", "", "container name (default: first container)")
-	logsCmd.ValidArgsFunction = completeJobName
-	jobCmd.AddCommand(logsCmd)
+	cmd.Flags().BoolVarP(&logsFollow, "follow", "f", false, "follow log output")
+	cmd.Flags().IntVar(&logsTail, "tail", -1, "number of lines to show from end")
+	cmd.Flags().StringVar(&logsPod, "pod", "", "pod name (skip label selector)")
+	cmd.Flags().StringVar(&logsContainer, "container", "", "container name (default: first container)")
+	cmd.ValidArgsFunction = completeJobName
+	return cmd
 }

--- a/pkg/cli/logs_test.go
+++ b/pkg/cli/logs_test.go
@@ -13,27 +13,28 @@ import (
 )
 
 func TestLogsCmd_ArgsValidator(t *testing.T) {
-	assert.Error(t, logsCmd.Args(logsCmd, []string{}))
-	assert.NoError(t, logsCmd.Args(logsCmd, []string{"my-job"}))
-	assert.Error(t, logsCmd.Args(logsCmd, []string{"a", "b"}))
+	cmd := newLogsCmd()
+	assert.Error(t, cmd.Args(cmd, []string{}))
+	assert.NoError(t, cmd.Args(cmd, []string{"my-job"}))
+	assert.Error(t, cmd.Args(cmd, []string{"a", "b"}))
 }
 
 func TestLogsCmd_FollowFlag(t *testing.T) {
-	f := logsCmd.Flags().Lookup("follow")
+	f := newLogsCmd().Flags().Lookup("follow")
 	require.NotNil(t, f, "expected --follow flag to be registered")
 	assert.Equal(t, "f", f.Shorthand)
 	assert.Equal(t, "false", f.DefValue)
 }
 
 func TestLogsCmd_TailFlag(t *testing.T) {
-	f := logsCmd.Flags().Lookup("tail")
+	f := newLogsCmd().Flags().Lookup("tail")
 	require.NotNil(t, f, "expected --tail flag to be registered")
 	assert.Equal(t, "-1", f.DefValue)
 }
 
 func TestLogsCmd_RegisteredOnJob(t *testing.T) {
 	found := false
-	for _, cmd := range jobCmd.Commands() {
+	for _, cmd := range newJobCmd().Commands() {
 		if cmd.Use == "logs <name>" {
 			found = true
 			break
@@ -47,14 +48,15 @@ func TestLogsCmd_RunE_FailsWithInvalidKubeconfig(t *testing.T) {
 	defer func() { kubeconfig = orig }()
 
 	kubeconfig = "/nonexistent/kubeconfig"
-	err := logsCmd.RunE(logsCmd, []string{"my-job"})
+	cmd := newLogsCmd()
+	err := cmd.RunE(cmd, []string{"my-job"})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to build config")
 }
 
 func TestLogsCmd_HasCorrectUse(t *testing.T) {
-	assert.Equal(t, "logs <name>", logsCmd.Use)
-	assert.NotEmpty(t, logsCmd.Short)
+	assert.Equal(t, "logs <name>", newLogsCmd().Use)
+	assert.NotEmpty(t, newLogsCmd().Short)
 }
 
 func TestLogsCmd_RunE_RequiresKubeconfig(t *testing.T) {
@@ -63,19 +65,20 @@ func TestLogsCmd_RunE_RequiresKubeconfig(t *testing.T) {
 
 	t.Setenv("KUBECONFIG", "/nonexistent/env-kubeconfig")
 	kubeconfig = ""
-	err := logsCmd.RunE(logsCmd, []string{"my-job"})
+	cmd := newLogsCmd()
+	err := cmd.RunE(cmd, []string{"my-job"})
 	// Without a valid kubeconfig, client creation or REST config should fail.
 	assert.Error(t, err)
 }
 
 func TestLogsCmd_PodFlag(t *testing.T) {
-	f := logsCmd.Flags().Lookup("pod")
+	f := newLogsCmd().Flags().Lookup("pod")
 	require.NotNil(t, f, "expected --pod flag to be registered")
 	assert.Equal(t, "", f.DefValue)
 }
 
 func TestLogsCmd_ContainerFlag(t *testing.T) {
-	f := logsCmd.Flags().Lookup("container")
+	f := newLogsCmd().Flags().Lookup("container")
 	require.NotNil(t, f, "expected --container flag to be registered")
 	assert.Equal(t, "", f.DefValue)
 }
@@ -602,13 +605,13 @@ func TestLogsCmd_BufferConfiguration(t *testing.T) {
 	// Verify that the logs command exists and has proper configuration
 	// The actual buffer size is set in the RunE function, but we can verify
 	// the command structure is correct
-	assert.Equal(t, "logs <name>", logsCmd.Use)
-	assert.NotNil(t, logsCmd.RunE)
+	assert.Equal(t, "logs <name>", newLogsCmd().Use)
+	assert.NotNil(t, newLogsCmd().RunE)
 
 	// Verify all expected flags are present
 	flags := []string{"follow", "tail", "pod", "container"}
 	for _, flagName := range flags {
-		f := logsCmd.Flags().Lookup(flagName)
+		f := newLogsCmd().Flags().Lookup(flagName)
 		require.NotNil(t, f, "expected flag %s to be registered", flagName)
 	}
 }

--- a/pkg/cli/logs_test.go
+++ b/pkg/cli/logs_test.go
@@ -44,9 +44,10 @@ func TestLogsCmd_RegisteredOnJob(t *testing.T) {
 }
 
 func TestLogsCmd_RunE_FailsWithInvalidKubeconfig(t *testing.T) {
-	orig := kubeconfig
-	defer func() { kubeconfig = orig }()
+	orig, origKubeconfig := outputFormat, kubeconfig
+	t.Cleanup(func() { outputFormat, kubeconfig = orig, origKubeconfig })
 
+	outputFormat = "table"
 	kubeconfig = "/nonexistent/kubeconfig"
 	cmd := newLogsCmd()
 	err := cmd.RunE(cmd, []string{"my-job"})
@@ -60,11 +61,12 @@ func TestLogsCmd_HasCorrectUse(t *testing.T) {
 }
 
 func TestLogsCmd_RunE_RequiresKubeconfig(t *testing.T) {
-	orig := kubeconfig
-	defer func() { kubeconfig = orig }()
+	orig, origKubeconfig := outputFormat, kubeconfig
+	t.Cleanup(func() { outputFormat, kubeconfig = orig, origKubeconfig })
 
-	t.Setenv("KUBECONFIG", "/nonexistent/env-kubeconfig")
+	outputFormat = "table"
 	kubeconfig = ""
+	t.Setenv("KUBECONFIG", "/nonexistent/env-kubeconfig")
 	cmd := newLogsCmd()
 	err := cmd.RunE(cmd, []string{"my-job"})
 	// Without a valid kubeconfig, client creation or REST config should fail.
@@ -925,4 +927,61 @@ func TestProviderSelectorsWithJobNameWithDashes(t *testing.T) {
 	}
 	assert.True(t, selector.Matches(podLabels),
 		"selector should match pod with dashed job name")
+}
+
+func TestLogsCmd_RejectsOutputFlag(t *testing.T) {
+	for _, args := range [][]string{
+		{"job", "logs", "my-job", "-o", "json"},
+		{"job", "logs", "my-job", "-o", "table"},
+		{"job", "logs", "my-job", "--output", "yaml"},
+	} {
+		err := ExecuteWithArgs(args)
+		require.Error(t, err, "%v should be rejected as an unknown flag", args)
+		assert.Contains(t, err.Error(), "unknown", "%v: -o must be unknown on job logs", args)
+	}
+}
+
+func TestJobSubcommands_OutputFlagRegistration(t *testing.T) {
+	jobCmd := newJobCmd()
+	assert.Nil(t, jobCmd.PersistentFlags().Lookup("output"), "job group must not register a persistent -o")
+	assert.Nil(t, jobCmd.Flags().Lookup("output"), "job group must not register a local -o")
+
+	wantOutput := map[string]bool{
+		"run": true, "get": true, "status": true, "list": true,
+		"delete": true, "suspend": true, "resume": true,
+		"logs": false,
+	}
+	for _, sub := range jobCmd.Commands() {
+		want, ok := wantOutput[sub.Name()]
+		if !ok {
+			continue
+		}
+		flag := sub.Flags().Lookup("output")
+		if want {
+			require.NotNil(t, flag, "job %s must register -o", sub.Name())
+			assert.Equal(t, "o", flag.Shorthand)
+		} else {
+			assert.Nil(t, flag, "job %s must not register -o", sub.Name())
+		}
+	}
+}
+
+func TestJobLeafCommands_OutputFlagParsesAtLeaf(t *testing.T) {
+	for _, args := range [][]string{
+		{"job", "list", "-o", "bogus"},
+		{"job", "get", "x", "-o", "bogus"},
+		{"job", "run", "-f", "x.yaml", "-o", "bogus"},
+		{"submit", "pytorch", "--name", "t", "--image", "img", "-o", "bogus"},
+	} {
+		err := ExecuteWithArgs(args)
+		require.Error(t, err, "%v should fail", args)
+		assert.Contains(t, err.Error(), "invalid output format", "%v: -o must parse at the leaf and hit format validation", args)
+	}
+}
+
+func TestJobGroup_InterspersedOutputFlagStillParses(t *testing.T) {
+	err := ExecuteWithArgs([]string{"job", "-o", "json", "list", "--kubeconfig", "/nonexistent/kubeconfig"})
+	require.Error(t, err, "nonexistent kubeconfig must fail the run")
+	assert.NotContains(t, err.Error(), "unknown flag")
+	assert.Contains(t, err.Error(), "failed to create K8s client")
 }

--- a/pkg/cli/results.go
+++ b/pkg/cli/results.go
@@ -1,0 +1,58 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	outputpkg "github.com/kubeflow/arena/pkg/output"
+)
+
+// SubmitResult is the machine-readable result of a successful submit.
+type SubmitResult struct {
+	Name       string `json:"name" yaml:"name"`
+	Namespace  string `json:"namespace" yaml:"namespace"`
+	Kind       string `json:"kind" yaml:"kind"`
+	APIVersion string `json:"apiVersion" yaml:"apiVersion"`
+}
+
+// ActionResult is the machine-readable result of a successful mutation
+// (delete, suspend, resume).
+type ActionResult struct {
+	Name      string `json:"name" yaml:"name"`
+	Namespace string `json:"namespace" yaml:"namespace"`
+	Kind      string `json:"kind" yaml:"kind"`
+	Action    string `json:"action" yaml:"action"` // deleted | suspended | resumed
+}
+
+// printSubmitResult writes the submit result honoring -o/--output: the
+// legacy one-liner unless json or yaml was explicitly requested.
+func printSubmitResult(out io.Writer, name, namespace, kind, apiVersion string) error {
+	switch outputpkg.Format(outputFormat) {
+	case outputpkg.FormatJSON, outputpkg.FormatYAML:
+		return outputpkg.Format(outputFormat).Render(out, &SubmitResult{
+			Name:       name,
+			Namespace:  namespace,
+			Kind:       kind,
+			APIVersion: apiVersion,
+		}, outputpkg.RenderOptions{})
+	}
+	fmt.Fprintf(out, "Job %s submitted successfully\n", name)
+	return nil
+}
+
+// printActionResult writes a mutation result honoring -o/--output: the
+// legacy one-liner unless json or yaml was explicitly requested.
+func printActionResult(out io.Writer, name, namespace, kind, action string) error {
+	switch outputpkg.Format(outputFormat) {
+	case outputpkg.FormatJSON, outputpkg.FormatYAML:
+		return outputpkg.Format(outputFormat).Render(out, &ActionResult{
+			Name:      name,
+			Namespace: namespace,
+			Kind:      kind,
+			Action:    action,
+		}, outputpkg.RenderOptions{})
+	}
+	fmt.Fprintf(out, "%s/%s %s\n", strings.ToLower(kind), name, action)
+	return nil
+}

--- a/pkg/cli/results_test.go
+++ b/pkg/cli/results_test.go
@@ -1,0 +1,163 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic/fake"
+
+	"github.com/kubeflow/arena/pkg/client"
+	"github.com/kubeflow/arena/pkg/task"
+)
+
+func TestPrintSubmitResult_DefaultText(t *testing.T) {
+	orig := outputFormat
+	t.Cleanup(func() { outputFormat = orig })
+	outputFormat = "table"
+
+	var buf bytes.Buffer
+	require.NoError(t, printSubmitResult(&buf, "my-job", "default", "PyTorchJob", "kubeflow.org/v1"))
+	assert.Equal(t, "Job my-job submitted successfully\n", buf.String())
+}
+
+func TestPrintSubmitResult_JSON(t *testing.T) {
+	orig := outputFormat
+	t.Cleanup(func() { outputFormat = orig })
+	outputFormat = "json"
+
+	var buf bytes.Buffer
+	require.NoError(t, printSubmitResult(&buf, "my-job", "default", "PyTorchJob", "kubeflow.org/v1"))
+
+	var parsed SubmitResult
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &parsed))
+	assert.Equal(t, SubmitResult{
+		Name:       "my-job",
+		Namespace:  "default",
+		Kind:       "PyTorchJob",
+		APIVersion: "kubeflow.org/v1",
+	}, parsed)
+}
+
+func TestPrintSubmitResult_YAML(t *testing.T) {
+	orig := outputFormat
+	t.Cleanup(func() { outputFormat = orig })
+	outputFormat = "yaml"
+
+	var buf bytes.Buffer
+	require.NoError(t, printSubmitResult(&buf, "my-job", "default", "PyTorchJob", "kubeflow.org/v1"))
+	assert.Contains(t, buf.String(), "name: my-job")
+	assert.Contains(t, buf.String(), "kind: PyTorchJob")
+	assert.Contains(t, buf.String(), "apiVersion: kubeflow.org/v1")
+}
+
+func TestPrintActionResult_DefaultText(t *testing.T) {
+	orig := outputFormat
+	t.Cleanup(func() { outputFormat = orig })
+	outputFormat = "table"
+
+	var buf bytes.Buffer
+	require.NoError(t, printActionResult(&buf, "my-job", "default", "PyTorchJob", "deleted"))
+	assert.Equal(t, "pytorchjob/my-job deleted\n", buf.String())
+}
+
+func TestPrintActionResult_JSON(t *testing.T) {
+	orig := outputFormat
+	t.Cleanup(func() { outputFormat = orig })
+	outputFormat = "json"
+
+	var buf bytes.Buffer
+	require.NoError(t, printActionResult(&buf, "my-job", "default", "PyTorchJob", "suspended"))
+
+	var parsed ActionResult
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &parsed))
+	assert.Equal(t, ActionResult{
+		Name:      "my-job",
+		Namespace: "default",
+		Kind:      "PyTorchJob",
+		Action:    "suspended",
+	}, parsed)
+}
+
+func TestSubmitCRD_JSONOutput(t *testing.T) {
+	origFormat := outputFormat
+	origNS := namespace
+	t.Cleanup(func() {
+		outputFormat = origFormat
+		namespace = origNS
+	})
+	outputFormat = "json"
+	namespace = "default"
+
+	scheme := runtime.NewScheme()
+	listKinds := map[schema.GroupVersionResource]string{
+		{Group: "", Version: "v1", Resource: "configmaps"}:                            "ConfigMapList",
+		{Group: "", Version: "v1", Resource: "serviceaccounts"}:                       "ServiceAccountList",
+		{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "roles"}:        "RoleList",
+		{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "rolebindings"}: "RoleBindingList",
+		{Group: "kubeflow.org", Version: "v1", Resource: "pytorchjobs"}:               "PyTorchJobList",
+	}
+	fakeClient := fake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds)
+	k8sClient := client.NewClientForInterface(fakeClient)
+
+	tk := &task.Task{
+		Name:      "json-submit-test",
+		Image:     "pytorch:2.1",
+		Framework: task.Framework{Name: "pytorch"},
+		Run:       "python train.py",
+		Worker:    &task.Worker{Replicas: 1},
+	}
+	tk.SetDefaults()
+
+	var buf bytes.Buffer
+	err := submitCRD(context.Background(), &buf, k8sClient, tk, "pytorch", false)
+	require.NoError(t, err)
+
+	var parsed SubmitResult
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &parsed))
+	assert.Equal(t, "json-submit-test", parsed.Name)
+	assert.Equal(t, "default", parsed.Namespace)
+	assert.Equal(t, "PyTorchJob", parsed.Kind)
+	assert.Equal(t, "kubeflow.org/v1", parsed.APIVersion)
+}
+
+func TestSubmitCRD_DefaultOutputUnchanged(t *testing.T) {
+	origFormat := outputFormat
+	origNS := namespace
+	t.Cleanup(func() {
+		outputFormat = origFormat
+		namespace = origNS
+	})
+	outputFormat = "table"
+	namespace = "default"
+
+	scheme := runtime.NewScheme()
+	listKinds := map[schema.GroupVersionResource]string{
+		{Group: "", Version: "v1", Resource: "configmaps"}:                            "ConfigMapList",
+		{Group: "", Version: "v1", Resource: "serviceaccounts"}:                       "ServiceAccountList",
+		{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "roles"}:        "RoleList",
+		{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "rolebindings"}: "RoleBindingList",
+		{Group: "kubeflow.org", Version: "v1", Resource: "pytorchjobs"}:               "PyTorchJobList",
+	}
+	fakeClient := fake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds)
+	k8sClient := client.NewClientForInterface(fakeClient)
+
+	tk := &task.Task{
+		Name:      "text-submit-test",
+		Image:     "pytorch:2.1",
+		Framework: task.Framework{Name: "pytorch"},
+		Run:       "python train.py",
+		Worker:    &task.Worker{Replicas: 1},
+	}
+	tk.SetDefaults()
+
+	var buf bytes.Buffer
+	err := submitCRD(context.Background(), &buf, k8sClient, tk, "pytorch", false)
+	require.NoError(t, err)
+	assert.Equal(t, "Job text-submit-test submitted successfully\n", buf.String())
+}

--- a/pkg/cli/resume.go
+++ b/pkg/cli/resume.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -18,6 +17,9 @@ func newResumeCmd() *cobra.Command {
 		Long:  `Resume a suspended training job by setting spec.runPolicy.suspend to false.`,
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := validateOutputFormat(); err != nil {
+				return err
+			}
 			name := args[0]
 
 			k8sClient, err := client.NewClient(kubeconfig, kubeContext)
@@ -32,11 +34,11 @@ func newResumeCmd() *cobra.Command {
 				return err
 			}
 
-			fmt.Fprintf(cmd.OutOrStdout(), "%s/%s resumed\n", strings.ToLower(jobType), name)
-			return nil
+			return printActionResult(cmd.OutOrStdout(), name, ns, jobType, "resumed")
 		},
 	}
 
+	registerOutputFlag(cmd)
 	cmd.ValidArgsFunction = completeJobName
 	return cmd
 }

--- a/pkg/cli/resume.go
+++ b/pkg/cli/resume.go
@@ -11,29 +11,34 @@ import (
 	"github.com/kubeflow/arena/pkg/client"
 )
 
-var resumeCmd = &cobra.Command{
-	Use:   "resume <name>",
-	Short: "Resume a suspended training job",
-	Long:  `Resume a suspended training job by setting spec.runPolicy.suspend to false.`,
-	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		name := args[0]
+func newResumeCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "resume <name>",
+		Short: "Resume a suspended training job",
+		Long:  `Resume a suspended training job by setting spec.runPolicy.suspend to false.`,
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			name := args[0]
 
-		k8sClient, err := client.NewClient(kubeconfig, kubeContext)
-		if err != nil {
-			return fmt.Errorf("failed to create K8s client: %w", err)
-		}
+			k8sClient, err := client.NewClient(kubeconfig, kubeContext)
+			if err != nil {
+				return fmt.Errorf("failed to create K8s client: %w", err)
+			}
 
-		ns := resolveNS("")
+			ns := resolveNS("")
 
-		jobType, err := resumeJob(cmdContext(cmd), k8sClient, ns, name)
-		if err != nil {
-			return err
-		}
+			jobType, err := resumeJob(cmdContext(cmd), k8sClient, ns, name)
+			if err != nil {
+				return err
+			}
 
-		fmt.Printf("%s/%s resumed\n", strings.ToLower(jobType), name)
-		return nil
-	},
+			fmt.Fprintf(cmd.OutOrStdout(), "%s/%s resumed\n", strings.ToLower(jobType), name)
+			return nil
+		},
+	}
+
+	cmd.ValidArgsFunction = completeJobName
+	return cmd
 }
 
 func resumeJob(ctx context.Context, k8sClient *client.Client, namespace, name string) (string, error) {
@@ -61,9 +66,4 @@ func resumeJob(ctx context.Context, k8sClient *client.Client, namespace, name st
 	}
 
 	return jobType, nil
-}
-
-func init() {
-	resumeCmd.ValidArgsFunction = completeJobName
-	jobCmd.AddCommand(resumeCmd)
 }

--- a/pkg/cli/resume_test.go
+++ b/pkg/cli/resume_test.go
@@ -14,23 +14,26 @@ import (
 )
 
 func TestResumeCmd_RequiresArg(t *testing.T) {
-	err := resumeCmd.Args(resumeCmd, []string{})
+	cmd := newResumeCmd()
+	err := cmd.Args(cmd, []string{})
 	assert.Error(t, err)
 }
 
 func TestResumeCmd_AcceptsOneArg(t *testing.T) {
-	err := resumeCmd.Args(resumeCmd, []string{"my-job"})
+	cmd := newResumeCmd()
+	err := cmd.Args(cmd, []string{"my-job"})
 	assert.NoError(t, err)
 }
 
 func TestResumeCmd_RejectsExtraArgs(t *testing.T) {
-	err := resumeCmd.Args(resumeCmd, []string{"job1", "job2"})
+	cmd := newResumeCmd()
+	err := cmd.Args(cmd, []string{"job1", "job2"})
 	assert.Error(t, err)
 }
 
 func TestResumeCmd_RegisteredWithJob(t *testing.T) {
 	found := false
-	for _, cmd := range jobCmd.Commands() {
+	for _, cmd := range newJobCmd().Commands() {
 		if cmd.Name() == "resume" {
 			found = true
 			break
@@ -44,14 +47,15 @@ func TestResumeCmd_NotFound(t *testing.T) {
 	defer func() { kubeconfig = orig }()
 
 	kubeconfig = "/nonexistent/kubeconfig"
-	err := resumeCmd.RunE(resumeCmd, []string{"nonexistent-job"})
+	cmd := newResumeCmd()
+	err := cmd.RunE(cmd, []string{"nonexistent-job"})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to create K8s client")
 }
 
 func TestResumeCmd_HasCorrectMetadata(t *testing.T) {
-	assert.Equal(t, "resume <name>", resumeCmd.Use)
-	assert.NotEmpty(t, resumeCmd.Short)
+	assert.Equal(t, "resume <name>", newResumeCmd().Use)
+	assert.NotEmpty(t, newResumeCmd().Short)
 }
 
 func TestResumeCmd_ClearsSuspendField(t *testing.T) {

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bytes"
 	"context"
 	"flag"
 	"os"
@@ -19,33 +20,64 @@ var (
 	verbose     int32
 )
 
-var rootCmd = &cobra.Command{
-	Use:   "arena-v2",
-	Short: "Arena v2 - AI workload CLI for Kubernetes",
-	Long:  `Arena v2 is a lightweight CLI for submitting AI training jobs to Kubernetes.`,
-	PersistentPreRun: func(_ *cobra.Command, _ []string) {
-		if err := log.SetVerbosity(flag.CommandLine, verbose); err != nil {
-			log.Warning("failed to set verbosity", "error", err.Error())
-		}
-	},
+// NewRootCommand builds a fresh arena-v2 command tree. Every Execute call and
+// every test constructs its own tree: pflag keeps per-flag state (Changed
+// bits, parsed values) on the command objects and never resets it between
+// parses, so sharing one tree across invocations leaks state.
+func NewRootCommand() *cobra.Command {
+	root := &cobra.Command{
+		Use:           "arena-v2",
+		Short:         "Arena v2 - AI workload CLI for Kubernetes",
+		Long:          `Arena v2 is a lightweight CLI for submitting AI training jobs to Kubernetes.`,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		PersistentPreRunE: func(_ *cobra.Command, _ []string) error {
+			return log.SetVerbosity(flag.CommandLine, verbose)
+		},
+	}
+
+	root.PersistentFlags().StringVar(&kubeconfig, "kubeconfig", "", "path to kubeconfig file")
+	root.PersistentFlags().StringVar(&kubeContext, "context", "", "kubeconfig context to use")
+	root.PersistentFlags().StringVarP(&namespace, "namespace", "n", "", "Kubernetes namespace (priority: flag > YAML > kubeconfig context > default)")
+	root.PersistentFlags().BoolVar(&debugMode, "debug", false, "enable debug mode with detailed error output")
+	root.PersistentFlags().Int32VarP(&verbose, "verbose", "v", 0, "verbosity level (higher = more detailed logs)")
+	_ = root.RegisterFlagCompletionFunc("kubeconfig", completeFile)
+
+	root.AddCommand(newJobCmd(), newSubmitCmd(), newTopCmd(), newCheckCmd(), newVersionCmd(), newCompletionCmd())
+
+	return root
 }
 
 func Execute() error {
-	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
-	defer cancel()
-	rootCmd.SetContext(ctx)
-	return rootCmd.Execute()
+	return execute(NewRootCommand(), nil)
 }
 
-// ExecuteWithArgs executes the root command with the given arguments.
+// ExecuteWithArgs executes a fresh root command with the given arguments.
 // It is primarily used for integration testing where the CLI needs to be
 // invoked programmatically with specific flags and subcommands.
 func ExecuteWithArgs(args []string) error {
+	return execute(NewRootCommand(), args)
+}
+
+// ExecuteWithArgsOutput is ExecuteWithArgs with stdout captured: everything
+// the command writes via OutOrStdout (help, CRD dry-run output, tables) is
+// returned alongside the error.
+func ExecuteWithArgsOutput(args []string) (string, error) {
+	root := NewRootCommand()
+	var buf bytes.Buffer
+	root.SetOut(&buf)
+	err := execute(root, args)
+	return buf.String(), err
+}
+
+func execute(root *cobra.Command, args []string) error {
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer cancel()
-	rootCmd.SetContext(ctx)
-	rootCmd.SetArgs(args)
-	return rootCmd.Execute()
+	root.SetContext(ctx)
+	if args != nil {
+		root.SetArgs(args)
+	}
+	return root.Execute()
 }
 
 // DebugMode returns whether debug mode is enabled.
@@ -56,14 +88,4 @@ func DebugMode() bool {
 func init() {
 	// Initialize klog with the standard flag set
 	log.Init(flag.CommandLine)
-
-	rootCmd.SilenceUsage = true
-	rootCmd.SilenceErrors = true
-
-	rootCmd.PersistentFlags().StringVar(&kubeconfig, "kubeconfig", "", "path to kubeconfig file")
-	rootCmd.PersistentFlags().StringVar(&kubeContext, "context", "", "kubeconfig context to use")
-	rootCmd.PersistentFlags().StringVarP(&namespace, "namespace", "n", "", "Kubernetes namespace (priority: flag > YAML > kubeconfig context > default)")
-	rootCmd.PersistentFlags().BoolVar(&debugMode, "debug", false, "enable debug mode with detailed error output")
-	rootCmd.PersistentFlags().Int32VarP(&verbose, "verbose", "v", 0, "verbosity level (higher = more detailed logs)")
-	_ = rootCmd.RegisterFlagCompletionFunc("kubeconfig", completeFile)
 }

--- a/pkg/cli/root_test.go
+++ b/pkg/cli/root_test.go
@@ -7,13 +7,13 @@ import (
 )
 
 func TestRootCmd_HasDebugFlag(t *testing.T) {
-	f := rootCmd.PersistentFlags().Lookup("debug")
+	f := NewRootCommand().PersistentFlags().Lookup("debug")
 	assert.NotNil(t, f, "debug flag should be registered")
 	assert.Equal(t, "false", f.DefValue)
 }
 
 func TestRootCmd_HasVerboseFlag(t *testing.T) {
-	f := rootCmd.PersistentFlags().Lookup("verbose")
+	f := NewRootCommand().PersistentFlags().Lookup("verbose")
 	assert.NotNil(t, f, "verbose flag should be registered")
 	assert.Equal(t, "0", f.DefValue)
 }

--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -27,6 +27,9 @@ func newRunCmd() *cobra.Command {
 		Long: `Submit a training job to Kubernetes by loading a YAML specification file.
 Use --set to override YAML fields with Helm-style dot-notation paths.`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := validateOutputFormat(); err != nil {
+				return err
+			}
 			applyDryRunOutputDefault(cmd, runDryRun)
 
 			log.Debug("loading task from file", "file", runFile)
@@ -40,6 +43,13 @@ Use --set to override YAML fields with Helm-style dot-notation paths.`,
 			// Apply --set overrides on raw YAML before parsing
 			mergedData, err := task.ApplySetOverrides(yamlData, runSetExprs)
 			if err != nil {
+				var serr *task.SetSyntaxError
+				if errors.As(err, &serr) {
+					return &CLIError{
+						Message: fmt.Sprintf("failed to apply --set: %v", serr),
+						Hint:    "expected key=value with dot-notation paths, e.g. --set worker.replicas=4",
+					}
+				}
 				return fmt.Errorf("failed to apply --set overrides: %w", err)
 			}
 
@@ -69,6 +79,7 @@ Use --set to override YAML fields with Helm-style dot-notation paths.`,
 
 	_ = cmd.MarkFlagRequired("file")
 	_ = cmd.RegisterFlagCompletionFunc("file", completeFile)
+	registerOutputFlag(cmd)
 	cmd.ValidArgsFunction = cobra.NoFileCompletions
 	return cmd
 }

--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -20,49 +20,57 @@ var (
 	runSetExprs []string
 )
 
-var runCmd = &cobra.Command{
-	Use:   "run",
-	Short: "Submit a training job from YAML file",
-	Long: `Submit a training job to Kubernetes by loading a YAML specification file.
+func newRunCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "run",
+		Short: "Submit a training job from YAML file",
+		Long: `Submit a training job to Kubernetes by loading a YAML specification file.
 Use --set to override YAML fields with Helm-style dot-notation paths.`,
-	RunE: func(cmd *cobra.Command, _ []string) error {
-		if runFile == "" {
-			return errors.New("--file is required")
-		}
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			applyDryRunOutputDefault(cmd, runDryRun)
 
-		applyDryRunOutputDefault(cmd, runDryRun)
+			log.Debug("loading task from file", "file", runFile)
 
-		log.Debug("loading task from file", "file", runFile)
-
-		// Read raw YAML
-		yamlData, err := os.ReadFile(runFile)
-		if err != nil {
-			return fmt.Errorf("failed to read file %q: %w", runFile, err)
-		}
-
-		// Apply --set overrides on raw YAML before parsing
-		mergedData, err := task.ApplySetOverrides(yamlData, runSetExprs)
-		if err != nil {
-			return fmt.Errorf("failed to apply --set overrides: %w", err)
-		}
-
-		// Parse merged YAML into Task
-		t, err := task.LoadFromBytes(mergedData)
-		if err != nil {
-			return fmt.Errorf("failed to load task: %w", err)
-		}
-
-		log.Debug("task loaded", "name", t.Name, "framework", t.Framework.Name)
-
-		var k8sClient *client.Client
-		if !runDryRun {
-			k8sClient, err = client.NewClient(kubeconfig, kubeContext)
+			// Read raw YAML
+			yamlData, err := os.ReadFile(runFile)
 			if err != nil {
-				return fmt.Errorf("failed to create K8s client: %w", err)
+				return fmt.Errorf("failed to read file %q: %w", runFile, err)
 			}
-		}
-		return submitCRD(cmdContext(cmd), k8sClient, t, t.Framework.Name, runDryRun)
-	},
+
+			// Apply --set overrides on raw YAML before parsing
+			mergedData, err := task.ApplySetOverrides(yamlData, runSetExprs)
+			if err != nil {
+				return fmt.Errorf("failed to apply --set overrides: %w", err)
+			}
+
+			// Parse merged YAML into Task
+			t, err := task.LoadFromBytes(mergedData)
+			if err != nil {
+				return fmt.Errorf("failed to load task: %w", err)
+			}
+
+			log.Debug("task loaded", "name", t.Name, "framework", t.Framework.Name)
+
+			var k8sClient *client.Client
+			if !runDryRun {
+				k8sClient, err = client.NewClient(kubeconfig, kubeContext)
+				if err != nil {
+					return fmt.Errorf("failed to create K8s client: %w", err)
+				}
+			}
+			return submitCRD(cmdContext(cmd), cmd.OutOrStdout(), k8sClient, t, t.Framework.Name, runDryRun)
+		},
+	}
+
+	cmd.Flags().StringVarP(&runFile, "file", "f", "", "path to YAML file")
+	cmd.Flags().BoolVar(&runDryRun, "dry-run", false, "print CRD as JSON (default) or YAML (-o yaml) without submitting")
+	cmd.Flags().StringArrayVar(&runSetExprs, "set", nil,
+		"override YAML field (Helm-style: key=value, repeatable)")
+
+	_ = cmd.MarkFlagRequired("file")
+	_ = cmd.RegisterFlagCompletionFunc("file", completeFile)
+	cmd.ValidArgsFunction = cobra.NoFileCompletions
+	return cmd
 }
 
 // getProvider returns the appropriate provider based on the framework name.
@@ -79,15 +87,4 @@ func getProvider(frameworkName string) (provider.Provider, error) {
 	default:
 		return nil, fmt.Errorf("unsupported framework: %q", frameworkName)
 	}
-}
-
-func init() {
-	runCmd.Flags().StringVarP(&runFile, "file", "f", "", "path to YAML file")
-	runCmd.Flags().BoolVar(&runDryRun, "dry-run", false, "print CRD as JSON (default) or YAML (-o yaml) without submitting")
-	runCmd.Flags().StringArrayVar(&runSetExprs, "set", nil,
-		"override YAML field (Helm-style: key=value, repeatable)")
-
-	_ = runCmd.RegisterFlagCompletionFunc("file", completeFile)
-	runCmd.ValidArgsFunction = cobra.NoFileCompletions
-	jobCmd.AddCommand(runCmd)
 }

--- a/pkg/cli/run_test.go
+++ b/pkg/cli/run_test.go
@@ -440,6 +440,10 @@ func TestRunCmd_SetOverrideInvalidValue(t *testing.T) {
 }
 
 func TestRunCmd_SetOverrideInvalidSyntax(t *testing.T) {
+	origFormat := outputFormat
+	t.Cleanup(func() { outputFormat = origFormat })
+	outputFormat = "table"
+
 	tmpFile := writeTestYAML(t, testRunYAML)
 	cmd := newRunCmd()
 	runFile = tmpFile
@@ -447,8 +451,11 @@ func TestRunCmd_SetOverrideInvalidSyntax(t *testing.T) {
 	runSetExprs = []string{"=nokey"}
 
 	err := cmd.RunE(cmd, nil)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to apply --set")
+	require.Error(t, err)
+	var cliErr *CLIError
+	require.True(t, errors.As(err, &cliErr))
+	assert.Contains(t, err.Error(), `failed to apply --set: failed to parse --set "=nokey": empty key`)
+	assert.Contains(t, cliErr.Hint, "worker.replicas=4")
 }
 
 func TestRunCmd_SetOverrideDeeplyNested(t *testing.T) {

--- a/pkg/cli/run_test.go
+++ b/pkg/cli/run_test.go
@@ -90,21 +90,13 @@ func TestGetProvider(t *testing.T) {
 }
 
 func TestRunCmd_FileRequired(t *testing.T) {
-	original := runFile
-	defer func() { runFile = original }()
-
-	runFile = ""
-	err := runCmd.RunE(runCmd, nil)
+	err := ExecuteWithArgs([]string{"job", "run"})
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "--file is required")
+	assert.Contains(t, err.Error(), `required flag(s) "file" not set`)
 }
 
 func TestRunCmd_InvalidFile(t *testing.T) {
-	original := runFile
-	defer func() { runFile = original }()
-
-	runFile = "/nonexistent/path/to/file.yaml"
-	err := runCmd.RunE(runCmd, nil)
+	err := ExecuteWithArgs([]string{"job", "run", "-f", "/nonexistent/path/to/file.yaml"})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to read file")
 }
@@ -115,11 +107,7 @@ func TestRunCmd_InvalidYAML(t *testing.T) {
 	err := os.WriteFile(tmpFile, []byte("not: valid: yaml: {{{"), 0600)
 	require.NoError(t, err)
 
-	original := runFile
-	defer func() { runFile = original }()
-
-	runFile = tmpFile
-	err = runCmd.RunE(runCmd, nil)
+	err = ExecuteWithArgs([]string{"job", "run", "-f", tmpFile})
 	assert.Error(t, err)
 }
 
@@ -137,11 +125,7 @@ worker:
 	err := os.WriteFile(tmpFile, []byte(content), 0600)
 	require.NoError(t, err)
 
-	original := runFile
-	defer func() { runFile = original }()
-
-	runFile = tmpFile
-	err = runCmd.RunE(runCmd, nil)
+	err = ExecuteWithArgs([]string{"job", "run", "-f", tmpFile})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to load task")
 }
@@ -160,11 +144,7 @@ worker:
 	err := os.WriteFile(tmpFile, []byte(content), 0600)
 	require.NoError(t, err)
 
-	original := runFile
-	defer func() { runFile = original }()
-
-	runFile = tmpFile
-	err = runCmd.RunE(runCmd, nil)
+	err = ExecuteWithArgs([]string{"job", "run", "-f", tmpFile})
 	assert.Error(t, err)
 }
 
@@ -182,33 +162,25 @@ worker:
 	err := os.WriteFile(tmpFile, []byte(content), 0600)
 	require.NoError(t, err)
 
-	originalFile := runFile
-	originalDryRun := runDryRun
-	defer func() {
-		runFile = originalFile
-		runDryRun = originalDryRun
-	}()
-
-	runFile = tmpFile
-	runDryRun = true
-	err = runCmd.RunE(runCmd, nil)
+	output, err := ExecuteWithArgsOutput([]string{"job", "run", "-f", tmpFile, "--dry-run"})
 	assert.NoError(t, err)
+	assert.Contains(t, output, "dry-run-test", "dry-run should print the CRD with the job name")
 }
 
 func TestRunCmd_HasDryRunFlag(t *testing.T) {
-	f := runCmd.Flags().Lookup("dry-run")
+	f := newRunCmd().Flags().Lookup("dry-run")
 	require.NotNil(t, f, "dry-run flag should be registered")
 	assert.Equal(t, "false", f.DefValue)
 }
 
 func TestRunCmd_HasSetFlag(t *testing.T) {
-	f := runCmd.Flags().Lookup("set")
+	f := newRunCmd().Flags().Lookup("set")
 	require.NotNil(t, f, "set flag should be registered")
 }
 
 func TestRunCmd_RegisteredWithJobCmd(t *testing.T) {
 	found := false
-	for _, cmd := range jobCmd.Commands() {
+	for _, cmd := range newJobCmd().Commands() {
 		if cmd.Name() == "run" {
 			found = true
 			break
@@ -312,14 +284,6 @@ func TestRunCmd_NamespaceSetOnCRD(t *testing.T) {
 	assert.Equal(t, "my-namespace", crd.GetNamespace())
 }
 
-// resetRunFlags resets run flag variables to their defaults for test isolation.
-func resetRunFlags(t *testing.T) {
-	t.Helper()
-	runFile = ""
-	runDryRun = false
-	runSetExprs = nil
-}
-
 // writeTestYAML creates a temporary YAML file for run command tests.
 func writeTestYAML(t *testing.T, content string) string {
 	t.Helper()
@@ -343,25 +307,23 @@ worker:
 `
 
 func TestRunCmd_NoOverrides_TaskMatchesFile(t *testing.T) {
-	resetRunFlags(t)
-
 	tmpFile := writeTestYAML(t, testRunYAML)
+	cmd := newRunCmd()
 	runFile = tmpFile
 	runDryRun = true
 
-	err := runCmd.RunE(runCmd, nil)
+	err := cmd.RunE(cmd, nil)
 	assert.NoError(t, err)
 }
 
 func TestRunCmd_SetOverrideName(t *testing.T) {
-	resetRunFlags(t)
-
 	tmpFile := writeTestYAML(t, testRunYAML)
+	cmd := newRunCmd()
 	runFile = tmpFile
 	runDryRun = true
 	runSetExprs = []string{"name=overridden-name"}
 
-	err := runCmd.RunE(runCmd, nil)
+	err := cmd.RunE(cmd, nil)
 	assert.NoError(t, err)
 
 	// Verify merged value reaches the Task struct
@@ -375,14 +337,13 @@ func TestRunCmd_SetOverrideName(t *testing.T) {
 }
 
 func TestRunCmd_SetOverrideWorkers(t *testing.T) {
-	resetRunFlags(t)
-
 	tmpFile := writeTestYAML(t, testRunYAML)
+	cmd := newRunCmd()
 	runFile = tmpFile
 	runDryRun = true
 	runSetExprs = []string{"worker.replicas=8"}
 
-	err := runCmd.RunE(runCmd, nil)
+	err := cmd.RunE(cmd, nil)
 	assert.NoError(t, err)
 
 	yamlData, err := os.ReadFile(tmpFile)
@@ -395,14 +356,13 @@ func TestRunCmd_SetOverrideWorkers(t *testing.T) {
 }
 
 func TestRunCmd_SetOverrideGPUs(t *testing.T) {
-	resetRunFlags(t)
-
 	tmpFile := writeTestYAML(t, testRunYAML)
+	cmd := newRunCmd()
 	runFile = tmpFile
 	runDryRun = true
 	runSetExprs = []string{"worker.resources.gpu=4"}
 
-	err := runCmd.RunE(runCmd, nil)
+	err := cmd.RunE(cmd, nil)
 	assert.NoError(t, err)
 
 	yamlData, err := os.ReadFile(tmpFile)
@@ -415,14 +375,13 @@ func TestRunCmd_SetOverrideGPUs(t *testing.T) {
 }
 
 func TestRunCmd_SetOverrideEnvs(t *testing.T) {
-	resetRunFlags(t)
-
 	tmpFile := writeTestYAML(t, testRunYAML)
+	cmd := newRunCmd()
 	runFile = tmpFile
 	runDryRun = true
 	runSetExprs = []string{"envs.MY_VAR=hello", "envs.OTHER=world"}
 
-	err := runCmd.RunE(runCmd, nil)
+	err := cmd.RunE(cmd, nil)
 	assert.NoError(t, err)
 
 	yamlData, err := os.ReadFile(tmpFile)
@@ -436,9 +395,8 @@ func TestRunCmd_SetOverrideEnvs(t *testing.T) {
 }
 
 func TestRunCmd_SetMultipleOverrides(t *testing.T) {
-	resetRunFlags(t)
-
 	tmpFile := writeTestYAML(t, testRunYAML)
+	cmd := newRunCmd()
 	runFile = tmpFile
 	runDryRun = true
 	runSetExprs = []string{
@@ -451,7 +409,7 @@ func TestRunCmd_SetMultipleOverrides(t *testing.T) {
 		"scheduling.gang.enabled=true",
 	}
 
-	err := runCmd.RunE(runCmd, nil)
+	err := cmd.RunE(cmd, nil)
 	assert.NoError(t, err)
 
 	yamlData, err := os.ReadFile(tmpFile)
@@ -470,34 +428,30 @@ func TestRunCmd_SetMultipleOverrides(t *testing.T) {
 }
 
 func TestRunCmd_SetOverrideInvalidValue(t *testing.T) {
-	resetRunFlags(t)
-
 	tmpFile := writeTestYAML(t, testRunYAML)
+	cmd := newRunCmd()
 	runFile = tmpFile
 	runDryRun = true
 	runSetExprs = []string{"restart=InvalidPolicy"}
 
-	err := runCmd.RunE(runCmd, nil)
+	err := cmd.RunE(cmd, nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "validation failed")
 }
 
 func TestRunCmd_SetOverrideInvalidSyntax(t *testing.T) {
-	resetRunFlags(t)
-
 	tmpFile := writeTestYAML(t, testRunYAML)
+	cmd := newRunCmd()
 	runFile = tmpFile
 	runDryRun = true
 	runSetExprs = []string{"=nokey"}
 
-	err := runCmd.RunE(runCmd, nil)
+	err := cmd.RunE(cmd, nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to apply --set")
 }
 
 func TestRunCmd_SetOverrideDeeplyNested(t *testing.T) {
-	resetRunFlags(t)
-
 	yaml := `name: deep-test
 image: pytorch:2.1
 run: python train.py
@@ -517,11 +471,12 @@ scheduling:
           app: web
 `
 	tmpFile := writeTestYAML(t, yaml)
+	cmd := newRunCmd()
 	runFile = tmpFile
 	runDryRun = true
 	runSetExprs = []string{"scheduling.affinity.policy=binpack"}
 
-	err := runCmd.RunE(runCmd, nil)
+	err := cmd.RunE(cmd, nil)
 	assert.NoError(t, err)
 
 	yamlData, err := os.ReadFile(tmpFile)
@@ -535,14 +490,13 @@ scheduling:
 }
 
 func TestRunCmd_DryRunWithSetOverridesEndToEnd(t *testing.T) {
-	resetRunFlags(t)
-
 	tmpFile := writeTestYAML(t, testRunYAML)
+	cmd := newRunCmd()
 	runFile = tmpFile
 	runDryRun = true
 	runSetExprs = []string{"name=e2e-override", "worker.resources.gpu=2"}
 
-	err := runCmd.RunE(runCmd, nil)
+	err := cmd.RunE(cmd, nil)
 	assert.NoError(t, err)
 
 	yamlData, err := os.ReadFile(tmpFile)
@@ -556,8 +510,6 @@ func TestRunCmd_DryRunWithSetOverridesEndToEnd(t *testing.T) {
 }
 
 func TestRunCmd_SetOverrideValueAssertion(t *testing.T) {
-	resetRunFlags(t)
-
 	tmpFile := writeTestYAML(t, testRunYAML)
 
 	yamlData, err := os.ReadFile(tmpFile)
@@ -684,8 +636,6 @@ worker:
 }
 
 func TestRunCmd_SetOverrideQuotedKeyValueAssertion(t *testing.T) {
-	resetRunFlags(t)
-
 	tmpFile := writeTestYAML(t, testRunYAML)
 
 	yamlData, err := os.ReadFile(tmpFile)
@@ -701,14 +651,13 @@ func TestRunCmd_SetOverrideQuotedKeyValueAssertion(t *testing.T) {
 }
 
 func TestRunCmd_SetOverrideTypeMismatch(t *testing.T) {
-	resetRunFlags(t)
-
 	tmpFile := writeTestYAML(t, testRunYAML)
+	cmd := newRunCmd()
 	runFile = tmpFile
 	runDryRun = true
 	runSetExprs = []string{"worker.replicas=notanint"}
 
-	err := runCmd.RunE(runCmd, nil)
+	err := cmd.RunE(cmd, nil)
 	assert.Error(t, err)
 	// The --set parser stores "notanint" as a string; YAML unmarshal into int field fails
 	// during LoadFromBytes, which wraps the error.
@@ -716,16 +665,15 @@ func TestRunCmd_SetOverrideTypeMismatch(t *testing.T) {
 }
 
 func TestRunCmd_SetOverrideWithNamespace(t *testing.T) {
-	resetRunFlags(t)
-
 	// Add namespace to the YAML
 	yamlWithNS := "namespace: my-ns\n" + testRunYAML
 	tmpFile := writeTestYAML(t, yamlWithNS)
+	cmd := newRunCmd()
 	runFile = tmpFile
 	runDryRun = true
 	runSetExprs = []string{"name=ns-override"}
 
-	err := runCmd.RunE(runCmd, nil)
+	err := cmd.RunE(cmd, nil)
 	assert.NoError(t, err)
 
 	// Verify both the override and the namespace reach the Task

--- a/pkg/cli/status.go
+++ b/pkg/cli/status.go
@@ -4,15 +4,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var statusCmd = &cobra.Command{
-	Use:   "status <name>",
-	Short: "Show job status (alias for get)",
-	Args:  cobra.ExactArgs(1),
-	RunE:  getCmd.RunE,
-}
-
-func init() {
-	jobCmd.AddCommand(statusCmd)
-	statusCmd.Flags().BoolVar(&getDetails, "details", false, "show job configuration details")
-	statusCmd.ValidArgsFunction = completeJobName
+func newStatusCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "status <name>",
+		Short: "Show job status (alias for get)",
+		Args:  cobra.ExactArgs(1),
+		RunE:  runGet,
+	}
+	cmd.Flags().BoolVar(&getDetails, "details", false, "show job configuration details")
+	cmd.ValidArgsFunction = completeJobName
+	return cmd
 }

--- a/pkg/cli/status.go
+++ b/pkg/cli/status.go
@@ -12,6 +12,7 @@ func newStatusCmd() *cobra.Command {
 		RunE:  runGet,
 	}
 	cmd.Flags().BoolVar(&getDetails, "details", false, "show job configuration details")
+	registerOutputFlag(cmd)
 	cmd.ValidArgsFunction = completeJobName
 	return cmd
 }

--- a/pkg/cli/submit.go
+++ b/pkg/cli/submit.go
@@ -25,12 +25,16 @@ func newSubmitCmd() *cobra.Command {
 			}
 			framework, v1TypeUnsupported := lookupFramework(args[0])
 			if v1TypeUnsupported {
-				return fmt.Errorf("framework type %q is an arena v1 type not supported by arena-v2 yet (supported: pytorch, tensorflow, mpi, horovod, deepspeed)",
-					args[0])
+				return &CLIError{
+					Message:     fmt.Sprintf("framework type %q is an arena v1 type not supported by arena-v2 yet", args[0]),
+					ValidValues: v2FrameworkNames(),
+				}
 			}
 			if framework == "" {
-				return fmt.Errorf("unsupported framework type: %q (supported: pytorch/pytorchjob, tf/tfjob/tensorflow, mpi/mpijob/mj, horovod/horovodjob/hj, deepspeed/deepspeedjob/dp)",
-					args[0])
+				return &CLIError{
+					Message:     fmt.Sprintf("unsupported framework type: %q", args[0]),
+					ValidValues: acceptedFrameworkTypes(),
+				}
 			}
 			// The parent cannot mark --name/--image required at registration
 			// (cobra would reject a bare `submit` before RunE prints help), so the
@@ -92,6 +96,9 @@ func validateSubmitRequiredFlags(cmd *cobra.Command) error {
 // the per-framework subcommands. trailingArgs are the positional args that
 // follow the framework type; they become the run command.
 func runSubmit(cmd *cobra.Command, framework, originalFrameworkName string, trailingArgs []string) error {
+	if err := validateOutputFormat(); err != nil {
+		return err
+	}
 	if err := applyV1LogLevel(submitLogLevel); err != nil {
 		return err
 	}

--- a/pkg/cli/submit.go
+++ b/pkg/cli/submit.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 
 	"github.com/kubeflow/arena/pkg/client"
 	"github.com/kubeflow/arena/pkg/constants"
@@ -13,31 +14,55 @@ import (
 	"github.com/kubeflow/arena/pkg/task"
 )
 
-var submitCmd = &cobra.Command{
-	Use:   "submit",
-	Short: "Submit a training job",
-	Long:  `Submit a training job using arena v1-compatible syntax`,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		if len(args) == 0 {
-			return cmd.Help()
+func newSubmitCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "submit",
+		Short: "Submit a training job",
+		Long:  `Submit a training job using arena v1-compatible syntax`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return cmd.Help()
+			}
+			framework, v1TypeUnsupported := lookupFramework(args[0])
+			if v1TypeUnsupported {
+				return fmt.Errorf("framework type %q is an arena v1 type not supported by arena-v2 yet (supported: pytorch, tensorflow, mpi, horovod, deepspeed)",
+					args[0])
+			}
+			if framework == "" {
+				return fmt.Errorf("unsupported framework type: %q (supported: pytorch/pytorchjob, tf/tfjob/tensorflow, mpi/mpijob/mj, horovod/horovodjob/hj, deepspeed/deepspeedjob/dp)",
+					args[0])
+			}
+			// The parent cannot mark --name/--image required at registration
+			// (cobra would reject a bare `submit` before RunE prints help), so the
+			// fallback path validates them here, mirroring the subcommands' error.
+			if err := validateSubmitRequiredFlags(cmd); err != nil {
+				return err
+			}
+			return runSubmit(cmd, framework, originalFramework(args[0]), args[1:])
+		},
+	}
+
+	registerSubmitCommonFlags(cmd)
+	registerPyTorchSubmitFlags(cmd)
+	registerTFSubmitFlags(cmd)
+	registerMPISubmitFlags(cmd)
+	registerSubmitCompatFlags(cmd)
+
+	cmd.ValidArgsFunction = completeFrameworkType
+
+	// The parent keeps the full flag set — the fallback path and the test
+	// suite parse it — but hides it from help: `submit -h` lists only the
+	// framework subcommands, matching arena v1.
+	cmd.Flags().VisitAll(func(f *pflag.Flag) { f.Hidden = true })
+
+	for _, def := range frameworkRegistry {
+		if def.canonical == "" {
+			continue
 		}
-		framework, v1TypeUnsupported := lookupFramework(args[0])
-		if v1TypeUnsupported {
-			return fmt.Errorf("framework type %q is an arena v1 type not supported by arena-v2 yet (supported: pytorch, tensorflow, mpi, horovod, deepspeed)",
-				args[0])
-		}
-		if framework == "" {
-			return fmt.Errorf("unsupported framework type: %q (supported: pytorch/pytorchjob, tf/tfjob/tensorflow, mpi/mpijob/mj, horovod/horovodjob/hj, deepspeed/deepspeedjob/dp)",
-				args[0])
-		}
-		// The parent cannot mark --name/--image required at registration
-		// (cobra would reject a bare `submit` before RunE prints help), so the
-		// fallback path validates them here, mirroring the subcommands' error.
-		if err := validateSubmitRequiredFlags(cmd); err != nil {
-			return err
-		}
-		return runSubmit(cmd, framework, originalFramework(args[0]), args[1:])
-	},
+		cmd.AddCommand(newSubmitFrameworkSubcommand(def))
+	}
+
+	return cmd
 }
 
 // validateSubmitRequiredFlags reports unset --name/--image in the exact
@@ -99,7 +124,7 @@ func runSubmit(cmd *cobra.Command, framework, originalFrameworkName string, trai
 			return fmt.Errorf("failed to create K8s client: %w", err)
 		}
 	}
-	return submitCRD(cmdContext(cmd), k8sClient, t, originalFrameworkName, submitDryRun)
+	return submitCRD(cmdContext(cmd), cmd.OutOrStdout(), k8sClient, t, originalFrameworkName, submitDryRun)
 }
 
 // buildSubmitTask constructs a Task from submit CLI flags with framework-specific conversions.

--- a/pkg/cli/submit_flags.go
+++ b/pkg/cli/submit_flags.go
@@ -8,7 +8,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/kubeflow/arena/pkg/constants"
-	outputpkg "github.com/kubeflow/arena/pkg/output"
 )
 
 var (
@@ -155,9 +154,8 @@ func registerSubmitCommonFlags(cmd *cobra.Command) {
 
 	// Dry-run
 	f.BoolVar(&submitDryRun, "dry-run", false, "print CRD as JSON (default) or YAML (-o yaml) without submitting")
-	f.StringVarP(&outputFormat, "output", "o", string(outputpkg.DefaultFormat), outputpkg.FormatHelpText)
+	registerOutputFlag(cmd)
 
-	_ = cmd.RegisterFlagCompletionFunc("output", completeOutputFormat)
 	_ = cmd.RegisterFlagCompletionFunc("clean-task-policy", completeStaticChoices(
 		"None\tDo not clean pods", "Running\tClean running pods", "All\tClean all pods"))
 	_ = cmd.RegisterFlagCompletionFunc("image-pull-policy", completeStaticChoices(

--- a/pkg/cli/submit_flags.go
+++ b/pkg/cli/submit_flags.go
@@ -6,7 +6,6 @@ package cli
 
 import (
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 
 	"github.com/kubeflow/arena/pkg/constants"
 	outputpkg "github.com/kubeflow/arena/pkg/output"
@@ -86,23 +85,6 @@ var (
 	submitIgnoredString        string
 	submitIgnoredBool          bool
 )
-
-func init() {
-	registerSubmitCommonFlags(submitCmd)
-	registerPyTorchSubmitFlags(submitCmd)
-	registerTFSubmitFlags(submitCmd)
-	registerMPISubmitFlags(submitCmd)
-	registerSubmitCompatFlags(submitCmd)
-
-	submitCmd.ValidArgsFunction = completeFrameworkType
-
-	// The parent keeps the full flag set — the fallback path and the test
-	// suite parse it — but hides it from help: `submit -h` lists only the
-	// framework subcommands, matching arena v1.
-	submitCmd.Flags().VisitAll(func(f *pflag.Flag) { f.Hidden = true })
-
-	rootCmd.AddCommand(submitCmd)
-}
 
 // registerSubmitCommonFlags registers the framework-agnostic submit flags on
 // cmd. Required marking of --name/--image is left to the caller: only the

--- a/pkg/cli/submit_flags_test.go
+++ b/pkg/cli/submit_flags_test.go
@@ -11,33 +11,6 @@ import (
 	"github.com/kubeflow/arena/pkg/task"
 )
 
-// resetSubmitCompatFlags resets v1-compat flag variables to their defaults.
-func resetSubmitCompatFlags() {
-	submitSyncMode = ""
-	submitSyncSource = ""
-	submitSyncImage = ""
-	submitPSCPU = ""
-	submitPSMemory = ""
-	submitPSGPUs = 0
-	submitChiefCPU = ""
-	submitChiefMemory = ""
-	submitEvaluatorCPU = ""
-	submitEvaluatorMemory = ""
-	submitWorkerCPU = ""
-	submitWorkerMemory = ""
-	submitPSCPULimit = ""
-	submitPSMemoryLimit = ""
-	submitChiefCPULimit = ""
-	submitChiefMemoryLimit = ""
-	submitEvaluatorCPULimit = ""
-	submitEvaluatorMemoryLimit = ""
-	submitWorkerCPULimit = ""
-	submitWorkerMemoryLimit = ""
-	submitLogLevel = ""
-	submitIgnoredString = ""
-	submitIgnoredBool = false
-}
-
 // v1RenamedFlags are v1 flag names that must be registered on the submit
 // command.
 var v1RenamedFlags = []string{
@@ -84,20 +57,23 @@ var wrongV2Names = []string{
 }
 
 func TestSubmitCompat_V1FlagNamesRegistered(t *testing.T) {
+	cmd := newSubmitCmd()
 	for _, name := range v1RenamedFlags {
-		f := submitCmd.Flags().Lookup(name)
+		f := cmd.Flags().Lookup(name)
 		require.NotNil(t, f, "v1 flag --%s should be registered", name)
 	}
 }
 
 func TestSubmitCompat_WrongV2FlagNamesRemoved(t *testing.T) {
+	cmd := newSubmitCmd()
 	for _, name := range wrongV2Names {
-		assert.Nil(t, submitCmd.Flags().Lookup(name),
+		assert.Nil(t, cmd.Flags().Lookup(name),
 			"--%s must not be registered; the v1 name is the correct name", name)
 	}
 }
 
 func TestSubmitCompat_V1LimitVariantsRegistered(t *testing.T) {
+	cmd := newSubmitCmd()
 	// v1 TFJob exposed -limit variants for per-role resources. They bind to their own variables and override only limits; requests come from the request flag.
 	limits := map[string]string{
 		"ps-cpu-limit":           "ps-cpu",
@@ -110,9 +86,9 @@ func TestSubmitCompat_V1LimitVariantsRegistered(t *testing.T) {
 		"worker-memory-limit":    "worker-memory",
 	}
 	for limit, base := range limits {
-		f := submitCmd.Flags().Lookup(limit)
+		f := cmd.Flags().Lookup(limit)
 		require.NotNil(t, f, "v1 flag --%s should be registered", limit)
-		assert.NotNil(t, submitCmd.Flags().Lookup(base), "--%s should also be registered", base)
+		assert.NotNil(t, cmd.Flags().Lookup(base), "--%s should also be registered", base)
 	}
 }
 
@@ -227,8 +203,8 @@ func TestSubmitCompat_V1FlagsBindToVariables(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			resetSubmitFlags(t)
-			err := submitCmd.Flags().Parse(tt.args)
+			cmd := newSubmitCmd()
+			err := cmd.Flags().Parse(tt.args)
 			if tt.parseErr {
 				require.Error(t, err)
 				return
@@ -241,19 +217,19 @@ func TestSubmitCompat_V1FlagsBindToVariables(t *testing.T) {
 
 func TestSubmitCompat_PriorityIsV1ClassName(t *testing.T) {
 	t.Run("--priority takes a class name like v1", func(t *testing.T) {
-		resetSubmitFlags(t)
-		require.NoError(t, submitCmd.Flags().Parse([]string{"--priority", "high-priority"}))
+		cmd := newSubmitCmd()
+		require.NoError(t, cmd.Flags().Parse([]string{"--priority", "high-priority"}))
 		assert.Equal(t, "high-priority", submitPriorityClass)
 	})
 
 	t.Run("-p shorthand is preserved", func(t *testing.T) {
-		resetSubmitFlags(t)
-		require.NoError(t, submitCmd.Flags().Parse([]string{"-p", "high"}))
+		cmd := newSubmitCmd()
+		require.NoError(t, cmd.Flags().Parse([]string{"-p", "high"}))
 		assert.Equal(t, "high", submitPriorityClass)
 	})
 
 	t.Run("--priority is a string flag", func(t *testing.T) {
-		f := submitCmd.Flags().Lookup("priority")
+		f := newSubmitCmd().Flags().Lookup("priority")
 		require.NotNil(t, f)
 		assert.Equal(t, "string", f.Value.Type())
 	})
@@ -261,20 +237,20 @@ func TestSubmitCompat_PriorityIsV1ClassName(t *testing.T) {
 
 func TestSubmitCompat_QueueIsV1Bool(t *testing.T) {
 	t.Run("--queue is a bool flag like v1", func(t *testing.T) {
-		f := submitCmd.Flags().Lookup("queue")
+		f := newSubmitCmd().Flags().Lookup("queue")
 		require.NotNil(t, f)
 		assert.Equal(t, "bool", f.Value.Type())
 	})
 
 	t.Run("bare --queue parses like a v1 invocation", func(t *testing.T) {
-		resetSubmitFlags(t)
-		require.NoError(t, submitCmd.Flags().Parse([]string{"--queue"}))
+		cmd := newSubmitCmd()
+		require.NoError(t, cmd.Flags().Parse([]string{"--queue"}))
 		assert.True(t, submitQueue)
 	})
 
 	t.Run("--queue suspends the job for kube-queue", func(t *testing.T) {
-		resetSubmitFlags(t)
-		require.NoError(t, submitCmd.Flags().Parse([]string{"--queue"}))
+		cmd := newSubmitCmd()
+		require.NoError(t, cmd.Flags().Parse([]string{"--queue"}))
 
 		tk := buildSubmitTask("pytorch", nil)
 		flags := buildSubmitFlags()
@@ -286,13 +262,14 @@ func TestSubmitCompat_QueueIsV1Bool(t *testing.T) {
 }
 
 func TestSubmitCompat_RepeatableFlagsAreStringArrays(t *testing.T) {
+	cmd := newSubmitCmd()
 	names := []string{
 		"env", "data", "data-dir", "config-file",
 		"label", "annotation", "selector", "toleration",
 		"device", "image-pull-secret",
 	}
 	for _, name := range names {
-		f := submitCmd.Flags().Lookup(name)
+		f := cmd.Flags().Lookup(name)
 		require.NotNil(t, f, "--%s should be registered", name)
 		assert.Equal(t, "stringArray", f.Value.Type(),
 			"--%s must be a stringArray flag (v1 semantics, no comma splitting)", name)
@@ -300,8 +277,8 @@ func TestSubmitCompat_RepeatableFlagsAreStringArrays(t *testing.T) {
 }
 
 func TestSubmitCompat_CommaValuesNotSplit(t *testing.T) {
-	resetSubmitFlags(t)
-	require.NoError(t, submitCmd.Flags().Parse([]string{
+	cmd := newSubmitCmd()
+	require.NoError(t, cmd.Flags().Parse([]string{
 		"--env", "A=1,2",
 		"--data", "ds:/data",
 	}))
@@ -312,9 +289,8 @@ func TestSubmitCompat_CommaValuesNotSplit(t *testing.T) {
 }
 
 func TestSubmitCompat_LimitFlagsHaveOwnVariables(t *testing.T) {
-	resetSubmitFlags(t)
-	resetSubmitCompatFlags()
-	require.NoError(t, submitCmd.Flags().Parse([]string{
+	cmd := newSubmitCmd()
+	require.NoError(t, cmd.Flags().Parse([]string{
 		"--ps-cpu", "1", "--ps-cpu-limit", "2",
 		"--worker-cpu", "1", "--worker-cpu-limit", "3",
 	}))
@@ -342,8 +318,9 @@ var v1OfficialMissingFlags = []string{
 }
 
 func TestSubmitCompat_V1OfficialFlagsRegistered(t *testing.T) {
+	cmd := newSubmitCmd()
 	for _, name := range v1OfficialMissingFlags {
-		f := submitCmd.Flags().Lookup(name)
+		f := cmd.Flags().Lookup(name)
 		require.NotNil(t, f, "v1 official flag --%s should be registered", name)
 		assert.True(t, f.Hidden, "--%s is deprecated and must be hidden from help", name)
 	}
@@ -353,15 +330,14 @@ func TestSubmitCompat_ConfigBindsKubeconfig(t *testing.T) {
 	oldKubeconfig := kubeconfig
 	t.Cleanup(func() { kubeconfig = oldKubeconfig })
 
-	resetSubmitFlags(t)
-	require.NoError(t, submitCmd.Flags().Parse([]string{"--config", "/tmp/kube-config"}))
+	cmd := newSubmitCmd()
+	require.NoError(t, cmd.Flags().Parse([]string{"--config", "/tmp/kube-config"}))
 	assert.Equal(t, "/tmp/kube-config", kubeconfig)
 }
 
 func TestSubmitCompat_DeprecatedFlagsParse(t *testing.T) {
-	resetSubmitFlags(t)
-	resetSubmitCompatFlags()
-	require.NoError(t, submitCmd.Flags().Parse([]string{
+	cmd := newSubmitCmd()
+	require.NoError(t, cmd.Flags().Parse([]string{
 		"--rdma",
 		"--ps-selector", "gpu=a100",
 		"--worker-image", "tf:2.15",

--- a/pkg/cli/submit_subcommands.go
+++ b/pkg/cli/submit_subcommands.go
@@ -43,12 +43,3 @@ func newSubmitFrameworkSubcommand(def frameworkDef) *cobra.Command {
 	registerSubmitCompatFlags(cmd)
 	return cmd
 }
-
-func init() {
-	for _, def := range frameworkRegistry {
-		if def.canonical == "" {
-			continue
-		}
-		submitCmd.AddCommand(newSubmitFrameworkSubcommand(def))
-	}
-}

--- a/pkg/cli/submit_subcommands_test.go
+++ b/pkg/cli/submit_subcommands_test.go
@@ -1,73 +1,23 @@
 package cli
 
 import (
-	"bytes"
 	"encoding/json"
-	"io"
-	"os"
 	"testing"
 
-	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-// resetSubmitCommandState restores the cobra-side flag state of the submit
-// command tree (the parent and every framework subcommand) after earlier
-// ExecuteWithArgs calls in the same process. pflag never clears a flag's
-// Changed bit — nor the implicit --help flag's value — between Parse calls,
-// so a subcommand that once saw --name/--image would skip cobra's
-// required-flag validation forever, and a command whose --help ran once
-// would print help on every later execution. resetSubmitFlags covers the
-// bound package variables; this covers the state pflag keeps on the shared
-// command objects.
-//
-// The flags are reached through Lookup on each command's flag set: the
-// leaked state lives on per-command pflag.Flag objects — every command in
-// the tree registers its own --name and --image, plus cobra's implicit
-// --help — so each of the three flags is looked up by name on every
-// command, and Lookup's nil return lets the loop skip commands that have
-// not (yet) defined one.
-func resetSubmitCommandState(t *testing.T) {
-	t.Helper()
-	cmds := append([]*cobra.Command{submitCmd}, submitCmd.Commands()...)
-	for _, cmd := range cmds {
-		for _, name := range []string{"name", "image", "help"} {
-			f := cmd.Flags().Lookup(name)
-			if f == nil {
-				continue
-			}
-			if name == "help" {
-				// Cobra checks the help flag's value, not its Changed bit, so
-				// resetting the value through the flag's Value is enough.
-				_ = f.Value.Set("false")
-			}
-			f.Changed = false
-		}
-	}
-}
-
-// executeSubmitForJSON runs the CLI with the given args, captures stdout, and
-// unmarshals the CRD JSON printed by a --dry-run submit.
+// executeSubmitForJSON runs the CLI with the given args and unmarshals the
+// CRD JSON printed by a --dry-run submit.
 func executeSubmitForJSON(t *testing.T, args ...string) map[string]interface{} {
 	t.Helper()
-	resetSubmitCommandState(t)
-
-	oldStdout := os.Stdout
-	r, w, _ := os.Pipe()
-	os.Stdout = w
-	err := ExecuteWithArgs(args)
-	w.Close()
-	os.Stdout = oldStdout
-
-	var buf bytes.Buffer
-	_, _ = io.Copy(&buf, r)
-
-	require.NoError(t, err, "submit should succeed, stdout: %s", buf.String())
+	out, err := ExecuteWithArgsOutput(args)
+	require.NoError(t, err, "submit should succeed, stdout: %s", out)
 
 	var crd map[string]interface{}
-	require.NoError(t, json.Unmarshal(buf.Bytes(), &crd),
-		"dry-run output should be valid JSON, got: %s", buf.String())
+	require.NoError(t, json.Unmarshal([]byte(out), &crd),
+		"dry-run output should be valid JSON, got: %s", out)
 	return crd
 }
 
@@ -75,20 +25,9 @@ func executeSubmitForJSON(t *testing.T, args ...string) map[string]interface{} {
 // everything written to stdout (used for --help output).
 func executeSubmitCaptureStdout(t *testing.T, args ...string) string {
 	t.Helper()
-	resetSubmitCommandState(t)
-
-	oldStdout := os.Stdout
-	r, w, _ := os.Pipe()
-	os.Stdout = w
-	err := ExecuteWithArgs(args)
-	w.Close()
-	os.Stdout = oldStdout
-
-	var buf bytes.Buffer
-	_, _ = io.Copy(&buf, r)
-
+	out, err := ExecuteWithArgsOutput(args)
 	require.NoError(t, err)
-	return buf.String()
+	return out
 }
 
 func TestSubmitSubcommands_DispatchDryRun(t *testing.T) {
@@ -104,7 +43,6 @@ func TestSubmitSubcommands_DispatchDryRun(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.subcommand, func(t *testing.T) {
-			resetSubmitFlags(t)
 			crd := executeSubmitForJSON(t, "submit", tt.subcommand,
 				"--name", "subcmd-test", "--image", "test:latest",
 				"--workers", "2", "--dry-run", "echo", "hi")
@@ -118,7 +56,6 @@ func TestSubmitSubcommands_DispatchDryRun(t *testing.T) {
 // carry the run command (trailing args) and the parsed --workers flag through
 // the shared runSubmit core into the CRD.
 func TestSubmitSubcommands_SubcommandPathCarriesRunConfig(t *testing.T) {
-	resetSubmitFlags(t)
 	crd := executeSubmitForJSON(t, "submit", "pytorchjob",
 		"--name", "cfg-test", "--image", "test:latest",
 		"--workers", "2", "--dry-run", "python", "train.py")
@@ -168,7 +105,6 @@ func TestSubmitSubcommands_RejectForeignFlags(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			resetSubmitFlags(t)
 			err := ExecuteWithArgs(tt.args)
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), "unknown flag")
@@ -210,7 +146,6 @@ func TestSubmitSubcommands_HelpShowsOnlyRelevantFlags(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.subcommand, func(t *testing.T) {
-			resetSubmitFlags(t)
 			help := executeSubmitCaptureStdout(t, "submit", tt.subcommand, "--help")
 			for _, want := range tt.contains {
 				assert.Contains(t, help, want)
@@ -244,7 +179,6 @@ func TestSubmitSubcommands_AliasMatrixDispatch(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.alias, func(t *testing.T) {
-			resetSubmitFlags(t)
 			crd := executeSubmitForJSON(t, "submit", tt.alias,
 				"--name", "alias-test", "--image", "test:latest", "--dry-run", "echo", "hi")
 			assert.Equal(t, tt.kind, crd["kind"])
@@ -269,7 +203,6 @@ func TestSubmitSubcommands_FrameworkLabelIsCanonical(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.typed, func(t *testing.T) {
-			resetSubmitFlags(t)
 			crd := executeSubmitForJSON(t, "submit", tt.typed,
 				"--name", "label-test", "--image", "test:latest", "--dry-run", "echo", "hi")
 			labels, ok := crd["metadata"].(map[string]interface{})["labels"].(map[string]interface{})
@@ -281,36 +214,30 @@ func TestSubmitSubcommands_FrameworkLabelIsCanonical(t *testing.T) {
 
 func TestSubmitSubcommands_ParentFallbackBehaviors(t *testing.T) {
 	t.Run("v1-only type with flags still gets the dedicated error", func(t *testing.T) {
-		resetSubmitFlags(t)
 		err := ExecuteWithArgs([]string{"submit", "ray", "--name", "x", "--image", "y", "python", "train.py"})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "not supported by arena-v2 yet")
 	})
 
 	t.Run("unknown type still gets the unsupported error", func(t *testing.T) {
-		resetSubmitFlags(t)
 		err := ExecuteWithArgs([]string{"submit", "bogus", "--name", "x", "--image", "y", "python", "train.py"})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "unsupported framework type")
 	})
 
 	t.Run("case variant falls back to the parent and still submits", func(t *testing.T) {
-		resetSubmitFlags(t)
 		crd := executeSubmitForJSON(t, "submit", "PyTorch",
 			"--name", "case-test", "--image", "test:latest", "--dry-run", "echo", "hi")
 		assert.Equal(t, "PyTorchJob", crd["kind"])
 	})
 
 	t.Run("fallback path missing required flags matches the subcommand error", func(t *testing.T) {
-		resetSubmitCommandState(t)
-		resetSubmitFlags(t)
 		err := ExecuteWithArgs([]string{"submit", "PyTorch", "python", "train.py"})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), `required flag(s) "image", "name" not set`)
 	})
 
 	t.Run("bare submit prints help instead of erroring", func(t *testing.T) {
-		resetSubmitFlags(t)
 		help := executeSubmitCaptureStdout(t, "submit")
 		for _, sub := range []string{"pytorchjob", "tfjob", "mpijob", "horovodjob", "deepspeedjob"} {
 			assert.Contains(t, help, sub, "bare submit help should list the %s subcommand", sub)
@@ -318,7 +245,6 @@ func TestSubmitSubcommands_ParentFallbackBehaviors(t *testing.T) {
 	})
 
 	t.Run("flags but no framework prints help instead of erroring", func(t *testing.T) {
-		resetSubmitFlags(t)
 		help := executeSubmitCaptureStdout(t, "submit", "--name", "x", "--image", "y")
 		assert.Contains(t, help, "Available Commands:")
 	})
@@ -331,15 +257,12 @@ func TestSubmitSubcommands_ParentFallbackBehaviors(t *testing.T) {
 		// if that state leaked in. Reset it so this subtest passes regardless
 		// of ordering. (Parent-path missing --name is covered by
 		// TestSubmitCmd_NameAndImageRequired via task validation.)
-		resetSubmitCommandState(t)
-		resetSubmitFlags(t)
 		err := ExecuteWithArgs([]string{"submit", "pytorchjob", "python", "train.py"})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "required flag")
 	})
 
 	t.Run("flags before the type still route to the subcommand", func(t *testing.T) {
-		resetSubmitFlags(t)
 		crd := executeSubmitForJSON(t, "submit",
 			"--name", "order-test", "--image", "test:latest",
 			"pytorchjob", "--dry-run", "echo", "hi")
@@ -348,7 +271,6 @@ func TestSubmitSubcommands_ParentFallbackBehaviors(t *testing.T) {
 }
 
 func TestSubmitParentHelp_ListsSubcommandsOnly(t *testing.T) {
-	resetSubmitFlags(t)
 	help := executeSubmitCaptureStdout(t, "submit", "--help")
 
 	for _, sub := range []string{"pytorchjob", "tfjob", "mpijob", "horovodjob", "deepspeedjob"} {

--- a/pkg/cli/submit_test.go
+++ b/pkg/cli/submit_test.go
@@ -4,8 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"io"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -20,13 +18,14 @@ func TestSubmitCmd_NoFrameworkArgPrintsHelp(t *testing.T) {
 	// RunE guards the empty-args case with help (the framework is the first
 	// positional argument); full stdout coverage lives in
 	// TestSubmitSubcommands_ParentFallbackBehaviors.
-	err := submitCmd.RunE(submitCmd, nil)
+	cmd := newSubmitCmd()
+	err := cmd.RunE(cmd, nil)
 	assert.NoError(t, err)
 }
 
 func TestSubmitCmd_RegisteredWithRootCmd(t *testing.T) {
 	found := false
-	for _, cmd := range rootCmd.Commands() {
+	for _, cmd := range NewRootCommand().Commands() {
 		if cmd.Name() == "submit" {
 			found = true
 			break
@@ -36,68 +35,64 @@ func TestSubmitCmd_RegisteredWithRootCmd(t *testing.T) {
 }
 
 func TestSubmitCmd_HasRequiredFlags(t *testing.T) {
+	cmd := newSubmitCmd()
 	flagNames := []string{"name", "image", "workers", "gpus", "cpu", "memory"}
 	for _, name := range flagNames {
-		f := submitCmd.Flags().Lookup(name)
+		f := cmd.Flags().Lookup(name)
 		require.NotNil(t, f, "flag %q should be registered", name)
 	}
 }
 
 func TestSubmitCmd_HasFrameworkFlags(t *testing.T) {
-	f := submitCmd.Flags().Lookup("nproc-per-node")
+	cmd := newSubmitCmd()
+	f := cmd.Flags().Lookup("nproc-per-node")
 	assert.NotNil(t, f, "nproc-per-node flag should be registered")
 
-	f = submitCmd.Flags().Lookup("ps")
+	f = cmd.Flags().Lookup("ps")
 	assert.NotNil(t, f, "ps flag should be registered")
 
-	f = submitCmd.Flags().Lookup("slots-per-worker")
+	f = cmd.Flags().Lookup("slots-per-worker")
 	assert.NotNil(t, f, "slots-per-worker flag should be registered")
 }
 
 func TestSubmitCmd_HasDryRunFlag(t *testing.T) {
-	f := submitCmd.Flags().Lookup("dry-run")
+	cmd := newSubmitCmd()
+	f := cmd.Flags().Lookup("dry-run")
 	require.NotNil(t, f, "dry-run flag should be registered")
 	assert.Equal(t, "false", f.DefValue)
 }
 
 func TestSubmitCmd_NameAndImageRequired(t *testing.T) {
-	resetSubmitCommandState(t)
-	resetSubmitFlags(t)
-
-	err := submitCmd.RunE(submitCmd, []string{"pytorch"})
+	cmd := newSubmitCmd()
+	err := cmd.RunE(cmd, []string{"pytorch"})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "required flag")
 }
 
 func TestSubmitCmd_UnsupportedFramework(t *testing.T) {
-	resetSubmitFlags(t)
-
+	cmd := newSubmitCmd()
 	submitName = "test-job"
 	submitImage = "test-image:latest"
 
-	err := submitCmd.RunE(submitCmd, []string{"jax"})
+	err := cmd.RunE(cmd, []string{"jax"})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "unsupported framework")
 }
 
 func TestSubmitCmd_ValidationFailsWithoutName(t *testing.T) {
-	resetSubmitCommandState(t)
-	resetSubmitFlags(t)
+	cmd := newSubmitCmd()
+	require.NoError(t, cmd.Flags().Parse([]string{"--image", "some-image:latest"}))
 
-	require.NoError(t, submitCmd.Flags().Parse([]string{"--image", "some-image:latest"}))
-
-	err := submitCmd.RunE(submitCmd, []string{"pytorch"})
+	err := cmd.RunE(cmd, []string{"pytorch"})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), `required flag(s) "name" not set`)
 }
 
 func TestSubmitCmd_ValidationFailsWithoutImage(t *testing.T) {
-	resetSubmitCommandState(t)
-	resetSubmitFlags(t)
+	cmd := newSubmitCmd()
+	require.NoError(t, cmd.Flags().Parse([]string{"--name", "my-job"}))
 
-	require.NoError(t, submitCmd.Flags().Parse([]string{"--name", "my-job"}))
-
-	err := submitCmd.RunE(submitCmd, []string{"pytorch"})
+	err := cmd.RunE(cmd, []string{"pytorch"})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), `required flag(s) "image" not set`)
 }
@@ -146,7 +141,7 @@ func TestBuildSubmitTask_PyTorchWorkersNMinusOne(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			resetSubmitFlags(t)
+			resetSubmitGlobals(t)
 			submitName = "test-job"
 			submitImage = "test:latest"
 			submitWorkers = tt.workers
@@ -166,7 +161,7 @@ func TestBuildSubmitTask_PyTorchWorkersNMinusOne(t *testing.T) {
 }
 
 func TestBuildSubmitTask_ChiefEvaluatorPS(t *testing.T) {
-	resetSubmitFlags(t)
+	resetSubmitGlobals(t)
 	submitName = "test-job"
 	submitImage = "test:latest"
 	submitWorkers = 2
@@ -214,7 +209,7 @@ func TestBuildSubmitTask_ChiefEvaluatorPS(t *testing.T) {
 }
 
 func TestBuildSubmitTask_TrailingArgs(t *testing.T) {
-	resetSubmitFlags(t)
+	resetSubmitGlobals(t)
 	submitName = "test-job"
 	submitImage = "test:latest"
 	submitWorkers = 1
@@ -257,7 +252,7 @@ func TestNormalizeFramework(t *testing.T) {
 }
 
 func TestBuildSubmitFlags_IncludesTolerations(t *testing.T) {
-	resetSubmitFlags(t)
+	resetSubmitGlobals(t)
 	submitTolerations = []string{"key1=value1:NoSchedule", "key2=value2:NoExecute"}
 
 	flags := buildSubmitFlags()
@@ -267,7 +262,7 @@ func TestBuildSubmitFlags_IncludesTolerations(t *testing.T) {
 }
 
 func TestBuildSubmitFlags_EmptyTolerations(t *testing.T) {
-	resetSubmitFlags(t)
+	resetSubmitGlobals(t)
 	submitTolerations = nil
 
 	flags := buildSubmitFlags()
@@ -276,7 +271,7 @@ func TestBuildSubmitFlags_EmptyTolerations(t *testing.T) {
 }
 
 func TestBuildSubmitFlags(t *testing.T) {
-	resetSubmitFlags(t)
+	resetSubmitGlobals(t)
 
 	submitName = "test-job"
 	submitImage = "test:latest"
@@ -325,7 +320,7 @@ func TestOriginalFramework(t *testing.T) {
 func TestSubmitCmd_MPIVersionIntegration_V1FromCluster(t *testing.T) {
 	// Simulates the submit command flow when the cluster has MPIJob CRD with
 	// storage version v1. Verifies that the generated CR uses kubeflow.org/v1.
-	resetSubmitFlags(t)
+	resetSubmitGlobals(t)
 
 	submitName = "mpi-v1-submit"
 	submitImage = "openmpi:4.1"
@@ -362,7 +357,7 @@ func TestSubmitCmd_MPIVersionIntegration_V1FromCluster(t *testing.T) {
 func TestSubmitCmd_MPIVersionIntegration_V2beta1Default(t *testing.T) {
 	// Simulates the submit command flow in dry-run mode (no cluster).
 	// With the removal of the default fallback, APIVersion must be explicitly set.
-	resetSubmitFlags(t)
+	resetSubmitGlobals(t)
 
 	submitName = "mpi-v2beta1-submit"
 	submitImage = "openmpi:4.1"
@@ -392,7 +387,7 @@ func TestSubmitCmd_MPIVersionIntegration_V2beta1Default(t *testing.T) {
 
 func TestSubmitCmd_MPIVersionIntegration_DeepSpeed(t *testing.T) {
 	// Verifies that deepspeed (MPI-family) also uses the detected version.
-	resetSubmitFlags(t)
+	resetSubmitGlobals(t)
 
 	submitName = "deepspeed-v1"
 	submitImage = "deepspeed:latest"
@@ -419,7 +414,7 @@ func TestSubmitCmd_MPIVersionIntegration_DeepSpeed(t *testing.T) {
 
 func TestSubmitCmd_MPIVersionIntegration_Horovod(t *testing.T) {
 	// Verifies that horovod (MPI-family) also uses the detected version.
-	resetSubmitFlags(t)
+	resetSubmitGlobals(t)
 
 	submitName = "horovod-v1"
 	submitImage = "horovod:latest"
@@ -443,59 +438,12 @@ func TestSubmitCmd_MPIVersionIntegration_Horovod(t *testing.T) {
 	assert.Equal(t, "kubeflow.org/v1", crd.GetAPIVersion())
 }
 
-// resetSubmitFlags resets all submit flag variables to their defaults
-func resetSubmitFlags(t *testing.T) {
+// resetSubmitGlobals rebinds every submit flag variable to its default by
+// constructing a fresh submit command: pflag writes the default into the
+// bound variable at registration time, so a fresh tree is a full reset.
+func resetSubmitGlobals(t *testing.T) {
 	t.Helper()
-	submitName = ""
-	submitImage = ""
-	submitWorkers = 1
-	submitGPUs = 0
-	submitCPU = ""
-	submitMemory = ""
-	submitEnvs = nil
-	submitData = nil
-	submitLabels = nil
-	submitAnnotations = nil
-	submitSelectors = nil
-	submitTolerations = nil
-	submitPriorityClass = ""
-	submitGang = false
-	submitScheduler = ""
-	submitCleanTaskPolicy = "Running"
-	submitRunningTimeout = ""
-	submitTTLAfterFinished = ""
-	submitJobBackoffLimit = 0
-	submitImagePullPolicy = ""
-	submitImagePullSecret = nil
-	submitServiceAccount = ""
-	submitJobRestartPolicy = ""
-	submitHostNetwork = false
-	submitHostIPC = false
-	submitHostPID = false
-	submitWorkingDir = ""
-	submitShell = ""
-	submitShareMemory = "2Gi"
-	submitDevice = nil
-	submitGPUType = ""
-	submitTensorBoard = false
-	submitLogDir = "/training_logs"
-	submitTBImage = ""
-	submitNprocPerNode = ""
-	submitPS = 0
-	submitChief = false
-	submitEvaluator = false
-	submitSlotsPerWorker = 0
-	submitGPUTopology = false
-	submitMountsOnLauncher = false
-	submitAffinityPolicy = ""
-	submitAffinityConstraint = ""
-	submitAffinityTarget = ""
-	submitSuccessPolicy = ""
-	submitDryRun = false
-	submitQueue = false
-	submitDataDir = nil
-	submitConfigFile = nil
-	resetSubmitCompatFlags()
+	newSubmitCmd()
 }
 
 func TestCRDReplicaSpecs_PyTorch(t *testing.T) {
@@ -761,10 +709,8 @@ func TestProviderRejectsWrongFramework(t *testing.T) {
 }
 
 func TestSubmitCmd_DryRunCapturesOutput(t *testing.T) {
-	resetSubmitCommandState(t)
-	resetSubmitFlags(t)
-
-	require.NoError(t, submitCmd.Flags().Parse([]string{
+	cmd := newSubmitCmd()
+	require.NoError(t, cmd.Flags().Parse([]string{
 		"--name", "dryrun-test",
 		"--image", "pytorch:2.1",
 		"--workers", "2",
@@ -772,23 +718,14 @@ func TestSubmitCmd_DryRunCapturesOutput(t *testing.T) {
 		"--dry-run",
 	}))
 
-	// Capture stdout — printCRD uses fmt.Println which writes to os.Stdout.
-	// klog-based log output goes to stderr, so stdout should contain only the CRD JSON.
-	oldStdout := os.Stdout
-	r, w, _ := os.Pipe()
-	os.Stdout = w
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
 
 	// Trailing args "python train.py" become the run command (required by validation).
-	err := submitCmd.RunE(submitCmd, []string{"pytorch", "python", "train.py"})
-
-	w.Close()
-	os.Stdout = oldStdout
-
-	var buf bytes.Buffer
-	_, _ = io.Copy(&buf, r)
-	output := buf.String()
+	err := cmd.RunE(cmd, []string{"pytorch", "python", "train.py"})
 
 	require.NoError(t, err, "dry-run should succeed without a cluster")
+	output := buf.String()
 	require.NotEmpty(t, output, "dry-run should produce JSON output")
 
 	var crd map[string]interface{}
@@ -801,8 +738,7 @@ func TestSubmitCmd_DryRunCapturesOutput(t *testing.T) {
 // The generated CRD must wire the shared volume into both containers: the
 // sync init container (writer) and the main container (reader).
 func TestSubmitCompat_SyncVolumeSharedWithMainContainer(t *testing.T) {
-	resetSubmitFlags(t)
-
+	cmd := newSubmitCmd()
 	v1Args := []string{
 		"--name", "sync-volume-e2e",
 		"--image", "pytorch:2.1",
@@ -810,21 +746,13 @@ func TestSubmitCompat_SyncVolumeSharedWithMainContainer(t *testing.T) {
 		"--sync-source", "https://github.com/kubeflow/arena.git",
 		"--dry-run",
 	}
-	require.NoError(t, submitCmd.Flags().Parse(v1Args))
-
-	oldStdout := os.Stdout
-	r, w, _ := os.Pipe()
-	os.Stdout = w
-
-	err := submitCmd.RunE(submitCmd, []string{"pytorch", "python", "train.py"})
-
-	w.Close()
-	os.Stdout = oldStdout
+	require.NoError(t, cmd.Flags().Parse(v1Args))
 
 	var buf bytes.Buffer
-	_, _ = io.Copy(&buf, r)
-	output := buf.String()
+	cmd.SetOut(&buf)
+	err := cmd.RunE(cmd, []string{"pytorch", "python", "train.py"})
 
+	output := buf.String()
 	require.NoError(t, err, "sync invocation should succeed in dry-run mode")
 
 	var crd map[string]interface{}
@@ -857,7 +785,7 @@ func TestSubmitCompat_SyncVolumeSharedWithMainContainer(t *testing.T) {
 }
 
 func TestSubmitCompat_V1CommandEndToEndDryRun(t *testing.T) {
-	resetSubmitFlags(t)
+	cmd := newSubmitCmd()
 
 	// A representative v1 invocation using only v1 flag names.
 	v1Args := []string{
@@ -874,21 +802,13 @@ func TestSubmitCompat_V1CommandEndToEndDryRun(t *testing.T) {
 		"--sync-source", "https://github.com/kubeflow/arena.git",
 		"--dry-run",
 	}
-	require.NoError(t, submitCmd.Flags().Parse(v1Args))
-
-	oldStdout := os.Stdout
-	r, w, _ := os.Pipe()
-	os.Stdout = w
-
-	err := submitCmd.RunE(submitCmd, []string{"pytorch", "python", "train.py"})
-
-	w.Close()
-	os.Stdout = oldStdout
+	require.NoError(t, cmd.Flags().Parse(v1Args))
 
 	var buf bytes.Buffer
-	_, _ = io.Copy(&buf, r)
-	output := buf.String()
+	cmd.SetOut(&buf)
+	err := cmd.RunE(cmd, []string{"pytorch", "python", "train.py"})
 
+	output := buf.String()
 	require.NoError(t, err, "v1-style invocation should succeed in dry-run mode")
 
 	var crd map[string]interface{}
@@ -923,19 +843,20 @@ func TestSubmitCompat_V1CommandEndToEndDryRun(t *testing.T) {
 }
 
 func TestSubmitCompat_UniformV1Defaults(t *testing.T) {
-	f := submitCmd.Flags().Lookup("share-memory")
+	cmd := newSubmitCmd()
+	f := cmd.Flags().Lookup("share-memory")
 	require.NotNil(t, f)
 	assert.Equal(t, "2Gi", f.DefValue)
-	f = submitCmd.Flags().Lookup("clean-task-policy")
+	f = cmd.Flags().Lookup("clean-task-policy")
 	require.NotNil(t, f)
 	assert.Equal(t, "Running", f.DefValue)
-	f = submitCmd.Flags().Lookup("logdir")
+	f = cmd.Flags().Lookup("logdir")
 	require.NotNil(t, f)
 	assert.Equal(t, "/training_logs", f.DefValue)
 }
 
 func TestSubmitCompat_DefaultsReachTheTask(t *testing.T) {
-	resetSubmitFlags(t)
+	resetSubmitGlobals(t)
 	tk := buildSubmitTask("pytorch", nil)
 	flags := buildSubmitFlags()
 	require.NoError(t, task.ApplyOverrides(tk, flags))
@@ -955,8 +876,8 @@ func TestSubmitCompat_DefaultsReachTheTask(t *testing.T) {
 }
 
 func TestSubmitCompat_DefaultsOptOutViaEmptyValue(t *testing.T) {
-	resetSubmitFlags(t)
-	require.NoError(t, submitCmd.Flags().Parse([]string{"--share-memory", "", "--clean-task-policy", "", "--logdir", ""}))
+	cmd := newSubmitCmd()
+	require.NoError(t, cmd.Flags().Parse([]string{"--share-memory", "", "--clean-task-policy", "", "--logdir", ""}))
 	flags := buildSubmitFlags()
 	assert.NotContains(t, flags, "share-memory")
 	assert.NotContains(t, flags, "clean-task-policy")

--- a/pkg/cli/suspend.go
+++ b/pkg/cli/suspend.go
@@ -11,29 +11,34 @@ import (
 	"github.com/kubeflow/arena/pkg/client"
 )
 
-var suspendCmd = &cobra.Command{
-	Use:   "suspend <name>",
-	Short: "Suspend a running training job",
-	Long:  `Suspend a running training job by setting spec.runPolicy.suspend to true.`,
-	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		name := args[0]
+func newSuspendCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "suspend <name>",
+		Short: "Suspend a running training job",
+		Long:  `Suspend a running training job by setting spec.runPolicy.suspend to true.`,
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			name := args[0]
 
-		k8sClient, err := client.NewClient(kubeconfig, kubeContext)
-		if err != nil {
-			return fmt.Errorf("failed to create K8s client: %w", err)
-		}
+			k8sClient, err := client.NewClient(kubeconfig, kubeContext)
+			if err != nil {
+				return fmt.Errorf("failed to create K8s client: %w", err)
+			}
 
-		ns := resolveNS("")
+			ns := resolveNS("")
 
-		jobType, err := suspendJob(cmdContext(cmd), k8sClient, ns, name)
-		if err != nil {
-			return err
-		}
+			jobType, err := suspendJob(cmdContext(cmd), k8sClient, ns, name)
+			if err != nil {
+				return err
+			}
 
-		fmt.Printf("%s/%s suspended\n", strings.ToLower(jobType), name)
-		return nil
-	},
+			fmt.Fprintf(cmd.OutOrStdout(), "%s/%s suspended\n", strings.ToLower(jobType), name)
+			return nil
+		},
+	}
+
+	cmd.ValidArgsFunction = completeJobName
+	return cmd
 }
 
 func suspendJob(ctx context.Context, k8sClient *client.Client, namespace, name string) (string, error) {
@@ -61,9 +66,4 @@ func suspendJob(ctx context.Context, k8sClient *client.Client, namespace, name s
 	}
 
 	return jobType, nil
-}
-
-func init() {
-	suspendCmd.ValidArgsFunction = completeJobName
-	jobCmd.AddCommand(suspendCmd)
 }

--- a/pkg/cli/suspend.go
+++ b/pkg/cli/suspend.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -18,6 +17,9 @@ func newSuspendCmd() *cobra.Command {
 		Long:  `Suspend a running training job by setting spec.runPolicy.suspend to true.`,
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := validateOutputFormat(); err != nil {
+				return err
+			}
 			name := args[0]
 
 			k8sClient, err := client.NewClient(kubeconfig, kubeContext)
@@ -32,11 +34,11 @@ func newSuspendCmd() *cobra.Command {
 				return err
 			}
 
-			fmt.Fprintf(cmd.OutOrStdout(), "%s/%s suspended\n", strings.ToLower(jobType), name)
-			return nil
+			return printActionResult(cmd.OutOrStdout(), name, ns, jobType, "suspended")
 		},
 	}
 
+	registerOutputFlag(cmd)
 	cmd.ValidArgsFunction = completeJobName
 	return cmd
 }

--- a/pkg/cli/suspend_test.go
+++ b/pkg/cli/suspend_test.go
@@ -14,23 +14,26 @@ import (
 )
 
 func TestSuspendCmd_RequiresArg(t *testing.T) {
-	err := suspendCmd.Args(suspendCmd, []string{})
+	cmd := newSuspendCmd()
+	err := cmd.Args(cmd, []string{})
 	assert.Error(t, err)
 }
 
 func TestSuspendCmd_AcceptsOneArg(t *testing.T) {
-	err := suspendCmd.Args(suspendCmd, []string{"my-job"})
+	cmd := newSuspendCmd()
+	err := cmd.Args(cmd, []string{"my-job"})
 	assert.NoError(t, err)
 }
 
 func TestSuspendCmd_RejectsExtraArgs(t *testing.T) {
-	err := suspendCmd.Args(suspendCmd, []string{"job1", "job2"})
+	cmd := newSuspendCmd()
+	err := cmd.Args(cmd, []string{"job1", "job2"})
 	assert.Error(t, err)
 }
 
 func TestSuspendCmd_RegisteredWithJob(t *testing.T) {
 	found := false
-	for _, cmd := range jobCmd.Commands() {
+	for _, cmd := range newJobCmd().Commands() {
 		if cmd.Name() == "suspend" {
 			found = true
 			break
@@ -44,14 +47,15 @@ func TestSuspendCmd_NotFound(t *testing.T) {
 	defer func() { kubeconfig = orig }()
 
 	kubeconfig = "/nonexistent/kubeconfig"
-	err := suspendCmd.RunE(suspendCmd, []string{"nonexistent-job"})
+	cmd := newSuspendCmd()
+	err := cmd.RunE(cmd, []string{"nonexistent-job"})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to create K8s client")
 }
 
 func TestSuspendCmd_HasCorrectMetadata(t *testing.T) {
-	assert.Equal(t, "suspend <name>", suspendCmd.Use)
-	assert.NotEmpty(t, suspendCmd.Short)
+	assert.Equal(t, "suspend <name>", newSuspendCmd().Use)
+	assert.NotEmpty(t, newSuspendCmd().Short)
 }
 
 func TestSuspendCmd_PatchesSuspendField(t *testing.T) {

--- a/pkg/cli/top.go
+++ b/pkg/cli/top.go
@@ -12,7 +12,9 @@ import (
 	outputpkg "github.com/kubeflow/arena/pkg/output"
 )
 
-var topOutputFormat string
+var (
+	topAllNamespaces bool
+)
 
 // newTopCmd builds the `top` group. It has no Run hook on purpose: cobra
 // prints the group's help automatically when the bare command is invoked.
@@ -34,8 +36,7 @@ func newTopJobCmd() *cobra.Command {
 		Use:   "job",
 		Short: "Display Resource (GPU) usage of jobs.",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			// Validate format
-			if err := outputpkg.Format(topOutputFormat).Validate(); err != nil {
+			if err := validateOutputFormat(); err != nil {
 				return err
 			}
 
@@ -50,7 +51,7 @@ func newTopJobCmd() *cobra.Command {
 				mpiAvailable = false
 			}
 
-			ns := resolveNS("")
+			ns := resolveListNamespace(topAllNamespaces)
 			allJobs := make([]client.JobStatus, 0)
 			anySucceeded := false
 			failedKindCount := 0
@@ -97,7 +98,10 @@ func newTopJobCmd() *cobra.Command {
 				TableFn: func() string { return renderer.RenderTopJob(allJobs) },
 				WideFn:  func() string { return renderer.RenderTopJobWide(allJobs) },
 			}
-			if err := outputpkg.Format(topOutputFormat).Render(cmd.OutOrStdout(), allJobs, opts); err != nil {
+			if topAllNamespaces {
+				opts.TableFn = func() string { return renderer.RenderTopJobAllNamespaces(allJobs) }
+			}
+			if err := outputpkg.Format(outputFormat).Render(cmd.OutOrStdout(), allJobs, opts); err != nil {
 				return err
 			}
 			// Warn the user when some job types could not be listed so they
@@ -113,14 +117,8 @@ func newTopJobCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(
-		&topOutputFormat,
-		"output",
-		"o",
-		string(outputpkg.DefaultFormat),
-		outputpkg.FormatHelpText,
-	)
+	registerOutputFlag(cmd)
+	cmd.Flags().BoolVarP(&topAllNamespaces, "all-namespaces", "A", false, "list jobs across all namespaces")
 	cmd.ValidArgsFunction = cobra.NoFileCompletions
-	_ = cmd.RegisterFlagCompletionFunc("output", completeOutputFormat)
 	return cmd
 }

--- a/pkg/cli/top.go
+++ b/pkg/cli/top.go
@@ -14,111 +14,113 @@ import (
 
 var topOutputFormat string
 
-var topCmd = &cobra.Command{
-	Use:   "top",
-	Short: "Display Resource (GPU) usage.",
-	Long: `Display Resource (GPU) usage.
+// newTopCmd builds the `top` group. It has no Run hook on purpose: cobra
+// prints the group's help automatically when the bare command is invoked.
+func newTopCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "top",
+		Short: "Display Resource (GPU) usage.",
+		Long: `Display Resource (GPU) usage.
 
 Available Commands:
   job         Display Resource (GPU) usage of jobs`,
-	Run: func(cmd *cobra.Command, args []string) {
-		cmd.HelpFunc()(cmd, args)
-	},
+	}
+	cmd.AddCommand(newTopJobCmd())
+	return cmd
 }
 
-var topJobCmd = &cobra.Command{
-	Use:   "job",
-	Short: "Display Resource (GPU) usage of jobs.",
-	RunE: func(cmd *cobra.Command, _ []string) error {
-		// Validate format
-		if err := outputpkg.Format(topOutputFormat).Validate(); err != nil {
-			return err
-		}
-
-		k8sClient, err := client.NewClient(kubeconfig, kubeContext)
-		if err != nil {
-			return fmt.Errorf("failed to create K8s client: %w", err)
-		}
-
-		mpiAvailable := true
-		if err := k8sClient.ResolveMPIVersion(cmdContext(cmd)); err != nil {
-			log.Debug("MPIJob CRD not available", "error", err.Error())
-			mpiAvailable = false
-		}
-
-		ns := resolveNS("")
-		allJobs := make([]client.JobStatus, 0)
-		anySucceeded := false
-		failedKindCount := 0
-		apiErrors := make([]string, 0)
-		for _, kind := range supportedJobKinds {
-			if kind == constants.KindMPIJob && !mpiAvailable {
-				continue
+func newTopJobCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "job",
+		Short: "Display Resource (GPU) usage of jobs.",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			// Validate format
+			if err := outputpkg.Format(topOutputFormat).Validate(); err != nil {
+				return err
 			}
-			jobs, err := k8sClient.List(cmdContext(cmd), kind, ns, v2LabelSelector)
+
+			k8sClient, err := client.NewClient(kubeconfig, kubeContext)
 			if err != nil {
-				if apierrors.IsNotFound(err) {
-					// CRD not installed — not an error, just skip silently
-					log.Debug("CRD not installed", "kind", kind)
+				return fmt.Errorf("failed to create K8s client: %w", err)
+			}
+
+			mpiAvailable := true
+			if err := k8sClient.ResolveMPIVersion(cmdContext(cmd)); err != nil {
+				log.Debug("MPIJob CRD not available", "error", err.Error())
+				mpiAvailable = false
+			}
+
+			ns := resolveNS("")
+			allJobs := make([]client.JobStatus, 0)
+			anySucceeded := false
+			failedKindCount := 0
+			apiErrors := make([]string, 0)
+			for _, kind := range supportedJobKinds {
+				if kind == constants.KindMPIJob && !mpiAvailable {
 					continue
 				}
-				// Real API error (permission, network, etc.) — track and report
-				apiVer, _ := k8sClient.KindToAPIVersion(kind)
-				log.Warning("failed to list CRD kind", "kind", kind, "apiVersion", apiVer, "error", err.Error())
-				apiErrors = append(apiErrors, fmt.Sprintf("%s: %s", kind, err.Error()))
-				failedKindCount++
-				continue
-			}
-			anySucceeded = true
-			for _, job := range jobs {
-				status := extractJobStatus(job, kind)
-				if fw, ok := job.GetLabels()[frameworkLabel]; ok && fw != "" {
-					status.Framework = fw
-				} else {
-					status.Framework = kindToFramework(kind)
+				jobs, err := k8sClient.List(cmdContext(cmd), kind, ns, v2LabelSelector)
+				if err != nil {
+					if apierrors.IsNotFound(err) {
+						// CRD not installed — not an error, just skip silently
+						log.Debug("CRD not installed", "kind", kind)
+						continue
+					}
+					// Real API error (permission, network, etc.) — track and report
+					apiVer, _ := k8sClient.KindToAPIVersion(kind)
+					log.Warning("failed to list CRD kind", "kind", kind, "apiVersion", apiVer, "error", err.Error())
+					apiErrors = append(apiErrors, fmt.Sprintf("%s: %s", kind, err.Error()))
+					failedKindCount++
+					continue
 				}
-				status.GPURequested = extractGPURequested(job)
-				allJobs = append(allJobs, status)
+				anySucceeded = true
+				for _, job := range jobs {
+					status := extractJobStatus(job, kind)
+					if fw, ok := job.GetLabels()[frameworkLabel]; ok && fw != "" {
+						status.Framework = fw
+					} else {
+						status.Framework = kindToFramework(kind)
+					}
+					status.GPURequested = extractGPURequested(job)
+					allJobs = append(allJobs, status)
+				}
 			}
-		}
 
-		// If all kinds failed with API errors (not just missing CRDs), return
-		// a clear error so the user understands the issue.
-		if !anySucceeded && failedKindCount > 0 {
-			return fmt.Errorf("failed to list any job types; checked %d kind(s)", failedKindCount)
-		}
-
-		renderer := &outputpkg.TableRenderer{}
-		opts := outputpkg.RenderOptions{
-			TableFn: func() string { return renderer.RenderTopJob(allJobs) },
-			WideFn:  func() string { return renderer.RenderTopJobWide(allJobs) },
-		}
-		if err := outputpkg.Format(topOutputFormat).Render(allJobs, opts); err != nil {
-			return err
-		}
-		// Warn the user when some job types could not be listed so they
-		// understand the results may be incomplete.
-		if failedKindCount > 0 && anySucceeded {
-			fmt.Fprintf(cmd.ErrOrStderr(),
-				"\nWarning: failed to list %d job type(s) due to API errors; results may be incomplete:\n", failedKindCount)
-			for _, e := range apiErrors {
-				fmt.Fprintf(cmd.ErrOrStderr(), "  - %s\n", e)
+			// If all kinds failed with API errors (not just missing CRDs), return
+			// a clear error so the user understands the issue.
+			if !anySucceeded && failedKindCount > 0 {
+				return fmt.Errorf("failed to list any job types; checked %d kind(s)", failedKindCount)
 			}
-		}
-		return nil
-	},
-}
 
-func init() {
-	topJobCmd.Flags().StringVarP(
+			renderer := &outputpkg.TableRenderer{}
+			opts := outputpkg.RenderOptions{
+				TableFn: func() string { return renderer.RenderTopJob(allJobs) },
+				WideFn:  func() string { return renderer.RenderTopJobWide(allJobs) },
+			}
+			if err := outputpkg.Format(topOutputFormat).Render(cmd.OutOrStdout(), allJobs, opts); err != nil {
+				return err
+			}
+			// Warn the user when some job types could not be listed so they
+			// understand the results may be incomplete.
+			if failedKindCount > 0 && anySucceeded {
+				fmt.Fprintf(cmd.ErrOrStderr(),
+					"\nWarning: failed to list %d job type(s) due to API errors; results may be incomplete:\n", failedKindCount)
+				for _, e := range apiErrors {
+					fmt.Fprintf(cmd.ErrOrStderr(), "  - %s\n", e)
+				}
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(
 		&topOutputFormat,
 		"output",
 		"o",
 		string(outputpkg.DefaultFormat),
 		outputpkg.FormatHelpText,
 	)
-	topJobCmd.ValidArgsFunction = cobra.NoFileCompletions
-	_ = topJobCmd.RegisterFlagCompletionFunc("output", completeOutputFormat)
-	topCmd.AddCommand(topJobCmd)
-	rootCmd.AddCommand(topCmd)
+	cmd.ValidArgsFunction = cobra.NoFileCompletions
+	_ = cmd.RegisterFlagCompletionFunc("output", completeOutputFormat)
+	return cmd
 }

--- a/pkg/cli/top_test.go
+++ b/pkg/cli/top_test.go
@@ -1,28 +1,29 @@
 package cli
 
 import (
+	"errors"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 func TestTopJobCommand_InvalidFormat(t *testing.T) {
-	// Save and restore the output format variable
-	origFormat := topOutputFormat
-	defer func() { topOutputFormat = origFormat }()
+	origFormat := outputFormat
+	t.Cleanup(func() { outputFormat = origFormat })
 
-	// Construct first (flag registration resets bound variables), then override.
 	cmd := newTopJobCmd()
-	topOutputFormat = "invalid"
+	outputFormat = "invalid"
 
-	// Call RunE directly to test format validation
 	err := cmd.RunE(cmd, []string{})
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "invalid output format")
-	assert.Contains(t, err.Error(), "invalid")
+	var cliErr *CLIError
+	require.Error(t, err)
+	require.True(t, errors.As(err, &cliErr), "top format error should be a CLIError, got %T: %v", err, err)
+	assert.Equal(t, []string{"table", "wide", "json", "yaml"}, cliErr.ValidValues)
+	assert.Contains(t, err.Error(), `invalid output format "invalid" for --output`)
 }
 
 func TestTopCmd_Help(t *testing.T) {
@@ -308,4 +309,17 @@ func TestFormatAge_Units(t *testing.T) {
 			assert.Contains(t, got, tt.contains)
 		})
 	}
+}
+
+func TestTopJobCmd_AllNamespacesFlagRegistered(t *testing.T) {
+	flag := newTopJobCmd().Flags().Lookup("all-namespaces")
+	require.NotNil(t, flag, "top job must register --all-namespaces")
+	assert.Equal(t, "A", flag.Shorthand)
+}
+
+func TestTopJobCmd_AllNamespacesParses(t *testing.T) {
+	err := ExecuteWithArgs([]string{"top", "job", "-A", "--kubeconfig", "/nonexistent/kubeconfig"})
+	require.Error(t, err, "nonexistent kubeconfig must fail the run")
+	assert.NotContains(t, err.Error(), "unknown", "-A must parse as a known flag")
+	assert.Contains(t, err.Error(), "failed to create K8s client")
 }

--- a/pkg/cli/top_test.go
+++ b/pkg/cli/top_test.go
@@ -14,23 +14,24 @@ func TestTopJobCommand_InvalidFormat(t *testing.T) {
 	origFormat := topOutputFormat
 	defer func() { topOutputFormat = origFormat }()
 
-	// Set invalid format directly (bypassing flag parsing)
+	// Construct first (flag registration resets bound variables), then override.
+	cmd := newTopJobCmd()
 	topOutputFormat = "invalid"
 
 	// Call RunE directly to test format validation
-	err := topJobCmd.RunE(topJobCmd, []string{})
+	err := cmd.RunE(cmd, []string{})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid output format")
 	assert.Contains(t, err.Error(), "invalid")
 }
 
 func TestTopCmd_Help(t *testing.T) {
-	assert.Equal(t, "top", topCmd.Use)
-	assert.NotEmpty(t, topCmd.Short)
+	assert.Equal(t, "top", newTopCmd().Use)
+	assert.NotEmpty(t, newTopCmd().Short)
 }
 
 func TestTopJobCmd_Registered(t *testing.T) {
-	commands := topCmd.Commands()
+	commands := newTopCmd().Commands()
 	var names []string
 	for _, cmd := range commands {
 		names = append(names, cmd.Name())
@@ -39,7 +40,7 @@ func TestTopJobCmd_Registered(t *testing.T) {
 }
 
 func TestTopCmd_RegisteredOnRoot(t *testing.T) {
-	commands := rootCmd.Commands()
+	commands := NewRootCommand().Commands()
 	var names []string
 	for _, cmd := range commands {
 		names = append(names, cmd.Name())

--- a/pkg/cli/version.go
+++ b/pkg/cli/version.go
@@ -14,20 +14,21 @@ var (
 	gitTreeState = "unknown"
 )
 
-var versionCmd = &cobra.Command{
-	Use:   "version",
-	Short: "Print version information",
-	Run: func(_ *cobra.Command, _ []string) {
-		fmt.Printf("Arena v2\n")
-		fmt.Printf("  Version:     %s\n", version)
-		fmt.Printf("  Git Commit:  %s\n", gitCommit)
-		fmt.Printf("  Git Tag:     %s\n", gitTag)
-		fmt.Printf("  Build Date:  %s\n", buildDate)
-		fmt.Printf("  Tree State:  %s\n", gitTreeState)
-	},
-}
-
-func init() {
-	versionCmd.ValidArgsFunction = cobra.NoFileCompletions
-	rootCmd.AddCommand(versionCmd)
+func newVersionCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "version",
+		Short: "Print version information",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			out := cmd.OutOrStdout()
+			fmt.Fprintln(out, "Arena v2")
+			fmt.Fprintf(out, "  Version:     %s\n", version)
+			fmt.Fprintf(out, "  Git Commit:  %s\n", gitCommit)
+			fmt.Fprintf(out, "  Git Tag:     %s\n", gitTag)
+			fmt.Fprintf(out, "  Build Date:  %s\n", buildDate)
+			fmt.Fprintf(out, "  Tree State:  %s\n", gitTreeState)
+			return nil
+		},
+	}
+	cmd.ValidArgsFunction = cobra.NoFileCompletions
+	return cmd
 }

--- a/pkg/cli/version_test.go
+++ b/pkg/cli/version_test.go
@@ -5,12 +5,10 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestVersionCmd_Output(t *testing.T) {
-	buf := new(bytes.Buffer)
-	versionCmd.SetOut(buf)
-
 	// Save and restore version variables
 	origVersion := version
 	origCommit := gitCommit
@@ -31,18 +29,22 @@ func TestVersionCmd_Output(t *testing.T) {
 	gitTag = "v0.1.0"
 	gitTreeState = "clean"
 
-	// versionCmd uses fmt.Printf (stdout), not cmd.OutOrStdout(),
-	// so we test the variable values directly.
-	assert.Equal(t, "0.1.0", version)
-	assert.Equal(t, "abc123", gitCommit)
-	assert.Equal(t, "2026-07-01T00:00:00Z", buildDate)
-	assert.Equal(t, "v0.1.0", gitTag)
-	assert.Equal(t, "clean", gitTreeState)
+	cmd := newVersionCmd()
+	buf := new(bytes.Buffer)
+	cmd.SetOut(buf)
+	require.NoError(t, cmd.RunE(cmd, nil))
+
+	assert.Contains(t, buf.String(), "Arena v2")
+	assert.Contains(t, buf.String(), "Version:     0.1.0")
+	assert.Contains(t, buf.String(), "Git Commit:  abc123")
+	assert.Contains(t, buf.String(), "Build Date:  2026-07-01T00:00:00Z")
+	assert.Contains(t, buf.String(), "Git Tag:     v0.1.0")
+	assert.Contains(t, buf.String(), "Tree State:  clean")
 }
 
 func TestVersionCmd_RegisteredOnRoot(t *testing.T) {
 	found := false
-	for _, cmd := range rootCmd.Commands() {
+	for _, cmd := range NewRootCommand().Commands() {
 		if cmd.Name() == "version" {
 			found = true
 			break
@@ -52,8 +54,9 @@ func TestVersionCmd_RegisteredOnRoot(t *testing.T) {
 }
 
 func TestVersionCmd_HasCorrectUse(t *testing.T) {
-	assert.Equal(t, "version", versionCmd.Use)
-	assert.NotEmpty(t, versionCmd.Short)
+	cmd := newVersionCmd()
+	assert.Equal(t, "version", cmd.Use)
+	assert.NotEmpty(t, cmd.Short)
 }
 
 func TestVersionCmd_DefaultValues(t *testing.T) {

--- a/pkg/output/format.go
+++ b/pkg/output/format.go
@@ -3,6 +3,7 @@ package output
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 
 	"gopkg.in/yaml.v3"
 )
@@ -47,7 +48,8 @@ func (f Format) Validate() error {
 	return fmt.Errorf("invalid output format: %q (supported: %s)", f, FormatSupported)
 }
 
-// Render dispatches to the appropriate rendering path for this format.
+// Render dispatches to the appropriate rendering path for this format and
+// writes the result to w.
 //
 //   - JSON:  marshals data with 2-space indentation and prints it followed
 //     by a newline.
@@ -55,31 +57,31 @@ func (f Format) Validate() error {
 //     trailing newline).
 //   - Wide:  calls WideFn when non-nil, otherwise falls back to TableFn.
 //   - Table: calls TableFn.
-func (f Format) Render(data interface{}, opts RenderOptions) error {
+func (f Format) Render(w io.Writer, data interface{}, opts RenderOptions) error {
 	switch f {
 	case FormatJSON:
 		b, err := json.MarshalIndent(data, "", "  ")
 		if err != nil {
 			return fmt.Errorf("failed to marshal JSON: %w", err)
 		}
-		fmt.Println(string(b))
+		fmt.Fprintln(w, string(b))
 	case FormatYAML:
 		b, err := yaml.Marshal(data)
 		if err != nil {
 			return fmt.Errorf("failed to marshal YAML: %w", err)
 		}
-		fmt.Print(string(b))
+		fmt.Fprint(w, string(b))
 	case FormatWide:
 		fn := opts.WideFn
 		if fn == nil {
 			fn = opts.TableFn
 		}
 		if fn != nil {
-			fmt.Print(fn())
+			fmt.Fprint(w, fn())
 		}
 	case FormatTable:
 		if opts.TableFn != nil {
-			fmt.Print(opts.TableFn())
+			fmt.Fprint(w, opts.TableFn())
 		}
 	}
 	return nil

--- a/pkg/output/format_test.go
+++ b/pkg/output/format_test.go
@@ -3,8 +3,6 @@ package output
 import (
 	"bytes"
 	"encoding/json"
-	"io"
-	"os"
 	"strings"
 	"testing"
 
@@ -16,38 +14,6 @@ import (
 type sampleJob struct {
 	Name   string `json:"name" yaml:"name"`
 	Status string `json:"status" yaml:"status"`
-}
-
-// captureStdout runs fn while redirecting os.Stdout to a pipe, returning the
-// captured text. This lets us assert on what Render prints.
-func captureStdout(t *testing.T, fn func()) string {
-	t.Helper()
-	orig := os.Stdout
-	r, w, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("os.Pipe: %v", err)
-	}
-	os.Stdout = w
-
-	t.Cleanup(func() {
-		os.Stdout = orig
-		w.Close()
-	})
-
-	outCh := make(chan string, 1)
-	go func() {
-		var buf bytes.Buffer
-		_, _ = io.Copy(&buf, r)
-		outCh <- buf.String()
-	}()
-
-	fn()
-
-	// Close the write end so io.Copy in the goroutine sees EOF and sends the
-	// captured output. t.Cleanup still restores stdout and closes w (a harmless
-	// double close) as a safety net for panic/FailNow paths that skip this line.
-	w.Close()
-	return <-outCh
 }
 
 // --- Validate() tests ---
@@ -75,31 +41,29 @@ func TestValidateRejectsInvalidFormat(t *testing.T) {
 
 func TestRenderJSON(t *testing.T) {
 	job := sampleJob{Name: "job-1", Status: "Running"}
-	out := captureStdout(t, func() {
-		err := FormatJSON.Render(job, RenderOptions{})
-		assert.NoError(t, err)
-	})
+	var buf bytes.Buffer
+	err := FormatJSON.Render(&buf, job, RenderOptions{})
+	assert.NoError(t, err)
 
-	// Trim trailing newline added by fmt.Println, then verify valid JSON.
+	// Trim trailing newline added by Fprintln, then verify valid JSON.
 	var got sampleJob
-	err := json.Unmarshal([]byte(strings.TrimSpace(out)), &got)
+	err = json.Unmarshal([]byte(strings.TrimSpace(buf.String())), &got)
 	assert.NoError(t, err, "output should be valid JSON")
 	assert.Equal(t, job, got)
 
 	// 2-space indent: a multi-field JSON object will contain "\n  " (newline + 2 spaces).
-	assert.Contains(t, out, "\n  ", "output should use 2-space indentation")
+	assert.Contains(t, buf.String(), "\n  ", "output should use 2-space indentation")
 }
 
 func TestRenderYAML(t *testing.T) {
 	job := sampleJob{Name: "job-1", Status: "Running"}
-	out := captureStdout(t, func() {
-		err := FormatYAML.Render(job, RenderOptions{})
-		assert.NoError(t, err)
-	})
+	var buf bytes.Buffer
+	err := FormatYAML.Render(&buf, job, RenderOptions{})
+	assert.NoError(t, err)
 
 	// Verify valid YAML by unmarshalling back.
 	var got sampleJob
-	err := yaml.Unmarshal([]byte(out), &got)
+	err = yaml.Unmarshal(buf.Bytes(), &got)
 	assert.NoError(t, err, "output should be valid YAML")
 	assert.Equal(t, job, got)
 }
@@ -112,12 +76,11 @@ func TestRenderTableCallsTableFn(t *testing.T) {
 			return "TABLE OUTPUT\n"
 		},
 	}
-	out := captureStdout(t, func() {
-		err := FormatTable.Render(nil, opts)
-		assert.NoError(t, err)
-	})
+	var buf bytes.Buffer
+	err := FormatTable.Render(&buf, nil, opts)
+	assert.NoError(t, err)
 	assert.True(t, called, "TableFn should be called for FormatTable")
-	assert.Contains(t, out, "TABLE OUTPUT", "TableFn output should be printed")
+	assert.Contains(t, buf.String(), "TABLE OUTPUT", "TableFn output should be printed")
 }
 
 func TestRenderWideCallsWideFn(t *testing.T) {
@@ -133,13 +96,12 @@ func TestRenderWideCallsWideFn(t *testing.T) {
 			return "WIDE OUTPUT\n"
 		},
 	}
-	out := captureStdout(t, func() {
-		err := FormatWide.Render(nil, opts)
-		assert.NoError(t, err)
-	})
+	var buf bytes.Buffer
+	err := FormatWide.Render(&buf, nil, opts)
+	assert.NoError(t, err)
 	assert.True(t, wideCalled, "WideFn should be called when provided")
 	assert.False(t, tableCalled, "TableFn should NOT be called when WideFn is provided")
-	assert.Contains(t, out, "WIDE OUTPUT", "WideFn output should be printed")
+	assert.Contains(t, buf.String(), "WIDE OUTPUT", "WideFn output should be printed")
 }
 
 func TestRenderWideFallsBackToTableFnWhenWideFnNil(t *testing.T) {
@@ -151,12 +113,11 @@ func TestRenderWideFallsBackToTableFnWhenWideFnNil(t *testing.T) {
 		},
 		WideFn: nil,
 	}
-	out := captureStdout(t, func() {
-		err := FormatWide.Render(nil, opts)
-		assert.NoError(t, err)
-	})
+	var buf bytes.Buffer
+	err := FormatWide.Render(&buf, nil, opts)
+	assert.NoError(t, err)
 	assert.True(t, tableCalled, "TableFn should be called as fallback when WideFn is nil")
-	assert.Contains(t, out, "TABLE OUTPUT", "TableFn output should be printed as fallback")
+	assert.Contains(t, buf.String(), "TABLE OUTPUT", "TableFn output should be printed as fallback")
 }
 
 // --- Constant tests ---

--- a/pkg/output/table.go
+++ b/pkg/output/table.go
@@ -15,10 +15,11 @@ import (
 
 // maxJobListWidths caps column widths in the job list table to prevent excessively wide output.
 var maxJobListWidths = map[string]int{
-	"NAME":     50,
-	"STATUS":   20,
-	"REPLICAS": 15,
-	"AGE":      15,
+	"NAME":      50,
+	"NAMESPACE": 20,
+	"STATUS":    20,
+	"REPLICAS":  15,
+	"AGE":       15,
 }
 
 // maxPodWidths caps column widths in the pod table to prevent excessively wide output.
@@ -44,6 +45,7 @@ var maxJobListWideWidths = map[string]int{
 // maxTopJobWidths caps column widths in the top job table.
 var maxTopJobWidths = map[string]int{
 	"NAME":          50,
+	"NAMESPACE":     20,
 	"STATUS":        20,
 	"GPU_REQUESTED": 15,
 	"REPLICAS":      15,
@@ -74,16 +76,33 @@ func NewTableRenderer() *TableRenderer {
 // Column widths expand dynamically to fit content, up to the caps defined in maxJobListWidths.
 // Returns "No jobs found" when the input slice is nil or empty.
 func (r *TableRenderer) RenderJobList(jobs []client.JobStatus) string {
+	return r.renderJobList(jobs, false)
+}
+
+// RenderJobListAllNamespaces renders the job list with a leading NAMESPACE
+// column, for listings that span all namespaces.
+func (r *TableRenderer) RenderJobListAllNamespaces(jobs []client.JobStatus) string {
+	return r.renderJobList(jobs, true)
+}
+
+func (r *TableRenderer) renderJobList(jobs []client.JobStatus, includeNamespace bool) string {
 	if len(jobs) == 0 {
 		return "No jobs found\n"
 	}
 
 	headers := []string{"NAME", "STATUS", "REPLICAS", "AGE"}
+	if includeNamespace {
+		headers = append([]string{"NAMESPACE"}, headers...)
+	}
 	rows := make([][]string, 0, len(jobs))
 	for _, job := range jobs {
-		rows = append(rows, []string{
-			job.Name, job.Status, fmt.Sprintf("%d/%d", job.Ready, job.Replicas), job.Age,
-		})
+		row := make([]string, 0, len(headers))
+		if includeNamespace {
+			row = append(row, job.Namespace)
+		}
+		row = append(row, job.Name)
+		row = append(row, job.Status, fmt.Sprintf("%d/%d", job.Ready, job.Replicas), job.Age)
+		rows = append(rows, row)
 	}
 
 	widths := calculateWidths(headers, rows, maxJobListWidths)
@@ -125,17 +144,34 @@ func (r *TableRenderer) RenderJobListWide(jobs []client.JobStatus) string {
 // RenderTopJob renders a table of job GPU requests with columns: NAME, STATUS, GPU_REQUESTED, REPLICAS, AGE.
 // Returns "No jobs found" when the input slice is nil or empty.
 func (r *TableRenderer) RenderTopJob(jobs []client.JobStatus) string {
+	return r.renderTopJob(jobs, false)
+}
+
+// RenderTopJobAllNamespaces renders the top job table with a leading NAMESPACE
+// column, for listings that span all namespaces.
+func (r *TableRenderer) RenderTopJobAllNamespaces(jobs []client.JobStatus) string {
+	return r.renderTopJob(jobs, true)
+}
+
+func (r *TableRenderer) renderTopJob(jobs []client.JobStatus, includeNamespace bool) string {
 	if len(jobs) == 0 {
 		return "No jobs found\n"
 	}
 
 	headers := []string{"NAME", "STATUS", "GPU_REQUESTED", "REPLICAS", "AGE"}
+	if includeNamespace {
+		headers = append([]string{"NAMESPACE"}, headers...)
+	}
 	rows := make([][]string, 0, len(jobs))
 	for _, job := range jobs {
-		rows = append(rows, []string{
-			job.Name, job.Status, strconv.Itoa(job.GPURequested),
-			fmt.Sprintf("%d/%d", job.Ready, job.Replicas), job.Age,
-		})
+		row := make([]string, 0, len(headers))
+		if includeNamespace {
+			row = append(row, job.Namespace)
+		}
+		row = append(row, job.Name)
+		row = append(row, job.Status, strconv.Itoa(job.GPURequested),
+			fmt.Sprintf("%d/%d", job.Ready, job.Replicas), job.Age)
+		rows = append(rows, row)
 	}
 
 	widths := calculateWidths(headers, rows, maxTopJobWidths)

--- a/pkg/output/table_test.go
+++ b/pkg/output/table_test.go
@@ -397,3 +397,56 @@ func TestIndentLines(t *testing.T) {
 		})
 	}
 }
+
+func TestRenderJobListAllNamespaces(t *testing.T) {
+	jobs := []client.JobStatus{
+		{Name: "job-1", Namespace: "team-a", Status: "Running", Replicas: 4, Ready: 3, Age: "5m"},
+		{Name: "job-2", Namespace: "team-b", Status: "Succeeded", Replicas: 2, Ready: 0, Age: "1h"},
+	}
+
+	output := (&TableRenderer{}).RenderJobListAllNamespaces(jobs)
+
+	headerLine := strings.SplitN(output, "\n", 2)[0]
+	assert.Equal(t, []string{"NAMESPACE", "NAME", "STATUS", "REPLICAS", "AGE"}, strings.Fields(headerLine))
+	dataLine := strings.SplitN(output, "\n", 3)[1]
+	assert.Equal(t, []string{"team-a", "job-1", "Running", "3/4", "5m"}, strings.Fields(dataLine),
+		"values must align with headers: NAMESPACE first")
+	assert.Contains(t, output, "team-a")
+	assert.Contains(t, output, "team-b")
+}
+
+func TestRenderJobListAllNamespacesEmpty(t *testing.T) {
+	assert.Contains(t, (&TableRenderer{}).RenderJobListAllNamespaces(nil), "No jobs found")
+}
+
+func TestRenderTopJobAllNamespaces(t *testing.T) {
+	jobs := []client.JobStatus{
+		{Name: "job-1", Namespace: "team-a", Status: "Running", GPURequested: 4, Replicas: 2, Ready: 2, Age: "5m"},
+	}
+
+	output := (&TableRenderer{}).RenderTopJobAllNamespaces(jobs)
+
+	headerLine := strings.SplitN(output, "\n", 2)[0]
+	assert.Equal(t, []string{"NAMESPACE", "NAME", "STATUS", "GPU_REQUESTED", "REPLICAS", "AGE"}, strings.Fields(headerLine))
+	dataLine := strings.SplitN(output, "\n", 3)[1]
+	assert.Equal(t, []string{"team-a", "job-1", "Running", "4", "2/2", "5m"}, strings.Fields(dataLine),
+		"values must align with headers: NAMESPACE first")
+	assert.Contains(t, output, "team-a")
+}
+
+func TestRenderTopJobAllNamespacesEmpty(t *testing.T) {
+	assert.Contains(t, (&TableRenderer{}).RenderTopJobAllNamespaces(nil), "No jobs found")
+}
+
+// 以下两个是重构守卫:plain 渲染不得因变体重构而混入 NAMESPACE 列。
+func TestRenderJobList_PlainKeepsNoNamespaceColumn(t *testing.T) {
+	jobs := []client.JobStatus{{Name: "job-1", Namespace: "team-a", Status: "Running", Replicas: 1, Ready: 1, Age: "5m"}}
+	headerLine := strings.SplitN((&TableRenderer{}).RenderJobList(jobs), "\n", 2)[0]
+	assert.Equal(t, []string{"NAME", "STATUS", "REPLICAS", "AGE"}, strings.Fields(headerLine))
+}
+
+func TestRenderTopJob_PlainKeepsNoNamespaceColumn(t *testing.T) {
+	jobs := []client.JobStatus{{Name: "job-1", Namespace: "team-a", Status: "Running", GPURequested: 2, Replicas: 1, Ready: 1, Age: "5m"}}
+	headerLine := strings.SplitN((&TableRenderer{}).RenderTopJob(jobs), "\n", 2)[0]
+	assert.Equal(t, []string{"NAME", "STATUS", "GPU_REQUESTED", "REPLICAS", "AGE"}, strings.Fields(headerLine))
+}

--- a/pkg/task/setter.go
+++ b/pkg/task/setter.go
@@ -17,6 +17,22 @@ const quotedKeyPrefix = "__ARENA_QK_"
 // items[999999999]=x, which would otherwise OOM the process.
 const maxIndex = 65536
 
+// SetSyntaxError reports a malformed --set expression. It carries the raw
+// expression and the underlying parse failure so callers can match with
+// errors.As while the rendered text stays stable.
+type SetSyntaxError struct {
+	Expr string
+	Err  error
+}
+
+func (e *SetSyntaxError) Error() string {
+	return fmt.Sprintf("failed to parse --set %q: %v", e.Expr, e.Err)
+}
+
+func (e *SetSyntaxError) Unwrap() error {
+	return e.Err
+}
+
 // pathSegment represents a single segment in a dotted key path.
 // It can be either a map key (isArr=false) or an array index (isArr=true).
 type pathSegment struct {
@@ -46,16 +62,16 @@ func ApplySetOverrides(yamlData []byte, expressions []string) ([]byte, error) {
 	for _, expr := range expressions {
 		// Validate that expression has a non-empty key
 		if len(expr) == 0 || expr[0] == '=' {
-			return nil, fmt.Errorf("failed to parse --set %q: empty key", expr)
+			return nil, &SetSyntaxError{Expr: expr, Err: errors.New("empty key")}
 		}
 
 		processed, quotedKeys, err := preprocessQuotedKeys(expr)
 		if err != nil {
-			return nil, fmt.Errorf("failed to parse --set %q: %w", expr, err)
+			return nil, &SetSyntaxError{Expr: expr, Err: err}
 		}
 
 		if err := parseInto(processed, base); err != nil {
-			return nil, fmt.Errorf("failed to parse --set %q: %w", expr, err)
+			return nil, &SetSyntaxError{Expr: expr, Err: err}
 		}
 
 		if len(quotedKeys) > 0 {

--- a/pkg/task/setter_test.go
+++ b/pkg/task/setter_test.go
@@ -1,6 +1,7 @@
 package task
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -1438,4 +1439,38 @@ worker:
 	assert.Equal(t, "training job v2", tk.Description)
 	assert.Equal(t, "/app", tk.WorkingDir)
 	assert.Equal(t, "/bin/bash", tk.Shell)
+}
+
+func TestSetSyntaxError_ErrorAndUnwrap(t *testing.T) {
+	inner := errors.New("boom")
+	serr := &SetSyntaxError{Expr: "a=", Err: inner}
+	assert.Equal(t, `failed to parse --set "a=": boom`, serr.Error())
+	assert.ErrorIs(t, serr, inner)
+}
+
+func TestApplySetOverrides_ParseErrorIsSetSyntaxError(t *testing.T) {
+	yamlData := []byte("name: test\n")
+	_, err := ApplySetOverrides(yamlData, []string{"foo[abc]=value"})
+	require.Error(t, err)
+	var serr *SetSyntaxError
+	require.True(t, errors.As(err, &serr), "error should be *SetSyntaxError, got %T", err)
+	assert.Equal(t, "foo[abc]=value", serr.Expr)
+	assert.Error(t, serr.Err)
+	assert.Contains(t, err.Error(), "failed to parse --set")
+}
+
+func TestApplySetOverrides_EmptyKeyIsSetSyntaxError(t *testing.T) {
+	yamlData := []byte("name: test\n")
+	_, err := ApplySetOverrides(yamlData, []string{"=nokey"})
+	require.Error(t, err)
+	var serr *SetSyntaxError
+	require.True(t, errors.As(err, &serr))
+	assert.Equal(t, "=nokey", serr.Expr)
+}
+
+func TestApplySetOverrides_YAMLErrorIsNotSetSyntaxError(t *testing.T) {
+	_, err := ApplySetOverrides([]byte("name: [unclosed"), []string{"a=b"})
+	require.Error(t, err)
+	var serr *SetSyntaxError
+	assert.False(t, errors.As(err, &serr), "YAML parse failure must not be a SetSyntaxError")
 }

--- a/test/e2e/error_paths_test.go
+++ b/test/e2e/error_paths_test.go
@@ -50,7 +50,7 @@ var _ = Describe("Error paths", func() {
 		cmd.Stderr = &out
 		err := cmd.Run()
 		Expect(err).To(HaveOccurred(), "run without --file should error")
-		Expect(out.String()).To(ContainSubstring("--file is required"))
+		Expect(out.String()).To(ContainSubstring(`required flag(s) "file" not set`))
 	})
 
 	It("should error on invalid YAML", func() {


### PR DESCRIPTION
## Purpose of this PR

Make the arena-v2 CLI agent-native — machine-readable errors and results for `-o json/yaml`, composable job list selection, and all-namespaces listing — plus a cobra code-style cleanup across command files. Implements the design in docs/superpowers/specs/2026-08-21-agent-native-cli-design.md, 2026-08-21-agent-native-cli-batch2-design.md, and 2026-08-22-agent-native-cli-batch3-design.md.

**Proposed changes:**

- **Error model**: new `CLIError` type renders a machine-readable JSON error envelope with non-zero exit codes when `-o json/yaml` is active; centralized output-format validation with teaching errors that enumerate valid values; typed `SetSyntaxError` sentinel for `--set` parse failures; valid values enumerated in submit framework-type and `--set` errors
- **Structured results**: `-o json/yaml` output for mutation commands (`submit`, `run`, `delete`, `suspend`, `resume`)
- **Job list selection**: `-l/--type/--status/--last` selectors with selection validators and composable label selectors
- **All-namespaces listing**: `-A/--all-namespaces` for `job list` and `top job` — lists across every namespace (overrides `-n`) and prepends a NAMESPACE column to table output
- **Flag surface cleanup**: `-o/--output` moved from the `job` group persistent flag to each leaf command via a shared `registerOutputFlag` helper; `job logs` has no `-o` flag at all since it returns raw log content
- **Cobra code style**: consistent command construction across `pkg/cli` (RunE, flag registration, helpers) with tests updated; net ~1,000 lines removed
- **Docs**: `docs/cli-reference.md` updated for the new flag surfaces

## Commit Message Format

This project uses [conventional commits](https://www.conventionalcommits.org/) for commit hygiene. The release changelog is driven by PR labels, which are auto-assigned based on your branch name prefix and changed files.

**Example commit messages:**

```
feat: add GPU sharing support for MPIJob
fix: correct pytorch replica count in dry-run output
feat(serving): add vLLM as serving framework
docs: update installation guide for v2
```

> **Note:** PR labels are auto-assigned by the Labeler workflow based on your branch name prefix and changed files. This determines how your change appears in the release changelog — `feat/` branch → Features, `fix/` branch → Bug Fixes, `breaking/` branch → Breaking Changes, `doc/` or `docs/` branch or all files in `docs/`/`examples/` → Documentation, `chore/` or `chores/` branch → Maintenance, `refactor/` branch → Refactoring, `test/`/`ci/` branch, all files are `.github/` CI configs, or only `VERSION` changed → excluded.

## Checklist

- [x] Code follows the project's style guidelines (`make v2-fmt`)
- [x] Code passes vet (`make v2-vet`)
- [x] Code passes lint (`make v2-lint`)
- [x] Tests pass (`make v2-test`)
- [x] `go mod tidy` has been run
- [x] Commit messages follow conventional commit format